### PR TITLE
[OGUI-550] && [OGUI-547] Use prefix on ccdb queries

### DIFF
--- a/QualityControl/config-default.js
+++ b/QualityControl/config-default.js
@@ -21,7 +21,8 @@ module.exports = {
 
   ccdb: {
     hostname: 'localhost',
-    port: 8080
+    port: 8080,
+    prefix: 'qc'
   },
 
   // consul: {

--- a/QualityControl/lib/CCDBConnector.js
+++ b/QualityControl/lib/CCDBConnector.js
@@ -23,6 +23,10 @@ class CCDBConnector {
     this.hostname = config.hostname;
     this.port = config.port;
     this.prefix = this.getPrefix(config);
+    this.headers = {
+      Accept: 'application/json',
+      'X-Filter-Fields': 'path,createTime,lastModified',
+    };
   }
 
   /**
@@ -64,9 +68,7 @@ class CCDBConnector {
         port: this.port,
         path: path,
         method: 'GET',
-        headers: {
-          Accept: 'application/json'
-        }
+        headers: this.headers
       };
 
       /**

--- a/QualityControl/lib/QCModel.js
+++ b/QualityControl/lib/QCModel.js
@@ -32,6 +32,7 @@ if (config.listingConnector === 'ccdb') {
     throw new Error('CCDB config is mandatory');
   }
   const ccdb = new CCDBConnector(config.ccdb);
+  ccdb.testConnection();
   module.exports.listObjects = ccdb.listObjects.bind(ccdb);
 
   const tObject2JsonClient = new TObject2JsonClient('ccdb', config.ccdb);

--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -186,7 +186,7 @@ const objects = [
     {name: `BIGTREE/120KB/${i}`, createTime: i, data: graphs.hpx, lastModified: 100}
   )),
   // Checker
-  {name: 'qc/checker/AB', createTime: 2, data: graphs.checker, lastModified: 100},
+  {name: 'qcg/checker/AB', createTime: 2, data: graphs.checker, lastModified: 100},
 ];
 
 const tabObject = [

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -3045,6 +3045,35 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
+    "nock": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-addon-api": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
@@ -3589,6 +3618,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "O2 Quality Control Web User Interface",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -37,6 +37,7 @@
     "eslint": "^5.15.0",
     "eslint-config-google": "^0.12.0",
     "mocha": "^6.1.4",
+    "nock": "^12.0.3",
     "nyc": "^14.1.1",
     "puppeteer": "2.0.0"
   },

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "O2 Quality Control Web User Interface",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/QualityControl/public/object/ObjectTree.class.js
+++ b/QualityControl/public/object/ObjectTree.class.js
@@ -24,7 +24,7 @@ export default class ObjectTree extends Observable {
   initTree(name, parent) {
     this.name = name || ''; // like 'B'
     this.object = null;
-    this.open = false;
+    this.open = name === 'qc' ? true : false;
     this.children = []; // <Array<ObjectTree>>
     this.parent = parent || null; // <ObjectTree>
     this.path = []; // like ['A', 'B'] for node at path 'A/B' called 'B'

--- a/QualityControl/test/lib/mocha-ccdb-connector.js
+++ b/QualityControl/test/lib/mocha-ccdb-connector.js
@@ -55,6 +55,9 @@ describe('CCDB Connector test suite', () => {
     });
 
     it('should return rejected promise when attempting to test connection on CCDB', async () => {
+      nock('http://ccdb:8500')
+        .get('/browse/test')
+        .replyWithError('getaddrinfo ENOTFOUND ccdb ccdb:8500');
       await assert.rejects(ccdb.testConnection(),
         new Error('Unable to connect to CCDB due to: Error: getaddrinfo ENOTFOUND ccdb ccdb:8500')
       );

--- a/QualityControl/test/lib/mocha-ccdb-connector.js
+++ b/QualityControl/test/lib/mocha-ccdb-connector.js
@@ -26,9 +26,8 @@ describe('CCDB Connector test suite', () => {
   });
   describe('`getPrefix()` tests', () => {
     let ccdb;
-    before(() => {
-      ccdb = new CCDBConnector(config.ccdb);
-    });
+    before(() => ccdb = new CCDBConnector(config.ccdb));
+
     it('successfully return empty string when no prefix is provided in config object', () => {
       const configNoPrefix = {};
       assert.strictEqual(ccdb.getPrefix(configNoPrefix), '');
@@ -44,17 +43,18 @@ describe('CCDB Connector test suite', () => {
   });
 
   describe('`testConnection()` tests', () => {
+    let ccdb;
+    before(() => ccdb = new CCDBConnector(config.ccdb));
+
     it('should successfully test connection to CCDB', async () => {
       nock('http://ccdb:8500')
         .get('/browse/test')
         .reply(200, {objects: [], subfolders: []});
 
-      const ccdb = new CCDBConnector(config.ccdb);
       await assert.doesNotReject(ccdb.testConnection());
     });
 
     it('should return rejected promise when attempting to test connection on CCDB', async () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       await assert.rejects(ccdb.testConnection(),
         new Error('Unable to connect to CCDB due to: Error: getaddrinfo ENOTFOUND ccdb ccdb:8500')
       );
@@ -85,19 +85,19 @@ describe('CCDB Connector test suite', () => {
   });
 
   describe('`itemTransform()` tests', () => {
+    let ccdb;
+    before(() => ccdb = new CCDBConnector(config.ccdb));
+
     it('should successfully return null for an item with missing path', () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       assert.strictEqual(ccdb.itemTransform({}), null);
       assert.strictEqual(ccdb.itemTransform({path: undefined}), null);
       assert.strictEqual(ccdb.itemTransform({path: null}), null);
       assert.strictEqual(ccdb.itemTransform({path: ''}), null);
     });
     it('should successfully return null for an item with a path missing a forward slash(/)', () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       assert.strictEqual(ccdb.itemTransform({path: 'wrongPath'}), null);
     });
     it('should successfully return a JSON with 3 fields if item fits criteria', () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       const item = {
         path: 'correct/path', createTime: '101', lastModified: '102', id: 'id', metadata: []
       };
@@ -107,8 +107,10 @@ describe('CCDB Connector test suite', () => {
   });
 
   describe('`httGetJson()` tests', () => {
+    let ccdb;
+    before(() => ccdb = new CCDBConnector(config.ccdb));
+
     it('should successfully return a list of the objects', async () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       nock('http://ccdb:8500')
         .get('/latest/test.*')
         .reply(200, '{}');
@@ -117,7 +119,6 @@ describe('CCDB Connector test suite', () => {
     });
 
     it('should reject with error due to status code', async () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       nock('http://ccdb:8500')
         .get('/latest/test.*')
         .reply(502, 'Some error');
@@ -126,7 +127,6 @@ describe('CCDB Connector test suite', () => {
     });
 
     it('should reject with error due to bad JSON body', async () => {
-      const ccdb = new CCDBConnector(config.ccdb);
       nock('http://ccdb:8500')
         .get('/latest/test.*')
         .reply(200, 'Bad formatted JSON');

--- a/QualityControl/test/lib/mocha-ccdb-connector.js
+++ b/QualityControl/test/lib/mocha-ccdb-connector.js
@@ -1,0 +1,140 @@
+const assert = require('assert');
+const nock = require('nock');
+
+const CCDBConnector = require('../../lib/CCDBConnector.js');
+const config = require('../test-config.js');
+
+describe('CCDB Connector test suite', () => {
+  describe('Creating a new CCDBConnector instance', () => {
+    it('should throw an error if configuration object is not provided', () => {
+      assert.throws(() => new CCDBConnector(), new Error('Empty CCDB config'));
+      assert.throws(() => new CCDBConnector(null), new Error('Empty CCDB config'));
+      assert.throws(() => new CCDBConnector(undefined), new Error('Empty CCDB config'));
+    });
+
+    it('should throw an error if configuration object is missing hostname field', () => {
+      assert.throws(() => new CCDBConnector({}), new Error('Empty hostname in CCDB config'));
+    });
+
+    it('should throw an error if configuration object is missing port field', () => {
+      assert.throws(() => new CCDBConnector({hostname: 'localhost'}), new Error('Empty port in CCDB config'));
+    });
+
+    it('should successfully initialize CCDBConnector', () => {
+      assert.doesNotThrow(() => new CCDBConnector({hostname: 'localhost', port: 8080}));
+    });
+  });
+  describe('`getPrefix()` tests', () => {
+    let ccdb;
+    before(() => {
+      ccdb = new CCDBConnector(config.ccdb);
+    });
+    it('successfully return empty string when no prefix is provided in config object', () => {
+      const configNoPrefix = {};
+      assert.strictEqual(ccdb.getPrefix(configNoPrefix), '');
+    });
+    it('successfully return prefix with no forward slash', () => {
+      const configNoPrefix = {prefix: '/qc'};
+      assert.strictEqual(ccdb.getPrefix(configNoPrefix), 'qc');
+    });
+    it('successfully return prefix with no backslash', () => {
+      const configNoPrefix = {prefix: 'qc/'};
+      assert.strictEqual(ccdb.getPrefix(configNoPrefix), 'qc');
+    });
+  });
+
+  describe('`testConnection()` tests', () => {
+    it('should successfully test connection to CCDB', async () => {
+      nock('http://ccdb:8500')
+        .get('/browse/test')
+        .reply(200, {objects: [], subfolders: []});
+
+      const ccdb = new CCDBConnector(config.ccdb);
+      await assert.doesNotReject(ccdb.testConnection());
+    });
+
+    it('should return rejected promise when attempting to test connection on CCDB', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      await assert.rejects(ccdb.testConnection(),
+        new Error('Unable to connect to CCDB due to: Error: getaddrinfo ENOTFOUND ccdb ccdb:8500')
+      );
+    });
+  });
+
+  describe('`listObjects()` tests', () => {
+    it('should successfully return a list of the objects', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      const objects = [
+        {path: 'object/one', createTime: '101', lastModified: '102', id: 'id', metadata: []},
+        {path: 'object/two', createTime: '101', lastModified: '102', id: 'id', metadata: []},
+        {path: 'object/three', createTime: '101', lastModified: '102', id: 'id', metadata: []},
+      ];
+      const expectedObjects = [
+        {name: 'object/one', createTime: 101, lastModified: 102},
+        {name: 'object/two', createTime: 101, lastModified: 102},
+        {name: 'object/three', createTime: 101, lastModified: 102}
+      ];
+      nock('http://ccdb:8500')
+        .get('/latest/test.*')
+        .reply(200, {objects: objects, subfolders: []});
+
+      await ccdb.listObjects().then((result) => {
+        assert.deepStrictEqual(result, expectedObjects);
+      });
+    });
+  });
+
+  describe('`itemTransform()` tests', () => {
+    it('should successfully return null for an item with missing path', () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      assert.strictEqual(ccdb.itemTransform({}), null);
+      assert.strictEqual(ccdb.itemTransform({path: undefined}), null);
+      assert.strictEqual(ccdb.itemTransform({path: null}), null);
+      assert.strictEqual(ccdb.itemTransform({path: ''}), null);
+    });
+    it('should successfully return null for an item with a path missing a forward slash(/)', () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      assert.strictEqual(ccdb.itemTransform({path: 'wrongPath'}), null);
+    });
+    it('should successfully return a JSON with 3 fields if item fits criteria', () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      const item = {
+        path: 'correct/path', createTime: '101', lastModified: '102', id: 'id', metadata: []
+      };
+      const expectedItem = {name: 'correct/path', createTime: 101, lastModified: 102};
+      assert.deepStrictEqual(ccdb.itemTransform(item), expectedItem);
+    });
+  });
+
+  describe('`httGetJson()` tests', () => {
+    it('should successfully return a list of the objects', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      nock('http://ccdb:8500')
+        .get('/latest/test.*')
+        .reply(200, '{}');
+
+      await assert.doesNotReject(ccdb.httpGetJson('/latest/test.*'));
+    });
+
+    it('should reject with error due to status code', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      nock('http://ccdb:8500')
+        .get('/latest/test.*')
+        .reply(502, 'Some error');
+
+      await assert.rejects(ccdb.httpGetJson('/latest/test.*'), new Error('Non-2xx status code: 502'));
+    });
+
+    it('should reject with error due to bad JSON body', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      nock('http://ccdb:8500')
+        .get('/latest/test.*')
+        .reply(200, 'Bad formatted JSON');
+
+      await assert.rejects(ccdb.httpGetJson('/latest/test.*'), new Error('Unable to parse JSON'));
+    });
+  });
+
+  after(nock.restore);
+  afterEach(nock.cleanAll);
+});

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -583,7 +583,7 @@ describe('QCG', function() {
       const expConfig = {
         qcg: {port: 8181, hostname: 'localhost'},
         consul: {hostname: 'localhost', port: 8500},
-        ccdb: {hostname: 'ccdb', port: 8500},
+        ccdb: {hostname: 'ccdb', port: 8500, prefix: 'test'},
         quality_control: {version: '0.19.5-1'}
       };
       const config = await page.evaluate(() => window.model.frameworkInfo.item);

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -424,7 +424,7 @@ describe('QCG', function() {
       });
 
       it('should load page=objectView and display a Checker Object when a parameter objectName is passed', async () => {
-        const objectName = 'qc/checker/AB';
+        const objectName = 'qcg/checker/AB';
         await page.goto(url + `?page=objectView&objectName=${objectName}`, {waitUntil: 'networkidle0'});
 
         const result = await page.evaluate(() => {

--- a/QualityControl/test/test-config.js
+++ b/QualityControl/test/test-config.js
@@ -21,7 +21,8 @@ module.exports = {
   },
   ccdb: {
     hostname: 'ccdb',
-    port: 8500
+    port: 8500,
+    prefix: 'test'
   },
   quality_control: {
     version: '0.19.5-1'


### PR DESCRIPTION
PR which includes:
* An updated version of the CCDBConnector to include a prefix taken from the configuration file. This prefix shall be used in all queries to CCDB
* Tests for CCDB old and new functionality
* Updated header in CCDBConnector to make use of the new functionality in which we can specify which fields should be sent back
