### PR TITLE
[OGUI-391] Object view drawing options layout should be propagated 

### DIFF
--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -32,7 +32,7 @@ function promiseResolveWithLatency(data) {
  */
 function readObjectData(name) {
   const object = objects.find((object) => object.name === `${name}`);
-  return promiseResolveWithLatency(object ? object.data : null);
+  return promiseResolveWithLatency(object ? object.data : 'Object not found');
 }
 
 /**

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -11,7 +11,7 @@
     "dev": "nodemon --watch index.js --watch lib --watch config.js index.js",
     "eslint": "./node_modules/.bin/eslint --config ../.eslintrc.js *.js lib/ public/",
     "coverage": "npm run eslint && nyc npm run mocha",
-    "mocha": "mocha --exit test/**/mocha-*"
+    "mocha": "mocha --exit test/**/mocha-i*"
   },
   "author": "Vladimir Kosmala",
   "license": "GPL-3.0",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -11,7 +11,7 @@
     "dev": "nodemon --watch index.js --watch lib --watch config.js index.js",
     "eslint": "./node_modules/.bin/eslint --config ../.eslintrc.js *.js lib/ public/",
     "coverage": "npm run eslint && nyc npm run mocha",
-    "mocha": "mocha --exit test/**/mocha-i*"
+    "mocha": "mocha --exit test/**/mocha-*"
   },
   "author": "Vladimir Kosmala",
   "license": "GPL-3.0",

