### PR TITLE
[OGUI-571] Add info icon on KV env panel

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "ALICE O2 Control GUI",
   "author": "Adam Wegrzynek",
   "contributors": [

--- a/Control/public/workflow/workflowsPage.js
+++ b/Control/public/workflow/workflowsPage.js
@@ -1,4 +1,4 @@
-import {h, iconReload, iconTrash, iconPlus} from '/js/src/index.js';
+import {h, iconReload, iconTrash, iconPlus, info} from '/js/src/index.js';
 import revisionPanel from './revisionPanel.js';
 import flpSelectionPanel from './flpSelectionPanel.js';
 import errorComponent from './../common/errorComponent.js';
@@ -157,13 +157,17 @@ const actionableCreateEnvironment = (model) =>
  * @return {vnode}
  */
 const extraVariablePanel = (workflow) =>
-  h('.w-50.ph2', {
-    style: 'display: flex; flex-direction: column'
-  }, [
+  h('.w-50.ph2.flex-column', [
     h('h5.bg-gray-light.p2.panel-title.w-100', 'FLP Selection'),
     flpSelectionPanel(workflow),
-
-    h('h5.bg-gray-light.p2.panel-title.w-100', 'Environment variables'),
+    h('h5.bg-gray-light.p2.panel-title.w-100.flex-row', [
+      h('.w-100', 'Environment variables'),
+      h('a.ph1.actionable-icon', {
+        href: 'https://github.com/AliceO2Group/ControlWorkflows',
+        target: '_blank',
+        title: 'Open Environment Variables Documentation'
+      }, info())
+    ]),
     addKVInputList(workflow),
     addKVInputPair(workflow),
   ]);


### PR DESCRIPTION
Add a small info icon (temporarily) to redirect user to the link with documentation on KV environments panel. 
On hover inform the user. 

![image](https://user-images.githubusercontent.com/9214854/82895293-46ac7d00-9f54-11ea-94b0-4cd77ff53d01.png)

