### PR TITLE
[OGUI-466] Throw error if unable to query

### DIFF
--- a/InfoLogger/lib/SQLDataSource.js
+++ b/InfoLogger/lib/SQLDataSource.js
@@ -133,7 +133,11 @@ module.exports = class SQLDataSource {
     const {criteria, values, criteriaVerbose} = this._filtersToSqlConditions(filters);
     const criteriaString = this._getCriteriaAsString(criteria);
 
-    const rows = await this._queryMessagesOnOptions(criteriaString, options, values);
+    const rows = await this._queryMessagesOnOptions(criteriaString, options, values)
+      .catch((error) => {
+        log.error(error);
+        throw error;
+      });
 
     const resultCount = await this._countMessagesOnOptions(criteriaString, values);
 
@@ -192,11 +196,7 @@ module.exports = class SQLDataSource {
     /* eslint-enable max-len */
     log.debug(`requestRows: ${requestRows} ${JSON.stringify(values)}`);
     return this.connection.query(requestRows, values)
-      .then((data) => data)
-      .catch((error) => {
-        log.error(error);
-        return [];
-      });
+      .then((data) => data);
   }
 
   /**

--- a/InfoLogger/test/lib/mocha-sqldatasource.js
+++ b/InfoLogger/test/lib/mocha-sqldatasource.js
@@ -153,11 +153,20 @@ describe('SQLDataSource', () => {
     assert.deepStrictEqual(queryResult, [{severity: 'W'}, {severity: 'I'}]);
   });
 
-  it('should successfully return empty data when querying mysql driver results in rejected promise', async () => {
+  it('should throw an error when unable to query within private method due to rejected promise', async () => {
     const stub = sinon.createStubInstance(MySQL, {query: sinon.stub().rejects()});
     const sqlDataSource = new SQLDataSource(stub, config.mysql);
-    const queryResult = await sqlDataSource._queryMessagesOnOptions('criteriaString', []);
-    assert.deepStrictEqual(queryResult, []);
+    return assert.rejects(async () => {
+      await sqlDataSource._queryMessagesOnOptions('criteriaString', []);
+    }, new Error('Error'));
+  });
+
+  it('should throw an error when unable to query(API) due to rejected promise', async () => {
+    const stub = sinon.createStubInstance(MySQL, {query: sinon.stub().rejects()});
+    const sqlDataSource = new SQLDataSource(stub, config.mysql);
+    return assert.rejects(async () => {
+      await sqlDataSource.queryFromFilters(realFilters, {limit: 10});
+    }, new Error('Error'));
   });
 
   it('should throw an error if no filters are provided for querying', async () => {


### PR DESCRIPTION
If SQLDataSource is unable to query, rather than returning empty (which might confuse the user thinking there are no logs for their criteria/filters), an error will be thrown. 