--- a/QualityControl/public/Model.js
+++ b/QualityControl/public/Model.js
@@ -136,10 +136,14 @@ export default class Model extends Observable {
         // data is already loaded at beginning
         this.notify();
         break;
-      case 'objectView':
+      case 'objectView': {
         this.page = 'objectView';
-        this.notify();
+        const layoutId = this.router.params.layoutId;
+        if (layoutId) {
+          this.layout.getLayoutById(layoutId);
+        }
         break;
+      }
       case 'about':
         this.page = 'about';
         this.frameworkInfo.getFrameworkInfo();

--- a/QualityControl/public/Model.js
+++ b/QualityControl/public/Model.js
@@ -142,6 +142,7 @@ export default class Model extends Observable {
         if (layoutId) {
           this.layout.getLayoutById(layoutId);
         }
+        this.notify();
         break;
       }
       case 'about':

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -70,7 +70,8 @@ export default class Layout extends Observable {
   }
 
   /**
-   * Load data about a layout by its id
+   * Load data about a layout by its id;
+   * Used within ObjectView page hence updating selected object as well
    * @param {string} layoutId
    */
   async getLayoutById(layoutId) {
@@ -79,8 +80,15 @@ export default class Layout extends Observable {
     this.requestedLayout = await this.model.layoutService.getLayoutById(layoutId);
     if (!this.requestedLayout.isSuccess()) {
       this.model.notification.show(`Unable to load requested layout.`, 'danger', Infinity);
+    } else {
+      if (this.model.router.params.objectId) {
+        console.log("Req)")
+        console.log(this.model.object.getObjectNameByIdFromLayout(this.requestedLayout.payload, this.model.router.params.objectId))
+        this.model.object.select({
+          name: this.model.object.getObjectNameByIdFromLayout(this.requestedLayout.payload, this.model.router.params.objectId)
+        });
+      }
     }
-    console.log("Notificam)")
     this.notify();
   }
 

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -80,6 +80,7 @@ export default class Layout extends Observable {
     if (!this.requestedLayout.isSuccess()) {
       this.model.notification.show(`Unable to load requested layout.`, 'danger', Infinity);
     }
+    console.log("Notificam)")
     this.notify();
   }
 

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -23,6 +23,7 @@ export default class Layout extends Observable {
     this.tab = null; // pointer to a tab from `item`
 
     this.myList = RemoteData.notAsked(); // array of layouts
+    this.requestedLayout = RemoteData.notAsked();
 
     this.searchInput = '';
     this.searchResult = null; // null means no search, sub-array of `list`
@@ -65,6 +66,20 @@ export default class Layout extends Observable {
       this.model.notification.show(`Unable to load your personal layouts.`, 'danger', Infinity);
     }
     this.model.folder.map.get('My Layouts').list = this.myList.payload;
+    this.notify();
+  }
+
+  /**
+   * Load data about a layout by its id
+   * @param {string} layoutId
+   */
+  async getLayoutById(layoutId) {
+    this.requestedLayout = RemoteData.loading();
+    this.notify();
+    this.requestedLayout = await this.model.layoutService.getLayoutById(layoutId);
+    if (!this.requestedLayout.isSuccess()) {
+      this.model.notification.show(`Unable to load requested layout.`, 'danger', Infinity);
+    }
     this.notify();
   }
 

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -82,10 +82,9 @@ export default class Layout extends Observable {
       this.model.notification.show(`Unable to load requested layout.`, 'danger', Infinity);
     } else {
       if (this.model.router.params.objectId) {
-        console.log("Req)")
-        console.log(this.model.object.getObjectNameByIdFromLayout(this.requestedLayout.payload, this.model.router.params.objectId))
         this.model.object.select({
-          name: this.model.object.getObjectNameByIdFromLayout(this.requestedLayout.payload, this.model.router.params.objectId)
+          name: this.model.object.getObjectNameByIdFromLayout(this.requestedLayout.payload,
+            this.model.router.params.objectId)
         });
       }
     }

--- a/QualityControl/public/layout/layoutShowPage.js
+++ b/QualityControl/public/layout/layoutShowPage.js
@@ -212,7 +212,7 @@ function drawComponent(model, tabObject) {
         ),
         h('a.btn', {
           title: 'Open object plot in full screen',
-          href: `?page=objectView&objectName=${tabObject.name}&layoutId=${model.router.params.layoutId}`,
+          href: `?page=objectView&objectId=${tabObject.id}&layoutId=${model.router.params.layoutId}`,
           onclick: (e) => model.router.handleLinkEvent(e)
         }, iconResizeBoth())
       ]),

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -439,6 +439,7 @@ export default class QCObject extends Observable {
       case 'objectView': {
         const layoutId = this.model.router.params.layoutId;
         const objectId = this.model.router.params.objectId;
+
         if (!layoutId || !objectId) {
           drawingOptions = JSON.parse(JSON.stringify(objectOptionList));
         } else {

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -436,13 +436,55 @@ export default class QCObject extends Observable {
         // merge all options or ignore if in layout view and user specifies so
         break;
       }
-      case 'objectView':
-        drawingOptions = JSON.parse(JSON.stringify(objectOptionList));
+      case 'objectView': {
+        const layoutId = this.model.router.params.layoutId;
+        const objectId = this.model.router.params.objectId;
+        if (!layoutId || !objectId) {
+          drawingOptions = JSON.parse(JSON.stringify(objectOptionList));
+        } else {
+          if (this.model.layout.requestedLayout.isSuccess()) {
+            let objectData = {};
+            this.model.layout.requestedLayout.payload.tabs.forEach((tab) => {
+              const obj = tab.objects.find((object) => object.id === objectId);
+              if (obj) {
+                objectData = obj;
+              }
+            });
+            if (!objectData.ignoreDefaults) {
+              objectData.options.forEach((option) => {
+                if (objectOptionList.indexOf(option) < 0) {
+                  objectOptionList.push(option);
+                }
+              });
+              drawingOptions = JSON.parse(JSON.stringify(objectOptionList));
+            } else {
+              drawingOptions = JSON.parse(JSON.stringify(objectData.options));
+            }
+          }
+        }
         break;
+      }
       default:
         drawingOptions = objectOptionList;
         break;
     }
     return drawingOptions;
+  }
+
+  /**
+   * Method to parse through tabs and objects of a layout to return one object by ID
+   * @param {Object} layout
+   * @param {string} objectId
+   * @return {string}
+   */
+  getObjectNameByIdFromLayout(layout, objectId) {
+    let objectName = '';
+    layout.tabs.forEach((tab) => {
+      const obj = tab.objects.find((object) => object.id === objectId);
+      if (obj) {
+        objectName = obj.name;
+      }
+    });
+    return objectName;
   }
 }

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -109,25 +109,28 @@ function getCopyURLToClipboardButton(model) {
 function getRootObject(model) {
   return h('.text-center', {style: 'flex-grow: 1; height:0;'},
     model.router.params.objectName ?
-      // means from objectTree
-      h('', {
-        oncreate: () => model.object.select({name: model.router.params.objectName}),
-        style: 'width: 100%; height: 100%',
-      }, model.object.selected ?
-        draw(model, model.object.selected.name, {stat: true})
-        : errorLoadingObject(`Object ${model.router.params.objectName} could not be loaded`)
-      )
-      :
+      ( // means from objectTree
+        h('', {
+          oncreate: () => model.object.select({name: model.router.params.objectName}),
+          style: 'width: 100%; height: 100%',
+        }, model.object.selected ?
+          draw(model, model.object.selected.name, {stat: true})
+          : errorLoadingObject(`Object ${model.router.params.objectName} could not be loaded`)
+        )
+      ) :
       // means layout
       model.router.params.objectId ?
         model.router.params.layoutId ?
           model.layout.requestedLayout.match({
             NotAsked: () => null,
             Loading: () => h('', spinner()),
-            Success: (layout) =>
-              model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId) ?
-                draw(model, model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId),
+            Success: () =>
+              model.object.selected ?
+                h('', {
+                  style: 'width: 100%; height: 100%'
+                }, draw(model, model.object.selected.name,
                   {stat: true})
+                )
                 :
                 errorLoadingObject('Object could not be found'),
             Failure: (error) => errorLoadingObject(error),

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -1,4 +1,5 @@
 import {h, iconBook, iconCircleX, iconArrowThickLeft} from '/js/src/index.js';
+import spinner from './../../loader/spinner.js';
 import {draw} from './../objectDraw.js';
 import infoButton from './../../common/infoButton.js';
 
@@ -21,7 +22,22 @@ export default (model) => h('.p2.absolute-fill', {style: 'display: flex; flex-di
  * @return {string}
  */
 function getObjectTitle(model) {
-  return model.router.params.objectName ? model.router.params.objectName : 'Please pass an objectName parameter';
+  return model.router.params.objectName ?
+    model.router.params.objectName
+    :
+    (
+      model.router.params.objectId && model.router.params.layoutId &&
+      model.layout.requestedLayout.match({
+        NotAsked: () => null,
+        Loading: () => null,
+        Success: (layout) =>
+          model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId) && h('.flex-column', [
+            h('', model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId)),
+            h('.text-light.f7', `(from layout: ${layout.name})`)
+          ]),
+        Failure: () => null
+      })
+    );
 }
 
 /**
@@ -33,7 +49,7 @@ function getActionsHeader(model) {
   return h('', {style: 'display: flex'},
     [
       getBackToQCGButton(model),
-      h('b.text-center', {style: 'flex-grow:1'}, getObjectTitle(model)),
+      h('b.text-center.flex-column', {style: 'flex-grow:1'}, getObjectTitle(model)),
       h('.flex-row', [
         infoButton(model.object),
         model.isContextSecure() && getCopyURLToClipboardButton(model)
@@ -93,13 +109,34 @@ function getCopyURLToClipboardButton(model) {
 function getRootObject(model) {
   return h('.text-center', {style: 'flex-grow: 1; height:0;'},
     model.router.params.objectName ?
-      h('',
-        {
+      // means from objectTree
+      (
+        h('', {
           oncreate: () => model.object.select({name: model.router.params.objectName}),
           style: 'width: 100%; height: 100%',
-        },
-        model.object.selected ? draw(model, model.object.selected.name, {stat: true}) : null)
-      : errorLoadingObject(''));
+        }, model.object.selected ?
+          draw(model, model.object.selected.name, {stat: true})
+          : errorLoadingObject(`Object ${model.router.params.objectName} could not be loaded`))
+      )
+      :
+      // means layout
+      model.router.params.objectId ?
+        model.router.params.layoutId ?
+          model.layout.requestedLayout.match({
+            NotAsked: () => null,
+            Loading: () => spinner(),
+            Success: (layout) =>
+              model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId) ?
+                draw(model, model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId),
+                  {stat: true})
+                :
+                errorLoadingObject('Object could not be found'),
+            Failure: (error) => errorLoadingObject(error),
+          })
+          :
+          errorLoadingObject('No layout ID was provided')
+        : errorLoadingObject('No object name or object ID were provided')
+  );
 }
 
 /**
@@ -108,8 +145,7 @@ function getRootObject(model) {
  * @return {vnode}
  */
 function errorLoadingObject(errorMessage) {
-  return h('',
-    {style: 'flex-direction: column;font-size: 10em;'},
-    [iconCircleX(), errorMessage]
+  return h('.flex-column',
+    [h('span.f1', iconCircleX()), h('span.f3', errorMessage)]
   );
 }

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -110,13 +110,12 @@ function getRootObject(model) {
   return h('.text-center', {style: 'flex-grow: 1; height:0;'},
     model.router.params.objectName ?
       // means from objectTree
-      (
-        h('', {
-          oncreate: () => model.object.select({name: model.router.params.objectName}),
-          style: 'width: 100%; height: 100%',
-        }, model.object.selected ?
-          draw(model, model.object.selected.name, {stat: true})
-          : errorLoadingObject(`Object ${model.router.params.objectName} could not be loaded`))
+      h('', {
+        oncreate: () => model.object.select({name: model.router.params.objectName}),
+        style: 'width: 100%; height: 100%',
+      }, model.object.selected ?
+        draw(model, model.object.selected.name, {stat: true})
+        : errorLoadingObject(`Object ${model.router.params.objectName} could not be loaded`)
       )
       :
       // means layout
@@ -124,7 +123,7 @@ function getRootObject(model) {
         model.router.params.layoutId ?
           model.layout.requestedLayout.match({
             NotAsked: () => null,
-            Loading: () => spinner(),
+            Loading: () => h('', spinner()),
             Success: (layout) =>
               model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId) ?
                 draw(model, model.object.getObjectNameByIdFromLayout(layout, model.router.params.objectId),
@@ -146,6 +145,6 @@ function getRootObject(model) {
  */
 function errorLoadingObject(errorMessage) {
   return h('.flex-column',
-    [h('span.f1', iconCircleX()), h('span.f3', errorMessage)]
+    [h('.f1', iconCircleX()), h('span.f3', errorMessage)]
   );
 }

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -64,22 +64,19 @@ function getActionsHeader(model) {
  */
 function getBackToQCGButton(model) {
   return h('',
-    h('a.btn',
-      {
-        title: model.router.params.layoutId ? 'Go back to layout' : 'Go back to all objects',
-        href: model.router.params.layoutId ?
-          `?page=layoutShow&layoutId=${model.router.params.layoutId}`
-          : '?page=objectTree',
-        onclick: (e) => {
-          model.router.handleLinkEvent(e);
-        }
-      },
-      [
-        iconArrowThickLeft(),
-        ' ',
-        model.router.params.layoutId ? 'Back to layout' : 'Back to QCG'
-      ]
-    )
+    h('a.btn', {
+      title: model.router.params.layoutId ? 'Go back to layout' : 'Go back to all objects',
+      href: model.router.params.layoutId ?
+        `?page=layoutShow&layoutId=${model.router.params.layoutId}`
+        : '?page=objectTree',
+      onclick: (e) => {
+        model.router.handleLinkEvent(e);
+      }
+    }, [
+      iconArrowThickLeft(),
+      ' ',
+      model.router.params.layoutId ? 'Back to layout' : 'Back to QCG'
+    ])
   );
 }
 
@@ -123,7 +120,7 @@ function getRootObject(model) {
         model.router.params.layoutId ?
           model.layout.requestedLayout.match({
             NotAsked: () => null,
-            Loading: () => h('', spinner()),
+            Loading: () => h('.f1', spinner()),
             Success: () =>
               model.object.selected ?
                 h('', {

--- a/QualityControl/public/services/Layout.service.js
+++ b/QualityControl/public/services/Layout.service.js
@@ -83,7 +83,7 @@ export default class LayoutService {
    */
   parseResult(result, ok) {
     if (!ok) {
-      return RemoteData.failure(result.error);
+      return RemoteData.failure(result.error || result.message);
     } else {
       return RemoteData.success(result);
     }

--- a/QualityControl/public/view.js
+++ b/QualityControl/public/view.js
@@ -39,6 +39,7 @@ function page(model) {
     case 'layoutList': return layoutListPage(model);
     case 'layoutShow': return layoutShowPage(model);
     case 'objectTree': return objectTreePage(model);
+    case 'objectView': return objectViewPage(model);
     case 'about': return frameworkInfoPage(model);
 
     // Should be seen only at the first start when the view is not yet really to be shown (data loading)

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -655,7 +655,7 @@ describe('QCG', function() {
       assert.deepStrictEqual(drawingOptions, expDrawingOpts);
     });
 
-    it('should merge options on layoutShow and false ignoreDefaults field', async () => {
+    it('should merge options on objectView and false ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {
         window.model.page = 'objectView';
         window.model.router.params.objectId = '5aba4a059b755d517e76ef54';
@@ -676,7 +676,7 @@ describe('QCG', function() {
       assert.deepStrictEqual(drawingOptions, expDrawingOpts);
     });
 
-    it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
+    it('should ignore default options on objectView and true ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {
         window.model.page = 'objectView';
         window.model.router.params.objectId = '5aba4a059b755d517e76ef54';

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -34,7 +34,7 @@ describe('QCG', function() {
 
     this.ok = true;
     // Start browser to test UI
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: false});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: true});
     page = await browser.newPage();
 
     // Listen to browser
@@ -298,302 +298,401 @@ describe('QCG', function() {
   //   });
   // });
 
-  describe('page objectView', () => {
-    describe('objectView called from objectTree', () => {
-      // it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
-      //   await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
-      //   const result = await page.evaluate(() => {
-      //     const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-      //     const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-      //     const backButtonTitle = document.querySelector('div div div a').title;
+  // describe('page objectView', () => {
+  //   describe('objectView called from objectTree', () => {
+  //     it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
+  //       await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+  //       const result = await page.evaluate(() => {
+  //         const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+  //         const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+  //         const backButtonTitle = document.querySelector('div div div a').title;
 
-      //     return {
-      //       location: window.location,
-      //       message: errorMessage,
-      //       iconClassList: iconClassList,
-      //       backButtonTitle: backButtonTitle
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.location.search, '?page=objectView');
-      //   assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
-      //   assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-      //   assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
-      // });
+  //         return {
+  //           location: window.location,
+  //           message: errorMessage,
+  //           iconClassList: iconClassList,
+  //           backButtonTitle: backButtonTitle
+  //         };
+  //       });
+  //       assert.deepStrictEqual(result.location.search, '?page=objectView');
+  //       assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+  //       assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+  //       assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+  //     });
 
-      // it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
-      //   await page.evaluate(() => document.querySelector('div div div a').click());
+  //     it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+  //       await page.evaluate(() => document.querySelector('div div div a').click());
 
-      //   const result = await page.evaluate(() => {
-      //     return {
-      //       location: window.location.search,
-      //       objectSelected: window.model.object.selected
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.location, '?page=objectTree');
-      //   assert.deepStrictEqual(result.objectSelected, null);
-      // });
+  //       const result = await page.evaluate(() => {
+  //         return {
+  //           location: window.location.search,
+  //           objectSelected: window.model.object.selected
+  //         };
+  //       });
+  //       assert.deepStrictEqual(result.location, '?page=objectTree');
+  //       assert.deepStrictEqual(result.objectSelected, null);
+  //     });
 
-      // it('should load page=objectView and display an error message when a parameter objectName is passed but object not found', async () => {
-      //   const objectName = 'NOT_FOUND_OBJECT';
-      //   await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
-      //   const result = await page.evaluate(() => {
-      //     const title = document.querySelector('body > div > div:nth-child(2) > div > div > span').textContent;
-      //     return {
-      //       title: title,
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.title, 'Object NOT_FOUND_OBJECT could not be loaded');
-      // });
+  //     it('should load page=objectView and display an error message when a parameter objectName is passed but object not found', async () => {
+  //       const objectName = 'NOT_FOUND_OBJECT';
+  //       await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+  //       const result = await page.evaluate(() => {
+  //         const title = document.querySelector('body > div > div:nth-child(2) > div > div > span').textContent;
+  //         return {
+  //           title: title,
+  //         };
+  //       });
+  //       assert.deepStrictEqual(result.title, 'Object NOT_FOUND_OBJECT could not be loaded');
+  //     });
 
-      // it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
-      //   const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-      //   await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
-      //   const result = await page.evaluate(() => {
-      //     const title = document.querySelector('div div b').textContent;
-      //     const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
-      //     const objectSelected = window.model.object.selected;
-      //     return {
-      //       title: title,
-      //       rootPlotClassList: rootPlotClassList,
-      //       objectSelected: objectSelected
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.title, objectName);
-      //   assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-      //   assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
-      // });
+  //     it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
+  //       const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
+  //       await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+  //       const result = await page.evaluate(() => {
+  //         const title = document.querySelector('div div b').textContent;
+  //         const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+  //         const objectSelected = window.model.object.selected;
+  //         return {
+  //           title: title,
+  //           rootPlotClassList: rootPlotClassList,
+  //           objectSelected: objectSelected
+  //         };
+  //       });
+  //       assert.deepStrictEqual(result.title, objectName);
+  //       assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+  //       assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
+  //     });
 
-      // it('should have an info button with full path and last modified when clicked (plot success)', async () => {
-      //   const result = await page.evaluate(() => {
-      //     const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
-      //     const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
-      //     const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
-      //     return {
-      //       title: infoButtonTitle,
-      //       fullPath: fullPath,
-      //       lastModified: lastModified
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.title, 'View details about histogram');
-      //   assert.deepStrictEqual(result.fullPath, 'PATHDAQ01/EquipmentSize/CPV/CPV');
-      //   assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED' + new Date(100).toLocaleString());
-      // });
+  //     it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+  //       await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
+
+  //       const result = await page.evaluate(() => {
+  //         const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+  //         const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+  //         const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+  //         const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
+  //         return {
+  //           title: infoButtonTitle,
+  //           fullPath: fullPath,
+  //           lastModified: lastModified,
+  //           dropdownInfoClass: dropdownInfoClass
+  //         };
+  //       });
+  //       assert.deepStrictEqual(result.title, 'View details about histogram');
+  //       assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
+  //       assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+  //       assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
+  //     });
+
+  //     describe('objectView called from layoutShow', () => {
+  //       it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
+  //         await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+  //         const result = await page.evaluate(() => {
+  //           const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+  //           const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+  //           const backButtonTitle = document.querySelector('div div div a').title;
+
+  //           return {
+  //             location: window.location,
+  //             message: errorMessage,
+  //             iconClassList: iconClassList,
+  //             backButtonTitle: backButtonTitle
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.location.search, '?page=objectView');
+  //         assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+  //         assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+  //       });
+
+  //       it('should load page=objectView and display error message & icon due to missing layoutId parameter', async () => {
+  //         await page.goto(url + '?page=objectView&objectId=123456', {waitUntil: 'networkidle0'});
+  //         const result = await page.evaluate(() => {
+  //           const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+  //           const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+  //           const backButtonTitle = document.querySelector('div div div a').title;
+
+  //           return {
+  //             location: window.location,
+  //             message: errorMessage,
+  //             iconClassList: iconClassList,
+  //             backButtonTitle: backButtonTitle
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.location.search, '?page=objectView&objectId=123456');
+  //         assert.deepStrictEqual(result.message, 'No layout ID was provided');
+  //         assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+  //       });
+
+  //       it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+  //         await page.evaluate(() => document.querySelector('div div div a').click());
+
+  //         const result = await page.evaluate(() => {
+  //           return {
+  //             location: window.location.search,
+  //             objectSelected: window.model.object.selected
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.location, '?page=objectTree');
+  //         assert.deepStrictEqual(result.objectSelected, null);
+  //       });
+
+  //       it('should load a plot and update button text to "Go back to layout" if layoutId parameter is provided', async () => {
+  //         const objectId = '5aba4a059b755d517e76ef54';
+  //         const layoutId = '5aba4a059b755d517e76ea10';
+  //         await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+
+  //         const result = await page.evaluate(() => {
+  //           const backButtonTitle = document.querySelector('div div div a').title;
+  //           return {
+  //             location: window.location.search,
+  //             backButtonTitle: backButtonTitle
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.location, `?page=objectView&objectId=5aba4a059b755d517e76ef54&layoutId=5aba4a059b755d517e76ea10`);
+  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
+  //       });
+
+  //       it('should take back the user to page=layoutShow when clicking "Go back to layout"', async () => {
+  //         const layoutId = '5aba4a059b755d517e76ea10';
+  //         await page.evaluate(() => document.querySelector('div div div a').click());
+
+  //         const result = await page.evaluate(() => {
+  //           return {
+  //             location: window.location.search,
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
+  //       });
+
+  //       it('should load page=objectView and display a plot when objectId and layoutId are passed', async () => {
+  //         const objectId = '5aba4a059b755d517e76ef54';
+  //         const layoutId = '5aba4a059b755d517e76ea10';
+  //         await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+  //         const result = await page.evaluate(() => {
+  //           const title = document.querySelector('div div b').textContent;
+  //           const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+  //           const objectSelected = window.model.object.selected;
+  //           return {
+  //             title: title,
+  //             rootPlotClassList: rootPlotClassList,
+  //             objectSelected: objectSelected
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(from layout: AliRoot)');
+  //         assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+  //         assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
+  //       });
+
+  //       it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+  //         await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
+  //         page.await
+  //         const result = await page.evaluate(() => {
+  //           const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+  //           const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+  //           const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+  //           const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
+  //           return {
+  //             title: infoButtonTitle,
+  //             fullPath: fullPath,
+  //             lastModified: lastModified,
+  //             dropdownInfoClass: dropdownInfoClass
+  //           };
+  //         });
+  //         assert.deepStrictEqual(result.title, 'View details about histogram');
+  //         assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
+  //         assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+  //         assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
+  //       });
+  //     });
+  //   });
+
+  //   describe('page frameworkInfo', () => {
+  //     before('reset browser to google', async () => {
+  //       // weird bug, if we don't go to external website just here, all next goto will wait forever
+  //       await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+  //     });
+
+  //     it('should load', async () => {
+  //       await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
+  //       const location = await page.evaluate(() => window.location);
+  //       assert.deepStrictEqual(location.search, '?page=about');
+  //     });
+
+  //     it('should have a frameworkInfo item with config fields', async () => {
+  //       const expConfig = {
+  //         qcg: {port: 8181, hostname: 'localhost'},
+  //         consul: {hostname: 'localhost', port: 8500},
+  //         ccdb: {hostname: 'ccdb', port: 8500}
+  //       };
+  //       const config = await page.evaluate(() => window.model.frameworkInfo.item);
+  //       delete config.payload.qcg.version;
+  //       assert.deepStrictEqual(config.payload, expConfig);
+  //     });
+  //   });
+  // });
+
+  describe('QCObject - drawing options', async () => {
+    before('reset browser to google', async () => {
+      // weird bug, if we don't go to external website just here, all next goto will wait forever
+      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
     });
 
-    describe('objectView called from layoutShow', () => {
-      it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
-        await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
-        const result = await page.evaluate(() => {
-          const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-          const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-          const backButtonTitle = document.querySelector('div div div a').title;
+    it('should load', async () => {
+      // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
+      await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
+      const location = await page.evaluate(() => window.location);
+      assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+    });
 
-          return {
-            location: window.location,
-            message: errorMessage,
-            iconClassList: iconClassList,
-            backButtonTitle: backButtonTitle
-          };
-        });
-        assert.deepStrictEqual(result.location.search, '?page=objectView');
-        assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
-        assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-        assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+    // it('should merge options on layoutShow and no ignoreDefaults field', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     const tabObject = {options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    // it('should merge options on layoutShow and false ignoreDefaults field', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    // it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['args', 'coly'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    // it('should use only default options on objectTree', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     window.model.page = 'objectTree';
+    //     const tabObject = {options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    // it('should use only default options on objectView when no layoutId or objectId ar set', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     window.model.page = 'objectView';
+    //     const tabObject = {options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    // it('should use only default options on objectView when no layoutId is set', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     window.model.page = 'objectView';
+    //     window.model.router.params.objectId = '123';
+    //     const tabObject = {options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+
+    // it('should use only default options on objectView when no objectId is set', async () => {
+    //   const drawingOptions = await page.evaluate(() => {
+    //     window.model.page = 'objectView';
+    //     window.model.router.params.layoutId = '123';
+    //     const tabObject = {options: ['args', 'coly']};
+    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
+    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+    //   });
+
+    //   const expDrawingOpts = ['lego', 'colz'];
+    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    // });
+
+    it('should merge options on objectView and no ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.objectId = '5aba4a059b755d517e76ef54';
+        window.model.router.params.layoutId = '5aba4a059b755d517e76ea10';
+        window.model.layout.requestedLayout.kind = 'Success';
+        window.model.layout.requestedLayout.payload = {};
+        window.model.layout.requestedLayout.payload.tabs = [{
+          id: '5aba4a059b755d517e76eb61', name: 'SDD', objects: [{
+            id: '5aba4a059b755d517e76ef54',
+            options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+          }]
+        }];
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 
-      it('should load page=objectView and display error message & icon due to missing layoutId parameter', async () => {
-        await page.goto(url + '?page=objectView&objectId=123456', {waitUntil: 'networkidle0'});
-        const result = await page.evaluate(() => {
-          const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-          const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-          const backButtonTitle = document.querySelector('div div div a').title;
+      const expDrawingOpts = ['lego', 'colz', 'gridx'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-          return {
-            location: window.location,
-            message: errorMessage,
-            iconClassList: iconClassList,
-            backButtonTitle: backButtonTitle
-          };
-        });
-        assert.deepStrictEqual(result.location.search, '?page=objectView&objectId=123456');
-        assert.deepStrictEqual(result.message, 'No layout ID was provided');
-        assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-        assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+    it('should merge options on layoutShow and false ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.objectId = '5aba4a059b755d517e76ef54';
+        window.model.router.params.layoutId = '5aba4a059b755d517e76ea10';
+        window.model.layout.requestedLayout.kind = 'Success';
+        window.model.layout.requestedLayout.payload = {};
+        window.model.layout.requestedLayout.payload.tabs = [{
+          id: '5aba4a059b755d517e76eb61', name: 'SDD', objects: [{
+            id: '5aba4a059b755d517e76ef54',
+            options: ['gridx'], ignoreDefaults: false, name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+          }]
+        }];
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 
-      it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
-        await page.evaluate(() => document.querySelector('div div div a').click());
+      const expDrawingOpts = ['lego', 'colz', 'gridx'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-        const result = await page.evaluate(() => {
-          return {
-            location: window.location.search,
-            objectSelected: window.model.object.selected
-          };
-        });
-        assert.deepStrictEqual(result.location, '?page=objectTree');
-        assert.deepStrictEqual(result.objectSelected, null);
+    it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.objectId = '5aba4a059b755d517e76ef54';
+        window.model.router.params.layoutId = '5aba4a059b755d517e76ea10';
+        window.model.layout.requestedLayout.kind = 'Success';
+        window.model.layout.requestedLayout.payload = {};
+        window.model.layout.requestedLayout.payload.tabs = [{
+          id: '5aba4a059b755d517e76eb61', name: 'SDD', objects: [{
+            id: '5aba4a059b755d517e76ef54',
+            options: ['gridx'], ignoreDefaults: true, name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+          }]
+        }];
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 
-      it('should load a plot and update button text to "Go back to layout" if layoutId parameter is provided', async () => {
-        const objectId = '5aba4a059b755d517e76ef54';
-        const layoutId = '5aba4a059b755d517e76ea10';
-        await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
-
-        const result = await page.evaluate(() => {
-          const backButtonTitle = document.querySelector('div div div a').title;
-          return {
-            location: window.location.search,
-            backButtonTitle: backButtonTitle
-          };
-        });
-        assert.deepStrictEqual(result.location, `?page=objectView&objectId=5aba4a059b755d517e76ef54&layoutId=5aba4a059b755d517e76ea10`);
-        assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
-      });
-
-      it('should take back the user to page=layoutShow when clicking "Go back to layout"', async () => {
-        const layoutId = '5aba4a059b755d517e76ea10';
-        await page.evaluate(() => document.querySelector('div div div a').click());
-
-        const result = await page.evaluate(() => {
-          return {
-            location: window.location.search,
-          };
-        });
-        assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
-      });
-
-      it('should load page=objectView and display a plot when objectId and layoutId are passed', async () => {
-        const objectId = '5aba4a059b755d517e76ef54';
-        const layoutId = '5aba4a059b755d517e76ea10';
-        await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
-        const result = await page.evaluate(() => {
-          const title = document.querySelector('div div b').textContent;
-          const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
-          const objectSelected = window.model.object.selected;
-          return {
-            title: title,
-            rootPlotClassList: rootPlotClassList,
-            objectSelected: objectSelected
-          };
-        });
-        assert.deepStrictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(from layout: AliRoot)');
-        assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-        assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
-      });
-
-      // it('should have an info button with full path and last modified when clicked (plot success)', async () => {
-      //   const result = await page.evaluate(() => {
-      //     const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
-      //     const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
-      //     const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
-      //     return {
-      //       title: infoButtonTitle,
-      //       fullPath: fullPath,
-      //       lastModified: lastModified
-      //     };
-      //   });
-      //   assert.deepStrictEqual(result.title, 'View details about histogram');
-      //   assert.deepStrictEqual(result.fullPath, 'PATHDAQ01/EquipmentSize/CPV/CPV');
-      //   assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED' + new Date(100).toLocaleString());
-      // });
+      const expDrawingOpts = ['gridx'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
     });
   });
-
-  // describe('page frameworkInfo', () => {
-  //   before('reset browser to google', async () => {
-  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
-  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-  //   });
-
-  //   it('should load', async () => {
-  //     await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
-  //     const location = await page.evaluate(() => window.location);
-  //     assert.deepStrictEqual(location.search, '?page=about');
-  //   });
-
-  //   it('should have a frameworkInfo item with config fields', async () => {
-  //     const expConfig = {
-  //       qcg: {port: 8181, hostname: 'localhost'},
-  //       consul: {hostname: 'localhost', port: 8500},
-  //       ccdb: {hostname: 'ccdb', port: 8500}
-  //     };
-  //     const config = await page.evaluate(() => window.model.frameworkInfo.item);
-  //     delete config.payload.qcg.version;
-  //     assert.deepStrictEqual(config.payload, expConfig);
-  //   });
-  // });
-
-
-  // describe('QCObject - drawing options', async () => {
-  //   before('reset browser to google', async () => {
-  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
-  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-  //   });
-
-  //   it('should load', async () => {
-  //     // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
-  //     await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
-  //     const location = await page.evaluate(() => window.location);
-  //     assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-  //   });
-
-  //   it('should merge options on layoutShow and no ignoreDefaults field', async () => {
-  //     const drawingOptions = await page.evaluate(() => {
-  //       const tabObject = {options: ['args', 'coly']};
-  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
-  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-  //     });
-
-  //     const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-  //   });
-
-  //   it('should merge options on layoutShow and false ignoreDefaults field', async () => {
-  //     const drawingOptions = await page.evaluate(() => {
-  //       const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
-  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
-  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-  //     });
-
-  //     const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-  //   });
-
-  //   it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
-  //     const drawingOptions = await page.evaluate(() => {
-  //       const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
-  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
-  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-  //     });
-
-  //     const expDrawingOpts = ['args', 'coly'];
-  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-  //   });
-
-  //   it('should use only default options on objectTree', async () => {
-  //     const drawingOptions = await page.evaluate(() => {
-  //       window.model.page = 'objectTree';
-  //       const tabObject = {options: ['args', 'coly']};
-  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
-  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-  //     });
-
-  //     const expDrawingOpts = ['lego', 'colz'];
-  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-  //   });
-
-  //   it('should use only default options on objectView', async () => {
-  //     const drawingOptions = await page.evaluate(() => {
-  //       window.model.page = 'objectView';
-  //       const tabObject = {options: ['args', 'coly']};
-  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
-  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-  //     });
-
-  //     const expDrawingOpts = ['lego', 'colz'];
-  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-  //   });
-  // });
 
   beforeEach(() => {
     this.ok = true;

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -82,456 +82,456 @@ describe('QCG', function() {
     assert(sidebarContent.includes('Explore'));
   });
 
-  // describe('page layoutList', () => {
-  //   before(async () => {
-  //     await page.goto(url + '?page=layoutList', {waitUntil: 'networkidle0'});
-  //     const location = await page.evaluate(() => window.location);
-  //     assert(location.search === '?page=layoutList');
-  //   });
+  describe('page layoutList', () => {
+    before(async () => {
+      await page.goto(url + '?page=layoutList', {waitUntil: 'networkidle0'});
+      const location = await page.evaluate(() => window.location);
+      assert(location.search === '?page=layoutList');
+    });
 
-  //   it('should have a button for the Online mode in the header', async () => {
-  //     await page.waitForSelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)', {timeout: 5000});
-  //     const onlineButton = await page.evaluate(() =>
-  //       document.querySelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)').title);
-  //     assert.deepStrictEqual(onlineButton, 'Online');
-  //   });
+    it('should have a button for the Online mode in the header', async () => {
+      await page.waitForSelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)', {timeout: 5000});
+      const onlineButton = await page.evaluate(() =>
+        document.querySelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)').title);
+      assert.deepStrictEqual(onlineButton, 'Online');
+    });
 
-  //   it('should have a table with rows', async () => {
-  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-  //     assert(rowsCount > 1);
-  //   });
+    it('should have a table with rows', async () => {
+      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+      assert(rowsCount > 1);
+    });
 
-  //   it('should have a table with one row after filtering', async () => {
-  //     await page.type('header input', 'AliRoot');
-  //     await page.waitFor(200);
-  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-  //     assert(rowsCount === 1);
-  //   });
+    it('should have a table with one row after filtering', async () => {
+      await page.type('header input', 'AliRoot');
+      await page.waitFor(200);
+      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+      assert(rowsCount === 1);
+    });
 
-  //   it('should have a link to show a layout', async () => {
-  //     await page.evaluate(() => document.querySelector('section table tbody tr a').click());
-  //     const location = await page.evaluate(() => window.location);
-  //     assert.strictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-  //     // id 5aba4a059b755d517e76ea10 is set in QCModelDemo
-  //   });
-  // });
+    it('should have a link to show a layout', async () => {
+      await page.evaluate(() => document.querySelector('section table tbody tr a').click());
+      const location = await page.evaluate(() => window.location);
+      assert.strictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+      // id 5aba4a059b755d517e76ea10 is set in QCModelDemo
+    });
+  });
 
-  // describe('page layoutShow', () => {
-  //   before('reset browser to google', async () => {
-  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
-  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-  //   });
+  describe('page layoutShow', () => {
+    before('reset browser to google', async () => {
+      // weird bug, if we don't go to external website just here, all next goto will wait forever
+      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+    });
 
-  //   it('should load', async () => {
-  //     // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
-  //     await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
-  //     const location = await page.evaluate(() => window.location);
-  //     assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-  //   });
+    it('should load', async () => {
+      // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
+      await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
+      const location = await page.evaluate(() => window.location);
+      assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+    });
 
-  //   it('should have tabs in the header', async () => {
-  //     const tabsCount = await page.evaluate(() => document.querySelectorAll('header .btn-tab').length);
-  //     assert(tabsCount > 1);
-  //   });
+    it('should have tabs in the header', async () => {
+      const tabsCount = await page.evaluate(() => document.querySelectorAll('header .btn-tab').length);
+      assert(tabsCount > 1);
+    });
 
-  //   it('should have selected layout in the sidebar highlighted', async () => {
-  //     const layoutClassList = await page.evaluate(() => document.querySelector('nav div a:nth-child(5)').classList);
-  //     assert.deepStrictEqual(layoutClassList, {0: 'menu-item', 1: 'w-wrapped', 2: 'selected'});
-  //   });
+    it('should have selected layout in the sidebar highlighted', async () => {
+      const layoutClassList = await page.evaluate(() => document.querySelector('nav div a:nth-child(5)').classList);
+      assert.deepStrictEqual(layoutClassList, {0: 'menu-item', 1: 'w-wrapped', 2: 'selected'});
+    });
 
-  //   it('should have jsroot svg plots in the section', async () => {
-  //     const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
-  //     assert(plotsCount > 1);
-  //   });
+    it('should have jsroot svg plots in the section', async () => {
+      const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
+      assert(plotsCount > 1);
+    });
 
-  //   it('should have second tab to be empty (according to demo data)', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(2) > div > button:nth-child(2)').click());
-  //     await page.waitForSelector('section h1', {timeout: 5000});
-  //     const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
-  //     assert.deepStrictEqual(plotsCount, 0);
-  //   });
+    it('should have second tab to be empty (according to demo data)', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(2) > div > button:nth-child(2)').click());
+      await page.waitForSelector('section h1', {timeout: 5000});
+      const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
+      assert.deepStrictEqual(plotsCount, 0);
+    });
 
-  //   it('should have a button group containing three buttons in the header', async () => {
-  //     const buttonCount = await page.evaluate(() =>
-  //       document.querySelectorAll('header > div > div:nth-child(3) > div.btn-group > button').length);
-  //     assert.deepStrictEqual(buttonCount, 3);
-  //   });
+    it('should have a button group containing three buttons in the header', async () => {
+      const buttonCount = await page.evaluate(() =>
+        document.querySelectorAll('header > div > div:nth-child(3) > div.btn-group > button').length);
+      assert.deepStrictEqual(buttonCount, 3);
+    });
 
-  //   it('should have one duplicate button in the header to create a new duplicated layout', async () => {
-  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
-  //     const duplicateButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)').title);
-  //     assert.deepStrictEqual(duplicateButton, 'Duplicate layout');
-  //   });
+    it('should have one duplicate button in the header to create a new duplicated layout', async () => {
+      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
+      const duplicateButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)').title);
+      assert.deepStrictEqual(duplicateButton, 'Duplicate layout');
+    });
 
-  //   it('should have one delete button in the header to delete layout', async () => {
-  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)', {timeout: 5000});
-  //     const deleteButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)').title);
-  //     assert.deepStrictEqual(deleteButton, 'Delete layout');
-  //   });
+    it('should have one delete button in the header to delete layout', async () => {
+      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)', {timeout: 5000});
+      const deleteButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)').title);
+      assert.deepStrictEqual(deleteButton, 'Delete layout');
+    });
 
-  //   it('should have one edit button in the header to go in edit mode', async () => {
-  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
-  //     const editButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(2)').title);
-  //     assert.deepStrictEqual(editButton, 'Edit layout');
-  //   });
+    it('should have one edit button in the header to go in edit mode', async () => {
+      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
+      const editButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(2)').title);
+      assert.deepStrictEqual(editButton, 'Edit layout');
+    });
 
-  //   // Begin: Edit Mode;
-  //   it('should click the edit button in the header and enter edit mode', async () => {
-  //     await page.waitForSelector('header > div > div:nth-child(3) > div > button:nth-child(1)', {timeout: 5000});
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
-  //   });
+    // Begin: Edit Mode;
+    it('should click the edit button in the header and enter edit mode', async () => {
+      await page.waitForSelector('header > div > div:nth-child(3) > div > button:nth-child(1)', {timeout: 5000});
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
+    });
 
-  //   it('should have input field for changing layout name in edit mode', async () => {
-  //     await page.waitForSelector('header > div > div:nth-child(3) > input', {timeout: 5000});
-  //     const count = await page.evaluate(() => document.querySelectorAll('header > div > div:nth-child(3) > input').length);
-  //     assert.deepStrictEqual(count, 1);
-  //   });
+    it('should have input field for changing layout name in edit mode', async () => {
+      await page.waitForSelector('header > div > div:nth-child(3) > input', {timeout: 5000});
+      const count = await page.evaluate(() => document.querySelectorAll('header > div > div:nth-child(3) > input').length);
+      assert.deepStrictEqual(count, 1);
+    });
 
-  //   it('should have a tree sidebar in edit mode', async () => {
-  //     await page.waitForSelector('nav table tbody tr'); // loading., {timeout: 5000}..
-  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('nav table tbody tr').length);
-  //     assert.deepStrictEqual(rowsCount, 4); // 4 agents
-  //   });
+    it('should have a tree sidebar in edit mode', async () => {
+      await page.waitForSelector('nav table tbody tr'); // loading., {timeout: 5000}..
+      const rowsCount = await page.evaluate(() => document.querySelectorAll('nav table tbody tr').length);
+      assert.deepStrictEqual(rowsCount, 4); // 4 agents
+    });
 
-  //   it('should have filtered results on input search filled', async () => {
-  //     await page.type('nav input', 'HistoWithRandom');
-  //     await page.waitForFunction(`document.querySelectorAll('nav table tbody tr').length === 1`, {timeout: 5000});
-  //   });
+    it('should have filtered results on input search filled', async () => {
+      await page.type('nav input', 'HistoWithRandom');
+      await page.waitForFunction(`document.querySelectorAll('nav table tbody tr').length === 1`, {timeout: 5000});
+    });
 
-  //   it('should show normal sidebar after Cancel click', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
-  //     await page.waitForSelector('nav .menu-title', {timeout: 5000});
-  //   });
-  // });
+    it('should show normal sidebar after Cancel click', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
+      await page.waitForSelector('nav .menu-title', {timeout: 5000});
+    });
+  });
 
-  // describe('page objectTree', () => {
-  //   before('reset browser to google', async () => {
-  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
-  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-  //   });
+  describe('page objectTree', () => {
+    before('reset browser to google', async () => {
+      // weird bug, if we don't go to external website just here, all next goto will wait forever
+      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+    });
 
-  //   it('should load', async () => {
-  //     await page.goto(url + '?page=objectTree', {waitUntil: 'networkidle0'});
-  //     const location = await page.evaluate(() => window.location);
-  //     assert(location.search === '?page=objectTree');
-  //   });
+    it('should load', async () => {
+      await page.goto(url + '?page=objectTree', {waitUntil: 'networkidle0'});
+      const location = await page.evaluate(() => window.location);
+      assert(location.search === '?page=objectTree');
+    });
 
-  //   it('should have a tree as a table', async () => {
-  //     await page.waitForSelector('section table tbody tr', {timeout: 5000});
-  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-  //     assert.deepStrictEqual(rowsCount, 4); // 4 agents
-  //   });
+    it('should have a tree as a table', async () => {
+      await page.waitForSelector('section table tbody tr', {timeout: 5000});
+      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+      assert.deepStrictEqual(rowsCount, 4); // 4 agents
+    });
 
-  //   it('should have a button to sort by (default "Name" ASC)', async () => {
-  //     const sortByButtonTitle = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div').title);
-  //     assert.strictEqual(sortByButtonTitle, 'Sort by');
-  //   });
+    it('should have a button to sort by (default "Name" ASC)', async () => {
+      const sortByButtonTitle = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div').title);
+      assert.strictEqual(sortByButtonTitle, 'Sort by');
+    });
 
-  //   it('should have first element in tree as "DAQ01/EquipmentSize/ACORDE/ACORDE"', async () => {
-  //     const firstElement = await page.evaluate(() => window.model.object.currentList[0]);
-  //     assert.strictEqual(firstElement.name, 'DAQ01/EquipmentSize/ACORDE/ACORDE');
-  //   });
+    it('should have first element in tree as "DAQ01/EquipmentSize/ACORDE/ACORDE"', async () => {
+      const firstElement = await page.evaluate(() => window.model.object.currentList[0]);
+      assert.strictEqual(firstElement.name, 'DAQ01/EquipmentSize/ACORDE/ACORDE');
+    });
 
-  //   it('should sort list of histograms by name in descending order', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(4)').click());
-  //     const sorted = await page.evaluate(() => {
-  //       return {
-  //         list: window.model.object.currentList,
-  //         sort: window.model.object.sortBy
-  //       };
-  //     });
-  //     assert.strictEqual(sorted.sort.title, 'Name');
-  //     assert.strictEqual(sorted.sort.order, -1);
-  //     assert.strictEqual(sorted.sort.field, 'name');
-  //     assert.strictEqual(sorted.list[0].name, 'TST01/Default/hTOFRRawTimeVsTRM3671');
-  //   });
+    it('should sort list of histograms by name in descending order', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(4)').click());
+      const sorted = await page.evaluate(() => {
+        return {
+          list: window.model.object.currentList,
+          sort: window.model.object.sortBy
+        };
+      });
+      assert.strictEqual(sorted.sort.title, 'Name');
+      assert.strictEqual(sorted.sort.order, -1);
+      assert.strictEqual(sorted.sort.field, 'name');
+      assert.strictEqual(sorted.list[0].name, 'TST01/Default/hTOFRRawTimeVsTRM3671');
+    });
 
-  //   it('should sort list of histograms by name in ascending order', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(3)').click());
-  //     const sorted = await page.evaluate(() => {
-  //       return {
-  //         list: window.model.object.currentList,
-  //         sort: window.model.object.sortBy
-  //       };
-  //     });
-  //     assert.strictEqual(sorted.sort.title, 'Name');
-  //     assert.strictEqual(sorted.sort.order, 1);
-  //     assert.strictEqual(sorted.sort.field, 'name');
-  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
-  //   });
+    it('should sort list of histograms by name in ascending order', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(3)').click());
+      const sorted = await page.evaluate(() => {
+        return {
+          list: window.model.object.currentList,
+          sort: window.model.object.sortBy
+        };
+      });
+      assert.strictEqual(sorted.sort.title, 'Name');
+      assert.strictEqual(sorted.sort.order, 1);
+      assert.strictEqual(sorted.sort.field, 'name');
+      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
+    });
 
-  //   it('should sort list of histograms by created time in descending order', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(2)').click());
-  //     const sorted = await page.evaluate(() => {
-  //       return {
-  //         list: window.model.object.currentList,
-  //         sort: window.model.object.sortBy
-  //       };
-  //     });
-  //     assert.strictEqual(sorted.sort.title, 'Created Time');
-  //     assert.strictEqual(sorted.sort.order, -1);
-  //     assert.strictEqual(sorted.sort.field, 'createTime');
-  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/2499');
-  //   });
+    it('should sort list of histograms by created time in descending order', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(2)').click());
+      const sorted = await page.evaluate(() => {
+        return {
+          list: window.model.object.currentList,
+          sort: window.model.object.sortBy
+        };
+      });
+      assert.strictEqual(sorted.sort.title, 'Created Time');
+      assert.strictEqual(sorted.sort.order, -1);
+      assert.strictEqual(sorted.sort.field, 'createTime');
+      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/2499');
+    });
 
-  //   it('should sort list of histograms by created time in ascending order', async () => {
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(1)').click());
-  //     const sorted = await page.evaluate(() => {
-  //       return {
-  //         list: window.model.object.currentList,
-  //         sort: window.model.object.sortBy
-  //       };
-  //     });
-  //     assert.strictEqual(sorted.sort.title, 'Created Time');
-  //     assert.strictEqual(sorted.sort.order, 1);
-  //     assert.strictEqual(sorted.sort.field, 'createTime');
-  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
-  //   });
+    it('should sort list of histograms by created time in ascending order', async () => {
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(1)').click());
+      const sorted = await page.evaluate(() => {
+        return {
+          list: window.model.object.currentList,
+          sort: window.model.object.sortBy
+        };
+      });
+      assert.strictEqual(sorted.sort.title, 'Created Time');
+      assert.strictEqual(sorted.sort.order, 1);
+      assert.strictEqual(sorted.sort.field, 'createTime');
+      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
+    });
 
-  //   it('should have filtered results on input search filled', async () => {
-  //     await page.type('header input', 'BIGTREE');
-  //     await page.waitForFunction(`document.querySelectorAll('section table tbody tr').length === 2500`, {timeout: 5000});
-  //   });
-  // });
+    it('should have filtered results on input search filled', async () => {
+      await page.type('header input', 'BIGTREE');
+      await page.waitForFunction(`document.querySelectorAll('section table tbody tr').length === 2500`, {timeout: 5000});
+    });
+  });
 
-  // describe('page objectView', () => {
-  //   describe('objectView called from objectTree', () => {
-  //     it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
-  //       await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
-  //       const result = await page.evaluate(() => {
-  //         const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-  //         const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-  //         const backButtonTitle = document.querySelector('div div div a').title;
+  describe('page objectView', () => {
+    describe('objectView called from objectTree', () => {
+      it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
+        await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+          const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+          const backButtonTitle = document.querySelector('div div div a').title;
 
-  //         return {
-  //           location: window.location,
-  //           message: errorMessage,
-  //           iconClassList: iconClassList,
-  //           backButtonTitle: backButtonTitle
-  //         };
-  //       });
-  //       assert.deepStrictEqual(result.location.search, '?page=objectView');
-  //       assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
-  //       assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-  //       assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
-  //     });
+          return {
+            location: window.location,
+            message: errorMessage,
+            iconClassList: iconClassList,
+            backButtonTitle: backButtonTitle
+          };
+        });
+        assert.deepStrictEqual(result.location.search, '?page=objectView');
+        assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+        assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+        assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+      });
 
-  //     it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
-  //       await page.evaluate(() => document.querySelector('div div div a').click());
+      it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+        await page.evaluate(() => document.querySelector('div div div a').click());
 
-  //       const result = await page.evaluate(() => {
-  //         return {
-  //           location: window.location.search,
-  //           objectSelected: window.model.object.selected
-  //         };
-  //       });
-  //       assert.deepStrictEqual(result.location, '?page=objectTree');
-  //       assert.deepStrictEqual(result.objectSelected, null);
-  //     });
+        const result = await page.evaluate(() => {
+          return {
+            location: window.location.search,
+            objectSelected: window.model.object.selected
+          };
+        });
+        assert.deepStrictEqual(result.location, '?page=objectTree');
+        assert.deepStrictEqual(result.objectSelected, null);
+      });
 
-  //     it('should load page=objectView and display an error message when a parameter objectName is passed but object not found', async () => {
-  //       const objectName = 'NOT_FOUND_OBJECT';
-  //       await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
-  //       const result = await page.evaluate(() => {
-  //         const title = document.querySelector('body > div > div:nth-child(2) > div > div > span').textContent;
-  //         return {
-  //           title: title,
-  //         };
-  //       });
-  //       assert.deepStrictEqual(result.title, 'Object NOT_FOUND_OBJECT could not be loaded');
-  //     });
+      it('should load page=objectView and display an error message when a parameter objectName is passed but object not found', async () => {
+        const objectName = 'NOT_FOUND_OBJECT';
+        await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const title = document.querySelector('body > div > div:nth-child(2) > div > div > span').textContent;
+          return {
+            title: title,
+          };
+        });
+        assert.deepStrictEqual(result.title, 'Object NOT_FOUND_OBJECT could not be loaded');
+      });
 
-  //     it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
-  //       const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-  //       await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
-  //       const result = await page.evaluate(() => {
-  //         const title = document.querySelector('div div b').textContent;
-  //         const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
-  //         const objectSelected = window.model.object.selected;
-  //         return {
-  //           title: title,
-  //           rootPlotClassList: rootPlotClassList,
-  //           objectSelected: objectSelected
-  //         };
-  //       });
-  //       assert.deepStrictEqual(result.title, objectName);
-  //       assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-  //       assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
-  //     });
+      it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
+        const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
+        await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const title = document.querySelector('div div b').textContent;
+          const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+          const objectSelected = window.model.object.selected;
+          return {
+            title: title,
+            rootPlotClassList: rootPlotClassList,
+            objectSelected: objectSelected
+          };
+        });
+        assert.deepStrictEqual(result.title, objectName);
+        assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+        assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
+      });
 
-  //     it('should have an info button with full path and last modified when clicked (plot success)', async () => {
-  //       await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
+      it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+        await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
 
-  //       const result = await page.evaluate(() => {
-  //         const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
-  //         const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
-  //         const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
-  //         const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
-  //         return {
-  //           title: infoButtonTitle,
-  //           fullPath: fullPath,
-  //           lastModified: lastModified,
-  //           dropdownInfoClass: dropdownInfoClass
-  //         };
-  //       });
-  //       assert.deepStrictEqual(result.title, 'View details about histogram');
-  //       assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
-  //       assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
-  //       assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
-  //     });
+        const result = await page.evaluate(() => {
+          const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+          const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+          const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+          const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
+          return {
+            title: infoButtonTitle,
+            fullPath: fullPath,
+            lastModified: lastModified,
+            dropdownInfoClass: dropdownInfoClass
+          };
+        });
+        assert.deepStrictEqual(result.title, 'View details about histogram');
+        assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
+        assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+        assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
+      });
 
-  //     describe('objectView called from layoutShow', () => {
-  //       it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
-  //         await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
-  //         const result = await page.evaluate(() => {
-  //           const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-  //           const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-  //           const backButtonTitle = document.querySelector('div div div a').title;
+      describe('objectView called from layoutShow', () => {
+        it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
+          await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+          const result = await page.evaluate(() => {
+            const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+            const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+            const backButtonTitle = document.querySelector('div div div a').title;
 
-  //           return {
-  //             location: window.location,
-  //             message: errorMessage,
-  //             iconClassList: iconClassList,
-  //             backButtonTitle: backButtonTitle
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.location.search, '?page=objectView');
-  //         assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
-  //         assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
-  //       });
+            return {
+              location: window.location,
+              message: errorMessage,
+              iconClassList: iconClassList,
+              backButtonTitle: backButtonTitle
+            };
+          });
+          assert.deepStrictEqual(result.location.search, '?page=objectView');
+          assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+          assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+          assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+        });
 
-  //       it('should load page=objectView and display error message & icon due to missing layoutId parameter', async () => {
-  //         await page.goto(url + '?page=objectView&objectId=123456', {waitUntil: 'networkidle0'});
-  //         const result = await page.evaluate(() => {
-  //           const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
-  //           const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-  //           const backButtonTitle = document.querySelector('div div div a').title;
+        it('should load page=objectView and display error message & icon due to missing layoutId parameter', async () => {
+          await page.goto(url + '?page=objectView&objectId=123456', {waitUntil: 'networkidle0'});
+          const result = await page.evaluate(() => {
+            const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+            const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+            const backButtonTitle = document.querySelector('div div div a').title;
 
-  //           return {
-  //             location: window.location,
-  //             message: errorMessage,
-  //             iconClassList: iconClassList,
-  //             backButtonTitle: backButtonTitle
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.location.search, '?page=objectView&objectId=123456');
-  //         assert.deepStrictEqual(result.message, 'No layout ID was provided');
-  //         assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
-  //       });
+            return {
+              location: window.location,
+              message: errorMessage,
+              iconClassList: iconClassList,
+              backButtonTitle: backButtonTitle
+            };
+          });
+          assert.deepStrictEqual(result.location.search, '?page=objectView&objectId=123456');
+          assert.deepStrictEqual(result.message, 'No layout ID was provided');
+          assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+          assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+        });
 
-  //       it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
-  //         await page.evaluate(() => document.querySelector('div div div a').click());
+        it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+          await page.evaluate(() => document.querySelector('div div div a').click());
 
-  //         const result = await page.evaluate(() => {
-  //           return {
-  //             location: window.location.search,
-  //             objectSelected: window.model.object.selected
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.location, '?page=objectTree');
-  //         assert.deepStrictEqual(result.objectSelected, null);
-  //       });
+          const result = await page.evaluate(() => {
+            return {
+              location: window.location.search,
+              objectSelected: window.model.object.selected
+            };
+          });
+          assert.deepStrictEqual(result.location, '?page=objectTree');
+          assert.deepStrictEqual(result.objectSelected, null);
+        });
 
-  //       it('should load a plot and update button text to "Go back to layout" if layoutId parameter is provided', async () => {
-  //         const objectId = '5aba4a059b755d517e76ef54';
-  //         const layoutId = '5aba4a059b755d517e76ea10';
-  //         await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+        it('should load a plot and update button text to "Go back to layout" if layoutId parameter is provided', async () => {
+          const objectId = '5aba4a059b755d517e76ef54';
+          const layoutId = '5aba4a059b755d517e76ea10';
+          await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
 
-  //         const result = await page.evaluate(() => {
-  //           const backButtonTitle = document.querySelector('div div div a').title;
-  //           return {
-  //             location: window.location.search,
-  //             backButtonTitle: backButtonTitle
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.location, `?page=objectView&objectId=5aba4a059b755d517e76ef54&layoutId=5aba4a059b755d517e76ea10`);
-  //         assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
-  //       });
+          const result = await page.evaluate(() => {
+            const backButtonTitle = document.querySelector('div div div a').title;
+            return {
+              location: window.location.search,
+              backButtonTitle: backButtonTitle
+            };
+          });
+          assert.deepStrictEqual(result.location, `?page=objectView&objectId=5aba4a059b755d517e76ef54&layoutId=5aba4a059b755d517e76ea10`);
+          assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
+        });
 
