### PR TITLE
[OGUI-575] Include a message why the JWT failed

### DIFF
--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -470,9 +470,22 @@ class HttpServer {
           name: data.username
         };
         next();
-      }, (error) => {
-        log.warn(`${error.name} : ${error.message}`);
-        res.status(403).json({message: error.name});
+      }, ({name, message}) => {
+        log.warn(`${name} : ${message}`);
+
+        const response = {error: '403 - Json Web Token Error'};
+
+        // Allow for a custom message for known error messages
+        switch (message) {
+          case 'jwt must be provided':
+            response.message = 'You must provide a JWT token';
+            break;
+          default:
+            response.message = 'Invalid JWT token provided';
+            break;
+        }
+
+        res.status(403).json(response);
       });
   }
 }

--- a/Framework/Backend/test/mocha-http.js
+++ b/Framework/Backend/test/mocha-http.js
@@ -108,14 +108,20 @@ describe('REST API', () => {
     request(httpServer)
       .get('/api/get-request?token=wrong')
       .expect('Content-Type', /json/)
-      .expect(403, done);
+      .expect(403, {
+        error: '403 - Json Web Token Error',
+        message: 'Invalid JWT token provided',
+      }, done);
   });
 
   it('GET without a token should respond 403', (done) => {
     request(httpServer)
       .get('/api/get-request')
       .expect('Content-Type', /json/)
-      .expect(403, done);
+      .expect(403, {
+        error: '403 - Json Web Token Error',
+        message: 'You must provide a JWT token',
+      }, done);
   });
 
   it('GET with an incorrect path should respond 404', (done) => {


### PR DESCRIPTION
The current JWT error response does not explain to the end user why their request has failed. The proposed implementation uses the error message of the JWT package to atleast give a hint.

### No token provided
#### Before
```json
{
  "message": "JsonWebTokenError"
}
```

#### After
```json
{
  "error": "403 - Json Web Token Error",
  "message": "You must provide a JWT token"
}
```

### Wrong/invalid token provided
#### Before
```json
{
  "message": "JsonWebTokenError"
}
```

#### After
```json
{
  "error": "403 - Json Web Token Error",
  "message": "Invalid JWT token provided"
}
```

<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I DON'T have JIRA ticket
- [X] explain what this PR does
- [ ] if it is new feature explain how plan to use it
- [X] test are added
- [ ] documentation is changed or added


#### I have JIRA issue created
- [ ] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [ ] PR labels are selected
