### PR TITLE
Fix a hostname typo in config-default.js

### DIFF
--- a/QualityControl/config-default.js
+++ b/QualityControl/config-default.js
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   consul: {
-    hostname: 'locahost',
+    hostname: 'localhost',
     port: 8500
   }
 


### PR DESCRIPTION
Pointed out in https://alice-talk.web.cern.ch/t/qc-task-error-servicediscovery-timeout-was-reached/505/3 by Stefan.