-  //       it('should take back the user to page=layoutShow when clicking "Go back to layout"', async () => {
-  //         const layoutId = '5aba4a059b755d517e76ea10';
-  //         await page.evaluate(() => document.querySelector('div div div a').click());
+        it('should take back the user to page=layoutShow when clicking "Go back to layout"', async () => {
+          const layoutId = '5aba4a059b755d517e76ea10';
+          await page.evaluate(() => document.querySelector('div div div a').click());
 
-  //         const result = await page.evaluate(() => {
-  //           return {
-  //             location: window.location.search,
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
-  //       });
+          const result = await page.evaluate(() => {
+            return {
+              location: window.location.search,
+            };
+          });
+          assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
+        });
 
-  //       it('should load page=objectView and display a plot when objectId and layoutId are passed', async () => {
-  //         const objectId = '5aba4a059b755d517e76ef54';
-  //         const layoutId = '5aba4a059b755d517e76ea10';
-  //         await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
-  //         const result = await page.evaluate(() => {
-  //           const title = document.querySelector('div div b').textContent;
-  //           const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
-  //           const objectSelected = window.model.object.selected;
-  //           return {
-  //             title: title,
-  //             rootPlotClassList: rootPlotClassList,
-  //             objectSelected: objectSelected
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(from layout: AliRoot)');
-  //         assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-  //         assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
-  //       });
+        it('should load page=objectView and display a plot when objectId and layoutId are passed', async () => {
+          const objectId = '5aba4a059b755d517e76ef54';
+          const layoutId = '5aba4a059b755d517e76ea10';
+          await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+          const result = await page.evaluate(() => {
+            const title = document.querySelector('div div b').textContent;
+            const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+            const objectSelected = window.model.object.selected;
+            return {
+              title: title,
+              rootPlotClassList: rootPlotClassList,
+              objectSelected: objectSelected
+            };
+          });
+          assert.deepStrictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(from layout: AliRoot)');
+          assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+          assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
+        });
 
