### PR TITLE
[OGUI-577] Use set for Consul Keys

### DIFF
--- a/Control/lib/ConsulConnector.js
+++ b/Control/lib/ConsulConnector.js
@@ -76,7 +76,7 @@ class ConsulConnector {
           const flpList = data.filter((key) => key.match(regex))
             .map((key) => key.split('/')[3]);
           res.status(200);
-          res.json(flpList);
+          res.json([...new Set(flpList)]);
         })
         .catch((error) => {
           if (error.message.includes('404')) {

--- a/Control/test/lib/mocha-consul-connector.js
+++ b/Control/test/lib/mocha-consul-connector.js
@@ -104,6 +104,7 @@ describe('ConsulConnector test suite', () => {
       };
       consulService = {};
     });
+
     it('should successfully query, filter, match and return a list of FLP names', async () => {
       consulService.getKeysByPrefix = sinon.stub().resolves([
         'o2/hardware/flps/flpOne/cards',
@@ -115,6 +116,18 @@ describe('ConsulConnector test suite', () => {
 
       assert.ok(res.status.calledWith(200));
       assert.ok(res.json.calledWith(['flpOne', 'flpTwo']));
+    });
+
+    it('should successfully remove duplicates from list of FLP names', async () => {
+      consulService.getKeysByPrefix = sinon.stub().resolves([
+        'o2/hardware/flps/flpTwo/cards',
+        'o2/hardware/flps/flpTwo/info'
+      ]);
+      const connector = new ConsulConnector(consulService, 'some/path');
+      await connector.getFLPs(null, res);
+
+      assert.ok(res.status.calledWith(200));
+      assert.ok(res.json.calledWith(['flpTwo']));
     });
 
     // it('should successfully return 404 if consul did not send back any data for specified key', async () => {


### PR DESCRIPTION
In order to prevent potential issues when Ansible creates keys in Consul KV Store with empty values, we should use a set to remove duplicate keys