### PR TITLE
Bump infologger version to 1.1.5

### DIFF
--- a/InfoLogger/package-lock.json
+++ b/InfoLogger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "Infologger GUI to query and stream log events",
   "homepage": "https://alice-o2.web.cern.ch",
   "main": "index.js",


### PR DESCRIPTION
Seems like even 1.1.3 was removed we cannot use that version anymore in npm artifactory. 