-  //       it('should have an info button with full path and last modified when clicked (plot success)', async () => {
-  //         await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
-  //         page.await
-  //         const result = await page.evaluate(() => {
-  //           const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
-  //           const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
-  //           const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
-  //           const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
-  //           return {
-  //             title: infoButtonTitle,
-  //             fullPath: fullPath,
-  //             lastModified: lastModified,
-  //             dropdownInfoClass: dropdownInfoClass
-  //           };
-  //         });
-  //         assert.deepStrictEqual(result.title, 'View details about histogram');
-  //         assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
-  //         assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
-  //         assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
-  //       });
-  //     });
-  //   });
+        it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+          await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
+          page.await
+          const result = await page.evaluate(() => {
+            const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+            const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+            const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+            const dropdownInfoClass = document.querySelector('body > div > div > div:nth-child(3) > div > div').classList;
+            return {
+              title: infoButtonTitle,
+              fullPath: fullPath,
+              lastModified: lastModified,
+              dropdownInfoClass: dropdownInfoClass
+            };
+          });
+          assert.deepStrictEqual(result.title, 'View details about histogram');
+          assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
+          assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+          assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
+        });
+      });
+    });
 
-  //   describe('page frameworkInfo', () => {
-  //     before('reset browser to google', async () => {
-  //       // weird bug, if we don't go to external website just here, all next goto will wait forever
-  //       await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-  //     });
+    describe('page frameworkInfo', () => {
+      before('reset browser to google', async () => {
+        // weird bug, if we don't go to external website just here, all next goto will wait forever
+        await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+      });
 
-  //     it('should load', async () => {
-  //       await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
-  //       const location = await page.evaluate(() => window.location);
-  //       assert.deepStrictEqual(location.search, '?page=about');
-  //     });
+      it('should load', async () => {
+        await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
+        const location = await page.evaluate(() => window.location);
+        assert.deepStrictEqual(location.search, '?page=about');
+      });
 
-  //     it('should have a frameworkInfo item with config fields', async () => {
-  //       const expConfig = {
-  //         qcg: {port: 8181, hostname: 'localhost'},
-  //         consul: {hostname: 'localhost', port: 8500},
-  //         ccdb: {hostname: 'ccdb', port: 8500}
-  //       };
-  //       const config = await page.evaluate(() => window.model.frameworkInfo.item);
-  //       delete config.payload.qcg.version;
-  //       assert.deepStrictEqual(config.payload, expConfig);
-  //     });
-  //   });
-  // });
+      it('should have a frameworkInfo item with config fields', async () => {
+        const expConfig = {
+          qcg: {port: 8181, hostname: 'localhost'},
+          consul: {hostname: 'localhost', port: 8500},
+          ccdb: {hostname: 'ccdb', port: 8500}
+        };
+        const config = await page.evaluate(() => window.model.frameworkInfo.item);
+        delete config.payload.qcg.version;
+        assert.deepStrictEqual(config.payload, expConfig);
+      });
+    });
+  });
 
   describe('QCObject - drawing options', async () => {
     before('reset browser to google', async () => {
@@ -546,89 +546,93 @@ describe('QCG', function() {
       assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
     });
 
-    // it('should merge options on layoutShow and no ignoreDefaults field', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     const tabObject = {options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should merge options on layoutShow and no ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        const tabObject = {options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-    // it('should merge options on layoutShow and false ignoreDefaults field', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should merge options on layoutShow and false ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-    // it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['args', 'coly'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['args', 'coly'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-    // it('should use only default options on objectTree', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     window.model.page = 'objectTree';
-    //     const tabObject = {options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should use only default options on objectTree', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectTree';
+        const tabObject = {options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-    // it('should use only default options on objectView when no layoutId or objectId ar set', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     window.model.page = 'objectView';
-    //     const tabObject = {options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should use only default options on objectView when no layoutId or objectId is set', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.objectId = undefined;
+        window.model.router.params.layoutId = undefined;
+        const tabObject = {options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
-    // it('should use only default options on objectView when no layoutId is set', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     window.model.page = 'objectView';
-    //     window.model.router.params.objectId = '123';
-    //     const tabObject = {options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should use only default options on objectView when no layoutId is set', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.layoutId = undefined;
+        window.model.router.params.objectId = '123';
+        const tabObject = {options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
 
-    // it('should use only default options on objectView when no objectId is set', async () => {
-    //   const drawingOptions = await page.evaluate(() => {
-    //     window.model.page = 'objectView';
-    //     window.model.router.params.layoutId = '123';
-    //     const tabObject = {options: ['args', 'coly']};
-    //     const objectRemoteData = {payload: {fOption: 'lego colz'}};
-    //     return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-    //   });
+    it('should use only default options on objectView when no objectId is set', async () => {
+      const drawingOptions = await page.evaluate(() => {
+        window.model.page = 'objectView';
+        window.model.router.params.objectId = undefined;
+        window.model.router.params.layoutId = '123';
+        const tabObject = {options: ['args', 'coly']};
+        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+      });
 
-    //   const expDrawingOpts = ['lego', 'colz'];
-    //   assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    // });
+      const expDrawingOpts = ['lego', 'colz'];
+      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+    });
 
     it('should merge options on objectView and no ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -34,7 +34,7 @@ describe('QCG', function() {
 
     this.ok = true;
     // Start browser to test UI
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: true});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: false});
     page = await browser.newPage();
 
     // Listen to browser
@@ -82,414 +82,518 @@ describe('QCG', function() {
     assert(sidebarContent.includes('Explore'));
   });
 
-  describe('page layoutList', () => {
-    before(async () => {
-      await page.goto(url + '?page=layoutList', {waitUntil: 'networkidle0'});
-      const location = await page.evaluate(() => window.location);
-      assert(location.search === '?page=layoutList');
-    });
+  // describe('page layoutList', () => {
+  //   before(async () => {
+  //     await page.goto(url + '?page=layoutList', {waitUntil: 'networkidle0'});
+  //     const location = await page.evaluate(() => window.location);
+  //     assert(location.search === '?page=layoutList');
+  //   });
 
-    it('should have a button for the Online mode in the header', async () => {
-      await page.waitForSelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)', {timeout: 5000});
-      const onlineButton = await page.evaluate(() =>
-        document.querySelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)').title);
-      assert.deepStrictEqual(onlineButton, 'Online');
-    });
+  //   it('should have a button for the Online mode in the header', async () => {
+  //     await page.waitForSelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)', {timeout: 5000});
+  //     const onlineButton = await page.evaluate(() =>
+  //       document.querySelector('header > div:nth-child(1) > div:nth-child(1) > button:nth-child(3)').title);
+  //     assert.deepStrictEqual(onlineButton, 'Online');
+  //   });
 
-    it('should have a table with rows', async () => {
-      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-      assert(rowsCount > 1);
-    });
+  //   it('should have a table with rows', async () => {
+  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+  //     assert(rowsCount > 1);
+  //   });
 
-    it('should have a table with one row after filtering', async () => {
-      await page.type('header input', 'AliRoot');
-      await page.waitFor(200);
-      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-      assert(rowsCount === 1);
-    });
+  //   it('should have a table with one row after filtering', async () => {
+  //     await page.type('header input', 'AliRoot');
+  //     await page.waitFor(200);
+  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+  //     assert(rowsCount === 1);
+  //   });
 
-    it('should have a link to show a layout', async () => {
-      await page.evaluate(() => document.querySelector('section table tbody tr a').click());
-      const location = await page.evaluate(() => window.location);
-      assert.strictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-      // id 5aba4a059b755d517e76ea10 is set in QCModelDemo
-    });
-  });
+  //   it('should have a link to show a layout', async () => {
+  //     await page.evaluate(() => document.querySelector('section table tbody tr a').click());
+  //     const location = await page.evaluate(() => window.location);
+  //     assert.strictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+  //     // id 5aba4a059b755d517e76ea10 is set in QCModelDemo
+  //   });
+  // });
 
-  describe('page layoutShow', () => {
-    before('reset browser to google', async () => {
-      // weird bug, if we don't go to external website just here, all next goto will wait forever
-      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-    });
+  // describe('page layoutShow', () => {
+  //   before('reset browser to google', async () => {
+  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
+  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+  //   });
 
-    it('should load', async () => {
-      // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
-      await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
-      const location = await page.evaluate(() => window.location);
-      assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-    });
+  //   it('should load', async () => {
+  //     // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
+  //     await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
+  //     const location = await page.evaluate(() => window.location);
+  //     assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+  //   });
 
-    it('should have tabs in the header', async () => {
-      const tabsCount = await page.evaluate(() => document.querySelectorAll('header .btn-tab').length);
-      assert(tabsCount > 1);
-    });
+  //   it('should have tabs in the header', async () => {
+  //     const tabsCount = await page.evaluate(() => document.querySelectorAll('header .btn-tab').length);
+  //     assert(tabsCount > 1);
+  //   });
 
-    it('should have selected layout in the sidebar highlighted', async () => {
-      const layoutClassList = await page.evaluate(() => document.querySelector('nav div a:nth-child(5)').classList);
-      assert.deepStrictEqual(layoutClassList, {0: 'menu-item', 1: 'w-wrapped', 2: 'selected'});
-    });
+  //   it('should have selected layout in the sidebar highlighted', async () => {
+  //     const layoutClassList = await page.evaluate(() => document.querySelector('nav div a:nth-child(5)').classList);
+  //     assert.deepStrictEqual(layoutClassList, {0: 'menu-item', 1: 'w-wrapped', 2: 'selected'});
+  //   });
 
-    it('should have jsroot svg plots in the section', async () => {
-      const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
-      assert(plotsCount > 1);
-    });
+  //   it('should have jsroot svg plots in the section', async () => {
+  //     const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
+  //     assert(plotsCount > 1);
+  //   });
 
-    it('should have second tab to be empty (according to demo data)', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(2) > div > button:nth-child(2)').click());
-      await page.waitForSelector('section h1', {timeout: 5000});
-      const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
-      assert.deepStrictEqual(plotsCount, 0);
-    });
+  //   it('should have second tab to be empty (according to demo data)', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(2) > div > button:nth-child(2)').click());
+  //     await page.waitForSelector('section h1', {timeout: 5000});
+  //     const plotsCount = await page.evaluate(() => document.querySelectorAll('section svg.jsroot').length);
+  //     assert.deepStrictEqual(plotsCount, 0);
+  //   });
 
-    it('should have a button group containing three buttons in the header', async () => {
-      const buttonCount = await page.evaluate(() =>
-        document.querySelectorAll('header > div > div:nth-child(3) > div.btn-group > button').length);
-      assert.deepStrictEqual(buttonCount, 3);
-    });
+  //   it('should have a button group containing three buttons in the header', async () => {
+  //     const buttonCount = await page.evaluate(() =>
+  //       document.querySelectorAll('header > div > div:nth-child(3) > div.btn-group > button').length);
+  //     assert.deepStrictEqual(buttonCount, 3);
+  //   });
 
-    it('should have one duplicate button in the header to create a new duplicated layout', async () => {
-      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
-      const duplicateButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)').title);
-      assert.deepStrictEqual(duplicateButton, 'Duplicate layout');
-    });
+  //   it('should have one duplicate button in the header to create a new duplicated layout', async () => {
+  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
+  //     const duplicateButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)').title);
+  //     assert.deepStrictEqual(duplicateButton, 'Duplicate layout');
+  //   });
 
-    it('should have one delete button in the header to delete layout', async () => {
-      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)', {timeout: 5000});
-      const deleteButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)').title);
-      assert.deepStrictEqual(deleteButton, 'Delete layout');
-    });
+  //   it('should have one delete button in the header to delete layout', async () => {
+  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)', {timeout: 5000});
+  //     const deleteButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(3)').title);
+  //     assert.deepStrictEqual(deleteButton, 'Delete layout');
+  //   });
 
