### PR TITLE
[OGUI-570] & [OGUI-569] Improve integration-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 build
 tobject2json.node
 */.nyc*
+*/test/integration/test-config*

--- a/Control/test/integration/core-tests.js
+++ b/Control/test/integration/core-tests.js
@@ -33,6 +33,14 @@ describe('Control', function() {
         console.log(`        ${msg.args()[i]}`);
       }
     });
+    let testConfig;
+    try {
+      testConfig = require('./test-config');
+    } catch (error) {
+      console.warn('`test-config.js` file could not be found. Will use default values.');
+    }
+    exports.workflow = (testConfig && testConfig.workflow) ? testConfig.workflow : 'readout-stfb';
+    exports.timeout = (testConfig && testConfig.timeout) ? testConfig.timeout : 90;
     exports.page = page;
     exports.url = url;
     exports.requestTimeout = 90; // seconds

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -1,20 +1,22 @@
 /* eslint-disable max-len */
 const assert = require('assert');
-const test = require('./core-tests');
+const coreTests = require('./core-tests');
 
 let url;
 let page;
-const workflowToTest = 'readout-stfb';
+let workflowToTest;
 
 describe('`pageNewEnvironment` test-suite', async () => {
   before(async () => {
-    url = test.url;
-    page = test.page;
+    url = coreTests.url;
+    page = coreTests.page;
+    workflowToTest = coreTests.workflow;
   });
 
   it('should successfully load newEnvironment page', async () => {
     await page.goto(url + '?page=newEnvironment', {waitUntil: 'networkidle0'});
     const location = await page.evaluate(() => window.location);
+    await page.waitFor(2000);
     assert.strictEqual(location.search, '?page=newEnvironment');
   });
 
@@ -74,12 +76,13 @@ describe('`pageNewEnvironment` test-suite', async () => {
  * Wait for response from AliECS Core
  * Method will check if loader is still active (requests still pending) every second for 90 seconds
  * @param {Object} page
+ * @param {number} timeout
  * @return {Promise}
  */
-const waitForCoreResponse = async (page) => {
+const waitForCoreResponse = async (page, timeout = 90) => {
   return new Promise(async (resolve) => {
     let i = 0;
-    while (i++ < 90) {
+    while (i++ < timeout) {
       const isLoaderActive = await page.evaluate(() => window.model.loader.active);
       if (!isLoaderActive) {
         resolve();


### PR DESCRIPTION
Improve current integration-tests:
* take name of workflow to be tested and timeout allowed for core requests from test-config file if it exists otherwise use defaults; [OGUI-570]
* Check for `itemControl` in tests controlling the environment. This will give a proper message in case an action will fail [OGUI-569]
* Added 5s sleep before actions "RESET" and "SHUTDOWN". This is a temporary fix needed for [OCTRL-232]