### PR TITLE
OGUI-277 display user friendly instance name

### DIFF
--- a/Control/protobuf/o2control.proto
+++ b/Control/protobuf/o2control.proto
@@ -83,12 +83,22 @@ message StatusUpdate {
 // Framework
 ////////////////////////////////////////
 message GetFrameworkInfoRequest {}
+message Version {
+    int32 major = 1;
+    int32 minor = 2;
+    int32 patch = 3;
+    string build = 4;
+    string productName = 5;
+    string versionStr = 6;
+}
 message GetFrameworkInfoReply {
     string frameworkId = 1;
     int32 environmentsCount = 2;
     int32 tasksCount = 3;
     string state = 4;
     int32 hostsCount = 5;
+    string instanceName = 6;
+    Version version = 7;
 }
 
 // Not implemented yet

--- a/Control/public/common/showTableItem.js
+++ b/Control/public/common/showTableItem.js
@@ -9,6 +9,7 @@ import {h} from '/js/src/index.js';
 export default (item) => h('table.table', [
   h('tbody', Object.keys(item).map((columnName) => h('tr', [
     h('th', columnName),
-    typeof item[columnName] === 'object' ? h('td', item[columnName].length) : h('td', item[columnName])
+    typeof item[columnName] === 'object' ?
+      h('td', JSON.stringify(item[columnName], null, 2)) : h('td', item[columnName])
   ]))),
 ]);


### PR DESCRIPTION
Control status page is displaying all information sent back by the `getFrameworkInfo` request. 
Modified table to display JSON object if present instead of expected value. (e.g. version field). Otherwise it would have displayed an empty field

![Screenshot 2019-05-07 at 14 31 56](https://user-images.githubusercontent.com/9214854/57299530-1a1d8d00-70d5-11e9-8c91-5780e55b2d47.png)
