### PR TITLE
Free console resources even if the render failed

### DIFF
--- a/Framework/Frontend/js/src/renderer.js
+++ b/Framework/Frontend/js/src/renderer.js
@@ -139,10 +139,14 @@ function mount(element, view, model, debug) {
       // eslint-disable-next-line no-console
       console.time('render');
     }
-    render(element, view(model));
-    if (debug) {
-      // eslint-disable-next-line no-console
-      console.timeEnd('render');
+    try {
+      render(element, view(model));
+    }
+    finally {
+      if (debug) {
+        // eslint-disable-next-line no-console
+        console.timeEnd('render');
+      }
     }
   });
 


### PR DESCRIPTION
Free console resources even if the render throws an error. Currently, the timer will keep running on the background, calling `console.time('render');` won't restart the timer but display a warning (and thus keeps the existing time). This fix will always stop and clear the timer.

#### I DON'T have JIRA ticket
- [X] explain what this PR does
- [ ] if it is new feature explain how plan to use it
- [ ] test are added
- [ ] documentation is changed or added
