### PR TITLE
Pass configuration parameters to logging class

### DIFF
--- a/InfoLogger/lib/configProvider.js
+++ b/InfoLogger/lib/configProvider.js
@@ -22,7 +22,8 @@ try {
   process.exit(1);
 }
 
-log.info(`Reading config file "${configFile}"`);
 const config = require(configFile);
+log.configure(config);
+log.info(`Read config file "${configFile}"`);
 
 module.exports = config;


### PR DESCRIPTION
This fixes the problem with writing logs to the file.