### PR TITLE
Invoking monitor() twice crashes the ZMQ connection

### DIFF
--- a/QualityControl/lib/TObject2JsonClient.js
+++ b/QualityControl/lib/TObject2JsonClient.js
@@ -21,7 +21,6 @@ class TObject2JsonClient extends EventEmitter {
       'dealer'
     );
 
-    this.zmqClient.socket.monitor();
     this.zmqClient.on('message', this._onRawMessage.bind(this));
   }
 


### PR DESCRIPTION
With this line QCG is not able to connect to `tobject2json` at all...