### PR TITLE
Added API error handler

### DIFF
--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -199,6 +199,23 @@ class HttpServer {
       res.status(404).sendFile(path.join(__dirname, '../../Frontend/404.html'));
     });
 
+    // Error handler when an API controller crashes
+    this.app.use('/api', (err, req, res, next) => {
+      log.error(`Request ${req.originalUrl} failed: ${err.message || err}`);
+      log.trace(err);
+
+      if (process.env.NODE_ENV === 'development') {
+        res.status(500).json({
+          error: err,
+        });
+      } else {
+        res.status(500).json({
+          error: '500 - Server error',
+          message: 'Something went wrong, please try again or contact an administrator.'
+        });
+      }
+    });
+
     // Error handler when a controller crashes
     this.app.use((err, req, res, next) => {
       log.error(`Request ${req.originalUrl} failed: ${err.message || err}`);


### PR DESCRIPTION
Added an error handler for routes/controllers on the `/api` router. The response should be JSON not HTML and based on the NODE_ENV the error message should be included. Chosen for the explicit `development` instead of the not `production` statement to be backwards compatible.

---

#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [x] test are added
- [ ] documentation is changed or added


#### I have JIRA issue created
- [ ] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [ ] PR labels are selected