-    it('should have one edit button in the header to go in edit mode', async () => {
-      await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
-      const editButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(2)').title);
-      assert.deepStrictEqual(editButton, 'Edit layout');
-    });
+  //   it('should have one edit button in the header to go in edit mode', async () => {
+  //     await page.waitForSelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(1)', {timeout: 5000});
+  //     const editButton = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div.btn-group > button:nth-child(2)').title);
+  //     assert.deepStrictEqual(editButton, 'Edit layout');
+  //   });
 
-    // Begin: Edit Mode;
-    it('should click the edit button in the header and enter edit mode', async () => {
-      await page.waitForSelector('header > div > div:nth-child(3) > div > button:nth-child(1)', {timeout: 5000});
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
-    });
+  //   // Begin: Edit Mode;
+  //   it('should click the edit button in the header and enter edit mode', async () => {
+  //     await page.waitForSelector('header > div > div:nth-child(3) > div > button:nth-child(1)', {timeout: 5000});
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
+  //   });
 
-    it('should have input field for changing layout name in edit mode', async () => {
-      await page.waitForSelector('header > div > div:nth-child(3) > input', {timeout: 5000});
-      const count = await page.evaluate(() => document.querySelectorAll('header > div > div:nth-child(3) > input').length);
-      assert.deepStrictEqual(count, 1);
-    });
+  //   it('should have input field for changing layout name in edit mode', async () => {
+  //     await page.waitForSelector('header > div > div:nth-child(3) > input', {timeout: 5000});
+  //     const count = await page.evaluate(() => document.querySelectorAll('header > div > div:nth-child(3) > input').length);
+  //     assert.deepStrictEqual(count, 1);
+  //   });
 
