### PR TITLE
[OGUI-352] Move shutdown option to all envs page

### DIFF
--- a/Control/public/common/showTableList.js
+++ b/Control/public/common/showTableList.js
@@ -5,15 +5,17 @@ import parseObject from './utils.js';
  * Generic table to show list of objects
  * This can be forked to show more specific data (format date, colors, more buttons...)
  * @param {Array.<Object.<string, Any>>} list - things to be shown
- * @param {function(DOMEvent, item)} onclick - (optional) add a button for each line with object as argument
+ * @param {Array.<function(DOMEvent, item)>} actions - (optional) add a button for each line with object as argument
  * @return {vnode} table view
  */
-export default (list, onclick) => h('table.table', [
+export default (list, actions) => h('table.table', [
   h('thead', [
-    h('tr', [
-      list.length > 0 && Object.keys(list[0]).map((columnName) => h('th', columnName)),
-      onclick && h('th', '')
-    ])
+    h('tr',
+      [
+        list.length > 0 && Object.keys(list[0]).map((columnName) => h('th', {style: 'text-align:center'}, columnName)),
+        actions && h('th.text-center', {style: 'text-align:center'}, 'Actions')
+      ]
+    )
   ]),
   h('tbody', list.map((item) => h('tr', [
     Object.keys(item).map(
@@ -25,9 +27,11 @@ export default (list, onclick) => h('table.table', [
             style: 'font-weight: bold;'
           },
           item[columnName]
-
         )
     ),
-    onclick && h('td', h('button.btn', {onclick: (event) => onclick(event, item)}, 'Details'))
+    actions && h('td.btn-group',
+      h('button.btn.btn-primary', {onclick: (event) => actions[0](event, item)}, 'Details'),
+      h('button.btn.btn-danger', {onclick: (event) => actions[1](event, item)}, 'Shut Down'),
+    )
   ]))),
 ]);

--- a/Control/public/common/showTableList.js
+++ b/Control/public/common/showTableList.js
@@ -31,7 +31,7 @@ export default (list, actions) => h('table.table', [
     ),
     actions && h('td.btn-group',
       h('button.btn.btn-primary', {onclick: (event) => actions[0](event, item)}, 'Details'),
-      h('button.btn.btn-danger', {onclick: (event) => actions[1](event, item)}, 'Shut Down'),
+      item.state !== 'RUNNING' && h('button.btn.btn-danger', {onclick: (event) => actions[1](event, item)}, 'Shutdown'),
     )
   ]))),
 ]);

--- a/Control/public/environment/Environment.js
+++ b/Control/public/environment/Environment.js
@@ -115,6 +115,7 @@ export default class Environment extends Observable {
 
     const {result, ok} = await this.model.loader.post(`/api/DestroyEnvironment`, body);
     if (!ok) {
+      this.model.notification.show(result.message, 'danger', 5000);
       this.itemControl = RemoteData.failure(result.message);
       this.notify();
       return;

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -1,4 +1,4 @@
-import {h, iconTrash} from '/js/src/index.js';
+import {h} from '/js/src/index.js';
 import pageLoading from '../common/pageLoading.js';
 import pageError from '../common/pageError.js';
 import showTableList from '../common/showTableList.js';
@@ -157,17 +157,6 @@ const showControl = (environment, item) => h('.mv2.pv3.ph2', [
         controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', 'STANDBY'), ' ',
         controlButton('', environment, item, 'RESET', 'RESET', 'CONFIGURED'), ' '
       ]
-    ),
-    h('div.flex-grow.text-right',
-      h('button.btn.btn-danger',
-        {
-          class: environment.itemControl.isLoading() ? 'loading' : '',
-          disabled: environment.itemControl.isLoading(),
-          onclick: () => confirm('Are you sure to delete this environment?')
-            && environment.destroyEnvironment({id: item.id})
-        },
-        iconTrash()
-      )
     )
   ),
   environment.itemControl.match({

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -44,5 +44,10 @@ export const content = (model) => h('.scroll-y.absolute-fill.text-center', [
  * @return {vnode}
  */
 const showContent = (model, list) => (list && Object.keys(list).length > 0)
-  ? showTableList(list, (event, item) => model.router.go(`?page=environment&id=${item.id}`))
+  ? showTableList(list, [
+    (event, item) => model.router.go(`?page=environment&id=${item.id}`),
+    (event, item) =>
+      confirm('Are you sure to delete this environment?' + item.id)
+      && model.environment.destroyEnvironment({id: item.id})
+  ])
   : h('h3.m4', ['No environments found.']);


### PR DESCRIPTION
Changes in PR:
* `Delete` button from environment page was removed
* A `Shut Down` button was added in the environments page table
* User will be asked to confirm shutting down the environment
* In case state is not `locked` a danger notification(5s) will be displayed  when user tries to shut down the environment

![Screenshot 2019-06-21 at 13 16 13](https://user-images.githubusercontent.com/9214854/59919098-db465b00-9426-11e9-8ecb-598890494b77.png)
![Screenshot 2019-06-21 at 13 16 46](https://user-images.githubusercontent.com/9214854/59919099-db465b00-9426-11e9-948d-ba99e5a7d6b4.png)

