### PR TITLE
[OGUI-378] Inform user when plots were not loaded

### DIFF
--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -62,10 +62,12 @@ const showContent = (environment, item) => [
         ]
       ),
       environment.plots.match({
-        NotAsked: () => null,
+        NotAsked: () => h('.w-100.text-center.grafana-font', 'Grafana plots were not loaded, please refresh the page'),
         Loading: () => null,
         Success: (data) => showEmbeddedGraphs(data),
-        Failure: () => null,
+        Failure: () => h('.w-100.text-center.grafana-font',
+          'Grafana plots were not loaded, please contact an administrator'
+        ),
       })
     ]
   ),


### PR DESCRIPTION
In case aliecs did not manage/have enough time to get the data about where plots are hosted, a message will be displayed to the user. 

<img width="1397" alt="Screenshot 2019-07-24 at 16 32 55" src="https://user-images.githubusercontent.com/9214854/61803422-5fc73780-ae32-11e9-8526-c41ca3622a7b.png">