-    it('should have a tree sidebar in edit mode', async () => {
-      await page.waitForSelector('nav table tbody tr'); // loading., {timeout: 5000}..
-      const rowsCount = await page.evaluate(() => document.querySelectorAll('nav table tbody tr').length);
-      assert.deepStrictEqual(rowsCount, 4); // 4 agents
-    });
+  //   it('should have a tree sidebar in edit mode', async () => {
+  //     await page.waitForSelector('nav table tbody tr'); // loading., {timeout: 5000}..
+  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('nav table tbody tr').length);
+  //     assert.deepStrictEqual(rowsCount, 4); // 4 agents
+  //   });
 
-    it('should have filtered results on input search filled', async () => {
-      await page.type('nav input', 'HistoWithRandom');
-      await page.waitForFunction(`document.querySelectorAll('nav table tbody tr').length === 1`, {timeout: 5000});
-    });
+  //   it('should have filtered results on input search filled', async () => {
+  //     await page.type('nav input', 'HistoWithRandom');
+  //     await page.waitForFunction(`document.querySelectorAll('nav table tbody tr').length === 1`, {timeout: 5000});
+  //   });
 
-    it('should show normal sidebar after Cancel click', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
-      await page.waitForSelector('nav .menu-title', {timeout: 5000});
-    });
-  });
+  //   it('should show normal sidebar after Cancel click', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button:nth-child(2)').click());
+  //     await page.waitForSelector('nav .menu-title', {timeout: 5000});
+  //   });
+  // });
 
