### PR TITLE
Added listen, close and address method

### DIFF
--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -94,6 +94,24 @@ class HttpServer {
   }
 
   /**
+   * Stops the server from accepting new connections and keeps existing connections.
+   * This function is asynchronous, the server is finally closed when all connections
+   * are ended and the server emits a 'close' event.
+   * @return {Promise}
+   */
+  close() {
+    return new Promise((resolve, reject) => {
+      this.server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
    * Configures Helmet rules to increase web app secuirty
    * @param {string} hostname whitelisted hostname for websocket connection
    * @param {number} port secure port number

--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -94,6 +94,18 @@ class HttpServer {
   }
 
   /**
+   * Returns the bound `address`, the address `family` name, and `port` of the
+   * server as reported by the operating system if listening on an IP socket
+   * (useful to find which port was assigned when getting an OS-assigned address):
+   * { port: 12346, family: 'IPv4', address: '127.0.0.1' }. For a server listening
+   * on a pipe or Unix domain socket, the name is returned as a string.
+   * @return {(object|string)} The address of the server
+   */
+  address() {
+    return this.server.address();
+  }
+
+  /**
    * Stops the server from accepting new connections and keeps existing connections.
    * This function is asynchronous, the server is finally closed when all connections
    * are ended and the server emits a 'close' event.

--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -71,8 +71,6 @@ class HttpServer {
     const autoListenFlag = 'autoListen';
     if (!httpConfig.hasOwnProperty(autoListenFlag) || httpConfig[autoListenFlag]) {
       this.listen();
-    } else {
-      log.debug(`Server not automatically listening as '${autoListenFlag}' was set to '${httpConfig[autoListenFlag]}'`);
     }
   }
 

--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -60,13 +60,37 @@ class HttpServer {
         key: fs.readFileSync(httpConfig.key),
         cert: fs.readFileSync(httpConfig.cert)
       };
-      this.server = https.createServer(credentials, this.app).listen(httpConfig.portSecure);
+      this.server = https.createServer(credentials, this.app);
       this.enableHttpRedirect();
-      log.info(`Secure server listening on port ${httpConfig.portSecure}`);
+      this.port = httpConfig.portSecure;
     } else {
-      this.server = http.createServer(this.app).listen(httpConfig.port);
-      log.info(`Server listening on port ${httpConfig.port}`);
+      this.server = http.createServer(this.app);
+      this.port = httpConfig.port;
     }
+
+    const autoListenFlag = 'autoListen';
+    if (!httpConfig.hasOwnProperty(autoListenFlag) || httpConfig[autoListenFlag]) {
+      this.listen();
+    } else {
+      log.debug(`Server not automatically listening as '${autoListenFlag}' was set to '${httpConfig[autoListenFlag]}'`);
+    }
+  }
+
+  /**
+   * Starts the server listening for connections.
+   * @return {Promise}
+   */
+  listen() {
+    return new Promise((resolve, reject) => {
+      this.server.listen(this.port, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          log.info(`Server listening on port ${this.port}`);
+          resolve();
+        }
+      });
+    });
   }
 
   /**

--- a/Framework/Backend/test/mocha-http.js
+++ b/Framework/Backend/test/mocha-http.js
@@ -244,8 +244,8 @@ describe('REST API', () => {
 });
 
 describe('HTTP server', () => {
-  after(() => {
-    httpServer.getServer.close();
+  after(async () => {
+    await httpServer.close();
   });
 
   it('Add and verify custom static path', (done) => {

--- a/Framework/Backend/test/mocha-http.js
+++ b/Framework/Backend/test/mocha-http.js
@@ -13,9 +13,8 @@
 
 process.env.NODE_ENV = 'test';
 
-const assert = require('assert');
+const request = require('supertest');
 const path = require('path');
-const http = require('http');
 const url = require('url');
 const config = require('./../config-default.json');
 const JwtToken = require('./../jwt/token.js');
@@ -40,206 +39,116 @@ describe('REST API', () => {
   });
 
   it('GET the "/" and return user details', (done) => {
-    http.get('http://localhost:' + config.http.port + '/',
-      (res) => {
-        assert.strictEqual(res.statusCode, 302);
+    request(httpServer)
+      .get('/')
+      .expect(302)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
         const parsedUrl = new url.URL(res.headers.location, 'http://localhost');
         parsedUrl.searchParams.has('personid');
         parsedUrl.searchParams.has('name');
         parsedUrl.searchParams.has('token');
         done();
-      }
-    );
+      });
   });
 
   it('GET with token should respond 200/JSON', (done) => {
-    http.get('http://localhost:' + config.http.port + '/api/get-request?token=' + token,
-      (res) => {
-        assert.strictEqual(res.statusCode, 200);
-        let rawData = '';
-        res.on('data', (chunk) => {
-          rawData += chunk;
-        });
-        res.on('end', () => {
-          const parsedData = JSON.parse(rawData);
-          assert.strictEqual(parsedData.ok, 1);
-          done();
-        });
-      }
-    );
+    request(httpServer)
+      .get('/api/get-request?token=' + token)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({ok: 1}, done);
   });
 
   it('GET with an incorrect token should respond 403', (done) => {
-    http.get('http://localhost:' + config.http.port + '/api/get-request?token=wrong',
-      (res) => {
-        assert.strictEqual(res.statusCode, 403);
-        done();
-      }
-    );
+    request(httpServer)
+      .get('/api/get-request?token=wrong')
+      .expect('Content-Type', /json/)
+      .expect(403, done);
   });
 
   it('GET without a token should respond 403', (done) => {
-    http.get('http://localhost:' + config.http.port + '/api/get-request',
-      (res) => {
-        assert.strictEqual(res.statusCode, 403);
-        done();
-      }
-    );
+    request(httpServer)
+      .get('/api/get-request')
+      .expect('Content-Type', /json/)
+      .expect(403, done);
   });
 
   it('GET with an incorrect path should respond 404', (done) => {
-    http.get('http://localhost:' + config.http.port + '/api/get-wrong?token=' + token,
-      (res) => {
-        assert.strictEqual(res.statusCode, 404);
-        done();
-      }
-    );
+    request(httpServer)
+      .get('/api/get-wrong?token=' + token)
+      .expect(404, done);
   });
 
   describe('404 handler', () => {
     it('GET with an incorrect path should respond 404, response should be JSON for API', (done) => {
-      http.get('http://localhost:' + config.http.port + '/api/get-wrong?token=' + token,
-        (res) => {
-          assert.ok(/^application\/json;.+/.test(res.headers['content-type']));
-          assert.strictEqual(res.statusCode, 404);
-          done();
-        }
-      );
+      request(httpServer)
+        .get('/api/get-wrong?token=' + token)
+        .expect('Content-Type', /json/)
+        .expect(404, done);
     });
 
     it('GET with an incorrect path should respond 404, response should be HTML for UI', (done) => {
-      http.get('http://localhost:' + config.http.port + '/get-wrong?token=' + token,
-        (res) => {
-          assert.ok(/^text\/html;.+/.test(res.headers['content-type']));
-          assert.strictEqual(res.statusCode, 404);
-          done();
-        }
-      );
+      request(httpServer)
+        .get('/get-wrong?token=' + token)
+        .expect('Content-Type', /html/)
+        .expect(404, done);
     });
   });
 
   it('POST with a token should respond 200/JSON', (done) => {
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/post-request?token=' + token,
-      method: 'POST'
-    }, (res) => {
-      assert.strictEqual(res.statusCode, 200);
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        const parsedData = JSON.parse(rawData);
-        assert.strictEqual(parsedData.ok, 1);
-        done();
-      });
-    });
-    req.end();
+    request(httpServer)
+      .post('/api/post-request?token=' + token)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({ok: 1}, done);
   });
 
   it('POST with a JSON body', (done) => {
     const postData = {fake: 'message'};
-    const postDataString = JSON.stringify(postData);
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/post-with-body?token=' + token,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(postDataString)
-      }
-    }, (res) => {
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        const parsedData = JSON.parse(rawData);
-        assert.deepStrictEqual(parsedData.body, postData);
-        done();
-      });
-    });
-    req.write(postDataString);
-    req.end();
+
+    request(httpServer)
+      .post('/api/post-with-body?token=' + token)
+      .send(postData)
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({body: postData}, done);
   });
 
   it('POST with an incorrect token should respond 403', (done) => {
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/post-request?token=wrong',
-      method: 'POST'
-    }, (res) => {
-      assert.strictEqual(res.statusCode, 403);
-      done();
-    });
-    req.end();
+    request(httpServer)
+      .post('/api/post-request?token=wrong')
+      .expect('Content-Type', /json/)
+      .expect(403, done);
   });
 
   it('PUT with a token should respond 200/JSON', (done) => {
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/put-request?token=' + token,
-      method: 'PUT'
-    }, (res) => {
-      assert.strictEqual(res.statusCode, 200);
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        const parsedData = JSON.parse(rawData);
-        assert.strictEqual(parsedData.ok, 1);
-        done();
-      });
-    });
-    req.end();
+    request(httpServer)
+      .put('/api/put-request?token=' + token)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({ok: 1}, done);
   });
 
   it('PATCH with a token should respond 200/JSON', (done) => {
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/patch-request?token=' + token,
-      method: 'PATCH'
-    }, (res) => {
-      assert.strictEqual(res.statusCode, 200);
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        const parsedData = JSON.parse(rawData);
-        assert.strictEqual(parsedData.ok, 1);
-        done();
-      });
-    });
-    req.end();
+    request(httpServer)
+      .patch('/api/patch-request?token=' + token)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({ok: 1}, done);
   });
 
   it('DELETE with a token should respond 200/JSON', (done) => {
-    const req = http.request({
-      hostname: 'localhost',
-      port: config.http.port,
-      path: '/api/delete-request?token=' + token,
-      method: 'DELETE'
-    }, (res) => {
-      assert.strictEqual(res.statusCode, 200);
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        const parsedData = JSON.parse(rawData);
-        assert.strictEqual(parsedData.ok, 1);
-        done();
-      });
-    });
-    req.end();
+    request(httpServer)
+      .delete('/api/delete-request?token=' + token)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .expect({ok: 1}, done);
   });
 });
 
@@ -250,12 +159,9 @@ describe('HTTP server', () => {
 
   it('Add and verify custom static path', (done) => {
     httpServer.addStaticPath(path.join(__dirname, 'mocha-http.js'), 'mocha-http');
-    http.get('http://localhost:' + config.http.port + '/mocha-http',
-      (res) => {
-        assert.strictEqual(res.statusCode, 200);
-        done();
-      }
-    );
+    request(httpServer)
+      .get('/mocha-http')
+      .expect(200, done);
   });
 
   it('Add custom static path that does not exist', (done) => {

--- a/Framework/Backend/test/mocha-http.js
+++ b/Framework/Backend/test/mocha-http.js
@@ -153,8 +153,8 @@ describe('REST API', () => {
 });
 
 describe('HTTP server', () => {
-  after(async () => {
-    await httpServer.close();
+  after(() => {
+    httpServer.close();
   });
 
   it('Add and verify custom static path', (done) => {

--- a/Framework/Backend/test/mocha-ws.js
+++ b/Framework/Backend/test/mocha-ws.js
@@ -163,8 +163,8 @@ describe('websocket', () => {
     });
   });
 
-  after(async () => {
+  after(() => {
     ws.shutdown();
-    await http.close();
+    http.close();
   });
 });

--- a/Framework/Backend/test/mocha-ws.js
+++ b/Framework/Backend/test/mocha-ws.js
@@ -163,8 +163,8 @@ describe('websocket', () => {
     });
   });
 
-  after(() => {
+  after(async () => {
     ws.shutdown();
-    http.getServer.close();
+    await http.close();
   });
 });

--- a/Framework/docs/guide/http-server.md
+++ b/Framework/docs/guide/http-server.md
@@ -32,6 +32,9 @@ listen
 close
 ```
 ```js
+address
+```
+```js
 addStaticPath
 ```
 ```js

--- a/Framework/docs/guide/http-server.md
+++ b/Framework/docs/guide/http-server.md
@@ -9,7 +9,7 @@
 #### Instance
 ```js
 const {HttpServer} = require('@aliceo2/web-ui');
-HttpServer({port: PORT, hostname: HOSTNAME, tls: TLS_ENABLED, portSecure: HTTPS_PORT, key: TLS_KEY, cert: TLS_CERT}, JWT_CONF, OPENID_CONF);
+HttpServer({port: PORT, hostname: HOSTNAME, tls: TLS_ENABLED, portSecure: HTTPS_PORT, key: TLS_KEY, cert: TLS_CERT, autoListen: AUTO_LISTEN}, JWT_CONF, OPENID_CONF);
 ```
 Where:
  * `HTTP_CONF` consists of following fields:
@@ -19,11 +19,15 @@ Where:
      * [`HTTPS_PORT`] - HTTPS port number, TLS must be enabled
      * [`TLS_KEY`] - private key filepath, TLS must be enabled
      * [`TLS_CERT`] - certificate filepath, TLS must be enabled
+     * [`AUTO_LISTEN`] - flag that enables/disables automatic listening (default: `true`)
  * [`JWT_CONF`] - JWT module config, see [JWT module](json-tokens.md)
  * [`OPENID_CONF`] - OpenID config, see [OpenID Connect module](openid.md)
 
 
 #### Public methods
+```js
+listen
+```
 ```js
 addStaticPath
 ```

--- a/Framework/docs/guide/http-server.md
+++ b/Framework/docs/guide/http-server.md
@@ -29,6 +29,9 @@ Where:
 listen
 ```
 ```js
+close
+```
+```js
 addStaticPath
 ```
 ```js

--- a/Framework/package-lock.json
+++ b/Framework/package-lock.json
@@ -654,6 +654,12 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -708,6 +714,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1188,6 +1200,12 @@
         "vary": "~1.1.2"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "external-editor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -1362,6 +1380,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3435,6 +3459,51 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/Framework/package.json
+++ b/Framework/package.json
@@ -45,9 +45,10 @@
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.1.4",
     "nock": "11.7.0",
-    "sinon": "8.1.1",
     "nyc": "^14.1.1",
-    "puppeteer": "2.0.0"
+    "puppeteer": "2.0.0",
+    "sinon": "8.1.1",
+    "supertest": "^4.0.2"
   },
   "main": "Backend/index.js"
 }


### PR DESCRIPTION
This change allows for more freedom over starting/stopping of the server. It is however breaking for any applications currently using WebUI!

Reason for this change is that it allows us to configure the server before starting it. This also allows us to wait for the database to be up and running before starting the web server. Simplifies graceful shutdown as we do not need to access the underlying server layer. It also simplifies the testing with supertest.