-  describe('page objectTree', () => {
-    before('reset browser to google', async () => {
-      // weird bug, if we don't go to external website just here, all next goto will wait forever
-      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-    });
+  // describe('page objectTree', () => {
+  //   before('reset browser to google', async () => {
+  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
+  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+  //   });
 
-    it('should load', async () => {
-      await page.goto(url + '?page=objectTree', {waitUntil: 'networkidle0'});
-      const location = await page.evaluate(() => window.location);
-      assert(location.search === '?page=objectTree');
-    });
+  //   it('should load', async () => {
+  //     await page.goto(url + '?page=objectTree', {waitUntil: 'networkidle0'});
+  //     const location = await page.evaluate(() => window.location);
+  //     assert(location.search === '?page=objectTree');
+  //   });
 
-    it('should have a tree as a table', async () => {
-      await page.waitForSelector('section table tbody tr', {timeout: 5000});
-      const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
-      assert.deepStrictEqual(rowsCount, 4); // 4 agents
-    });
+  //   it('should have a tree as a table', async () => {
+  //     await page.waitForSelector('section table tbody tr', {timeout: 5000});
+  //     const rowsCount = await page.evaluate(() => document.querySelectorAll('section table tbody tr').length);
+  //     assert.deepStrictEqual(rowsCount, 4); // 4 agents
+  //   });
 
-    it('should have a button to sort by (default "Name" ASC)', async () => {
-      const sortByButtonTitle = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div').title);
-      assert.strictEqual(sortByButtonTitle, 'Sort by');
-    });
+  //   it('should have a button to sort by (default "Name" ASC)', async () => {
+  //     const sortByButtonTitle = await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div').title);
+  //     assert.strictEqual(sortByButtonTitle, 'Sort by');
+  //   });
 
-    it('should have first element in tree as "DAQ01/EquipmentSize/ACORDE/ACORDE"', async () => {
-      const firstElement = await page.evaluate(() => window.model.object.currentList[0]);
-      assert.strictEqual(firstElement.name, 'DAQ01/EquipmentSize/ACORDE/ACORDE');
-    });
+  //   it('should have first element in tree as "DAQ01/EquipmentSize/ACORDE/ACORDE"', async () => {
+  //     const firstElement = await page.evaluate(() => window.model.object.currentList[0]);
+  //     assert.strictEqual(firstElement.name, 'DAQ01/EquipmentSize/ACORDE/ACORDE');
+  //   });
 
-    it('should sort list of histograms by name in descending order', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(4)').click());
-      const sorted = await page.evaluate(() => {
-        return {
-          list: window.model.object.currentList,
-          sort: window.model.object.sortBy
-        };
-      });
-      assert.strictEqual(sorted.sort.title, 'Name');
-      assert.strictEqual(sorted.sort.order, -1);
-      assert.strictEqual(sorted.sort.field, 'name');
-      assert.strictEqual(sorted.list[0].name, 'TST01/Default/hTOFRRawTimeVsTRM3671');
-    });
+  //   it('should sort list of histograms by name in descending order', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(4)').click());
+  //     const sorted = await page.evaluate(() => {
+  //       return {
+  //         list: window.model.object.currentList,
+  //         sort: window.model.object.sortBy
+  //       };
+  //     });
+  //     assert.strictEqual(sorted.sort.title, 'Name');
+  //     assert.strictEqual(sorted.sort.order, -1);
+  //     assert.strictEqual(sorted.sort.field, 'name');
+  //     assert.strictEqual(sorted.list[0].name, 'TST01/Default/hTOFRRawTimeVsTRM3671');
+  //   });
 
-    it('should sort list of histograms by name in ascending order', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(3)').click());
-      const sorted = await page.evaluate(() => {
-        return {
-          list: window.model.object.currentList,
-          sort: window.model.object.sortBy
-        };
-      });
-      assert.strictEqual(sorted.sort.title, 'Name');
-      assert.strictEqual(sorted.sort.order, 1);
-      assert.strictEqual(sorted.sort.field, 'name');
-      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
-    });
+  //   it('should sort list of histograms by name in ascending order', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(3)').click());
+  //     const sorted = await page.evaluate(() => {
+  //       return {
+  //         list: window.model.object.currentList,
+  //         sort: window.model.object.sortBy
+  //       };
+  //     });
+  //     assert.strictEqual(sorted.sort.title, 'Name');
+  //     assert.strictEqual(sorted.sort.order, 1);
+  //     assert.strictEqual(sorted.sort.field, 'name');
+  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
+  //   });
 
-    it('should sort list of histograms by created time in descending order', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(2)').click());
-      const sorted = await page.evaluate(() => {
-        return {
-          list: window.model.object.currentList,
-          sort: window.model.object.sortBy
-        };
-      });
-      assert.strictEqual(sorted.sort.title, 'Created Time');
-      assert.strictEqual(sorted.sort.order, -1);
-      assert.strictEqual(sorted.sort.field, 'createTime');
-      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/2499');
-    });
+  //   it('should sort list of histograms by created time in descending order', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(2)').click());
+  //     const sorted = await page.evaluate(() => {
+  //       return {
+  //         list: window.model.object.currentList,
+  //         sort: window.model.object.sortBy
+  //       };
+  //     });
+  //     assert.strictEqual(sorted.sort.title, 'Created Time');
+  //     assert.strictEqual(sorted.sort.order, -1);
+  //     assert.strictEqual(sorted.sort.field, 'createTime');
+  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/2499');
+  //   });
 
-    it('should sort list of histograms by created time in ascending order', async () => {
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
-      await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(1)').click());
-      const sorted = await page.evaluate(() => {
-        return {
-          list: window.model.object.currentList,
-          sort: window.model.object.sortBy
-        };
-      });
-      assert.strictEqual(sorted.sort.title, 'Created Time');
-      assert.strictEqual(sorted.sort.order, 1);
-      assert.strictEqual(sorted.sort.field, 'createTime');
-      assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
-    });
+  //   it('should sort list of histograms by created time in ascending order', async () => {
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > button').click());
+  //     await page.evaluate(() => document.querySelector('header > div > div:nth-child(3) > div > div > a:nth-child(1)').click());
+  //     const sorted = await page.evaluate(() => {
+  //       return {
+  //         list: window.model.object.currentList,
+  //         sort: window.model.object.sortBy
+  //       };
+  //     });
+  //     assert.strictEqual(sorted.sort.title, 'Created Time');
+  //     assert.strictEqual(sorted.sort.order, 1);
+  //     assert.strictEqual(sorted.sort.field, 'createTime');
+  //     assert.strictEqual(sorted.list[0].name, 'BIGTREE/120KB/0');
+  //   });
 
-    it('should have filtered results on input search filled', async () => {
-      await page.type('header input', 'BIGTREE');
-      await page.waitForFunction(`document.querySelectorAll('section table tbody tr').length === 2500`, {timeout: 5000});
-    });
-  });
+  //   it('should have filtered results on input search filled', async () => {
+  //     await page.type('header input', 'BIGTREE');
+  //     await page.waitForFunction(`document.querySelectorAll('section table tbody tr').length === 2500`, {timeout: 5000});
+  //   });
+  // });
 
   describe('page objectView', () => {
-    it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
-      await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
-      const result = await page.evaluate(() => {
-        const errorMessage = document.querySelector('div div b').textContent;
-        const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
-        const backButtonTitle = document.querySelector('div div div a').title;
+    describe('objectView called from objectTree', () => {
+      // it('should load page=objectView and display error message & icon due to missing objectName parameter', async () => {
+      //   await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+      //   const result = await page.evaluate(() => {
+      //     const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+      //     const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+      //     const backButtonTitle = document.querySelector('div div div a').title;
 
-        return {
-          location: window.location,
-          message: errorMessage,
-          iconClassList: iconClassList,
-          backButtonTitle: backButtonTitle
-        };
-      });
-      assert.deepStrictEqual(result.location.search, '?page=objectView');
-      assert.deepStrictEqual(result.message, 'Please pass an objectName parameter');
-      assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
-      assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+      //     return {
+      //       location: window.location,
+      //       message: errorMessage,
+      //       iconClassList: iconClassList,
+      //       backButtonTitle: backButtonTitle
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.location.search, '?page=objectView');
+      //   assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+      //   assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+      //   assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
+      // });
+
+      // it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+      //   await page.evaluate(() => document.querySelector('div div div a').click());
+
+      //   const result = await page.evaluate(() => {
+      //     return {
+      //       location: window.location.search,
+      //       objectSelected: window.model.object.selected
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.location, '?page=objectTree');
+      //   assert.deepStrictEqual(result.objectSelected, null);
+      // });
+
+      // it('should load page=objectView and display an error message when a parameter objectName is passed but object not found', async () => {
+      //   const objectName = 'NOT_FOUND_OBJECT';
+      //   await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+      //   const result = await page.evaluate(() => {
+      //     const title = document.querySelector('body > div > div:nth-child(2) > div > div > span').textContent;
+      //     return {
+      //       title: title,
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.title, 'Object NOT_FOUND_OBJECT could not be loaded');
+      // });
+
+      // it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
+      //   const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
+      //   await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
+      //   const result = await page.evaluate(() => {
+      //     const title = document.querySelector('div div b').textContent;
+      //     const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+      //     const objectSelected = window.model.object.selected;
+      //     return {
+      //       title: title,
+      //       rootPlotClassList: rootPlotClassList,
+      //       objectSelected: objectSelected
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.title, objectName);
+      //   assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+      //   assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
+      // });
+
+      // it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+      //   const result = await page.evaluate(() => {
+      //     const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+      //     const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+      //     const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+      //     return {
+      //       title: infoButtonTitle,
+      //       fullPath: fullPath,
+      //       lastModified: lastModified
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.title, 'View details about histogram');
+      //   assert.deepStrictEqual(result.fullPath, 'PATHDAQ01/EquipmentSize/CPV/CPV');
+      //   assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED' + new Date(100).toLocaleString());
+      // });
     });
 
-    it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
-      await page.evaluate(() => document.querySelector('div div div a').click());
+    describe('objectView called from layoutShow', () => {
+      it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
+        await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+          const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+          const backButtonTitle = document.querySelector('div div div a').title;
 
-      const result = await page.evaluate(() => {
-        return {
-          location: window.location.search,
-          objectSelected: window.model.object.selected
-        };
+          return {
+            location: window.location,
+            message: errorMessage,
+            iconClassList: iconClassList,
+            backButtonTitle: backButtonTitle
+          };
+        });
+        assert.deepStrictEqual(result.location.search, '?page=objectView');
+        assert.deepStrictEqual(result.message, 'No object name or object ID were provided');
+        assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+        assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
       });
-      assert.deepStrictEqual(result.location, '?page=objectTree');
-      assert.deepStrictEqual(result.objectSelected, null);
-    });
 
-    it('should load page=objectView and display a plot when a parameter objectName is passed', async () => {
-      const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-      await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
-      const result = await page.evaluate(() => {
-        const title = document.querySelector('div div b').textContent;
-        const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
-        const objectSelected = window.model.object.selected;
-        return {
-          title: title,
-          rootPlotClassList: rootPlotClassList,
-          objectSelected: objectSelected
-        };
+      it('should load page=objectView and display error message & icon due to missing layoutId parameter', async () => {
+        await page.goto(url + '?page=objectView&objectId=123456', {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
+          const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
+          const backButtonTitle = document.querySelector('div div div a').title;
+
+          return {
+            location: window.location,
+            message: errorMessage,
+            iconClassList: iconClassList,
+            backButtonTitle: backButtonTitle
+          };
+        });
+        assert.deepStrictEqual(result.location.search, '?page=objectView&objectId=123456');
+        assert.deepStrictEqual(result.message, 'No layout ID was provided');
+        assert.deepStrictEqual(result.iconClassList, {0: 'icon', 1: 'fill-primary'});
+        assert.deepStrictEqual(result.backButtonTitle, 'Go back to all objects');
       });
-      assert.deepStrictEqual(result.title, objectName);
-      assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-      assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
-    });
 
-    it('should take back the user to page=objectTree when clicking "Back To QCG" (object passed and selected)', async () => {
-      const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-      await page.evaluate(() => document.querySelector('div div div a').click());
+      it('should take back the user to page=objectTree when clicking "Back To QCG" (no object passed or selected)', async () => {
+        await page.evaluate(() => document.querySelector('div div div a').click());
 
-      const result = await page.evaluate(() => {
-        return {
-          location: window.location.search,
-          objectSelected: window.model.object.selected
-        };
+        const result = await page.evaluate(() => {
+          return {
+            location: window.location.search,
+            objectSelected: window.model.object.selected
+          };
+        });
+        assert.deepStrictEqual(result.location, '?page=objectTree');
+        assert.deepStrictEqual(result.objectSelected, null);
       });
-      assert.deepStrictEqual(result.location, '?page=objectTree');
-      assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
-    });
 
-    it('should update button text to "Go back to layout" if layoutId parameter is provided', async () => {
-      const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-      const layoutId = '5aba4a059b755d517e76ea10';
-      await page.goto(url + `?page=objectView&objectName=${objectName}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+      it('should load a plot and update button text to "Go back to layout" if layoutId parameter is provided', async () => {
+        const objectId = '5aba4a059b755d517e76ef54';
+        const layoutId = '5aba4a059b755d517e76ea10';
+        await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
 
-      const result = await page.evaluate(() => {
-        const backButtonTitle = document.querySelector('div div div a').title;
-        return {
-          location: window.location.search,
-          backButtonTitle: backButtonTitle
-        };
+        const result = await page.evaluate(() => {
+          const backButtonTitle = document.querySelector('div div div a').title;
+          return {
+            location: window.location.search,
+            backButtonTitle: backButtonTitle
+          };
+        });
+        assert.deepStrictEqual(result.location, `?page=objectView&objectId=5aba4a059b755d517e76ef54&layoutId=5aba4a059b755d517e76ea10`);
+        assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
       });
-      assert.deepStrictEqual(result.location, `?page=objectView&objectName=DAQ01%2FEquipmentSize%2FCPV%2FCPV&layoutId=5aba4a059b755d517e76ea10`);
-      assert.deepStrictEqual(result.backButtonTitle, 'Go back to layout');
-    });
 
-    it('should take back the user to page=layoutShow when clicking "Go back to layout" (object passed and selected)', async () => {
-      await page.evaluate(() => document.querySelector('div div div a').click());
-      const objectName = 'DAQ01/EquipmentSize/CPV/CPV';
-      const layoutId = '5aba4a059b755d517e76ea10';
-      const result = await page.evaluate(() => {
-        return {
-          location: window.location.search,
-          objectSelected: window.model.object.selected
-        };
+      it('should take back the user to page=layoutShow when clicking "Go back to layout"', async () => {
+        const layoutId = '5aba4a059b755d517e76ea10';
+        await page.evaluate(() => document.querySelector('div div div a').click());
+
+        const result = await page.evaluate(() => {
+          return {
+            location: window.location.search,
+          };
+        });
+        assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
       });
-      assert.deepStrictEqual(result.location, `?page=layoutShow&layoutId=${layoutId}`);
-      assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
+
+      it('should load page=objectView and display a plot when objectId and layoutId are passed', async () => {
+        const objectId = '5aba4a059b755d517e76ef54';
+        const layoutId = '5aba4a059b755d517e76ea10';
+        await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+        const result = await page.evaluate(() => {
+          const title = document.querySelector('div div b').textContent;
+          const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;
+          const objectSelected = window.model.object.selected;
+          return {
+            title: title,
+            rootPlotClassList: rootPlotClassList,
+            objectSelected: objectSelected
+          };
+        });
+        assert.deepStrictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(from layout: AliRoot)');
+        assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
+        assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
+      });
+
+      // it('should have an info button with full path and last modified when clicked (plot success)', async () => {
+      //   const result = await page.evaluate(() => {
+      //     const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
+      //     const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
+      //     const lastModified = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div:nth-child(2)').innerText;
+      //     return {
+      //       title: infoButtonTitle,
+      //       fullPath: fullPath,
+      //       lastModified: lastModified
+      //     };
+      //   });
+      //   assert.deepStrictEqual(result.title, 'View details about histogram');
+      //   assert.deepStrictEqual(result.fullPath, 'PATHDAQ01/EquipmentSize/CPV/CPV');
+      //   assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED' + new Date(100).toLocaleString());
+      // });
     });
   });
 
-  describe('page frameworkInfo', () => {
-    before('reset browser to google', async () => {
-      // weird bug, if we don't go to external website just here, all next goto will wait forever
-      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-    });
+  // describe('page frameworkInfo', () => {
+  //   before('reset browser to google', async () => {
+  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
+  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+  //   });
 
-    it('should load', async () => {
-      await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
-      const location = await page.evaluate(() => window.location);
-      assert.deepStrictEqual(location.search, '?page=about');
-    });
+  //   it('should load', async () => {
+  //     await page.goto(url + '?page=about', {waitUntil: 'networkidle0'});
+  //     const location = await page.evaluate(() => window.location);
+  //     assert.deepStrictEqual(location.search, '?page=about');
+  //   });
 
-    it('should have a frameworkInfo item with config fields', async () => {
-      const expConfig = {
-        qcg: {port: 8181, hostname: 'localhost'},
-        consul: {hostname: 'localhost', port: 8500},
-        ccdb: {hostname: 'ccdb', port: 8500}
-      };
-      const config = await page.evaluate(() => window.model.frameworkInfo.item);
-      delete config.payload.qcg.version;
-      assert.deepStrictEqual(config.payload, expConfig);
-    });
-  });
+  //   it('should have a frameworkInfo item with config fields', async () => {
+  //     const expConfig = {
+  //       qcg: {port: 8181, hostname: 'localhost'},
+  //       consul: {hostname: 'localhost', port: 8500},
+  //       ccdb: {hostname: 'ccdb', port: 8500}
+  //     };
+  //     const config = await page.evaluate(() => window.model.frameworkInfo.item);
+  //     delete config.payload.qcg.version;
+  //     assert.deepStrictEqual(config.payload, expConfig);
+  //   });
+  // });
 
 
-  describe('QCObject - drawing options', async () => {
-    before('reset browser to google', async () => {
-      // weird bug, if we don't go to external website just here, all next goto will wait forever
-      await page.goto('http://google.com', {waitUntil: 'networkidle0'});
-    });
+  // describe('QCObject - drawing options', async () => {
+  //   before('reset browser to google', async () => {
+  //     // weird bug, if we don't go to external website just here, all next goto will wait forever
+  //     await page.goto('http://google.com', {waitUntil: 'networkidle0'});
+  //   });
 
-    it('should load', async () => {
-      // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
-      await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
-      const location = await page.evaluate(() => window.location);
-      assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
-    });
+  //   it('should load', async () => {
+  //     // id 5aba4a059b755d517e76ea12 is set in QCModelDemo
+  //     await page.goto(url + '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot', {waitUntil: 'networkidle0'});
+  //     const location = await page.evaluate(() => window.location);
+  //     assert.deepStrictEqual(location.search, '?page=layoutShow&layoutId=5aba4a059b755d517e76ea10&layoutName=AliRoot');
+  //   });
 
-    it('should merge options on layoutShow and no ignoreDefaults field', async () => {
-      const drawingOptions = await page.evaluate(() => {
-        const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
-        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-      });
+  //   it('should merge options on layoutShow and no ignoreDefaults field', async () => {
+  //     const drawingOptions = await page.evaluate(() => {
+  //       const tabObject = {options: ['args', 'coly']};
+  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
+  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+  //     });
 
-      const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    });
+  //     const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+  //   });
 
-    it('should merge options on layoutShow and false ignoreDefaults field', async () => {
-      const drawingOptions = await page.evaluate(() => {
-        const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
-        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-      });
+  //   it('should merge options on layoutShow and false ignoreDefaults field', async () => {
+  //     const drawingOptions = await page.evaluate(() => {
+  //       const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
+  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
+  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+  //     });
 
-      const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    });
+  //     const expDrawingOpts = ['lego', 'colz', 'args', 'coly'];
+  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+  //   });
 
-    it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
-      const drawingOptions = await page.evaluate(() => {
-        const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
-        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-      });
+  //   it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
+  //     const drawingOptions = await page.evaluate(() => {
+  //       const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
+  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
+  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+  //     });
 
-      const expDrawingOpts = ['args', 'coly'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    });
+  //     const expDrawingOpts = ['args', 'coly'];
+  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+  //   });
 
-    it('should use only default options on objectTree', async () => {
-      const drawingOptions = await page.evaluate(() => {
-        window.model.page = 'objectTree';
-        const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
-        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-      });
+  //   it('should use only default options on objectTree', async () => {
+  //     const drawingOptions = await page.evaluate(() => {
+  //       window.model.page = 'objectTree';
+  //       const tabObject = {options: ['args', 'coly']};
+  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
+  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+  //     });
 
-      const expDrawingOpts = ['lego', 'colz'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    });
+  //     const expDrawingOpts = ['lego', 'colz'];
+  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+  //   });
 
-    it('should use only default options on objectView', async () => {
-      const drawingOptions = await page.evaluate(() => {
-        window.model.page = 'objectView';
-        const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
-        return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
-      });
+  //   it('should use only default options on objectView', async () => {
+  //     const drawingOptions = await page.evaluate(() => {
+  //       window.model.page = 'objectView';
+  //       const tabObject = {options: ['args', 'coly']};
+  //       const objectRemoteData = {payload: {fOption: 'lego colz'}};
+  //       return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
+  //     });
 
-      const expDrawingOpts = ['lego', 'colz'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
-    });
-  });
+  //     const expDrawingOpts = ['lego', 'colz'];
+  //     assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+  //   });
+  // });
 
   beforeEach(() => {
     this.ok = true;

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -379,8 +379,10 @@ describe('QCG', function() {
           };
         });
         assert.deepStrictEqual(result.title, 'View details about histogram');
-        assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
-        assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+        assert.deepStrictEqual(result.fullPath.includes('PATH'), true);
+        assert.deepStrictEqual(result.fullPath.includes('DAQ01/EquipmentSize/CPV/CPV'), true);
+        assert.deepStrictEqual(result.lastModified.includes('LAST MODIFIED'), true);
+        assert.deepStrictEqual(result.lastModified.includes(new Date(100).toLocaleString('EN')), true);
         assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
       });
 
@@ -487,7 +489,6 @@ describe('QCG', function() {
 
         it('should have an info button with full path and last modified when clicked (plot success)', async () => {
           await page.evaluate(() => document.querySelector('body > div > div > div:nth-child(3) > div > div > button').click());
-          page.await
           const result = await page.evaluate(() => {
             const infoButtonTitle = document.querySelector('body > div > div > div:nth-child(3) > div > div > button').title;
             const fullPath = document.querySelector('body > div > div > div:nth-child(3) > div > div > div > div').innerText;
@@ -501,8 +502,10 @@ describe('QCG', function() {
             };
           });
           assert.deepStrictEqual(result.title, 'View details about histogram');
-          assert.deepStrictEqual(result.fullPath, 'PATH\nDAQ01/EquipmentSize/CPV/CPV');
-          assert.deepStrictEqual(result.lastModified, 'LAST MODIFIED\n' + new Date(100).toLocaleString('EN'));
+          assert.deepStrictEqual(result.fullPath.includes('PATH'), true);
+          assert.deepStrictEqual(result.fullPath.includes('DAQ01/EquipmentSize/CPV/CPV'), true);
+          assert.deepStrictEqual(result.lastModified.includes('LAST MODIFIED'), true);
+          assert.deepStrictEqual(result.lastModified.includes(new Date(100).toLocaleString('EN')), true);
           assert.deepStrictEqual(result.dropdownInfoClass, {0: 'dropdown', 1: 'dropdown-open'});
         });
       });


### PR DESCRIPTION
objecView page should:
* display an object with default options (set in C++) if it was called from objectTree page; (URL is based on objectName)

For below scenarios URL will be based on layoutId and objectId; If one of them is missing an error icon will be displayed;
* display an object with both default and layout options merged if it is called from layoutShow page
* display an object with only the layout options if it is called from layoutShow page and the user selected "Ignore defaults" for that object in layoutEdit mode

e.g of objects that can be used to test: objectName=qc/testOptions/colz_arr