### PR TITLE
[OGUI-629] Add waiting rendering time

### DIFF
--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "O2 Quality Control Web User Interface",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/QualityControl/test/integration/offline-mode.js
+++ b/QualityControl/test/integration/offline-mode.js
@@ -40,8 +40,10 @@ describe('`OFFLINE` test-suite', async () => {
 
         await toggleGivenObjectPath(page, path);
 
+        await page.waitFor(500);
         const panelWidth = await page.evaluate(() => document.querySelector('section > div > div > div:nth-child(2)').style.width);
         assert.strictEqual(panelWidth, '50%', `Panel containing object ${objects[i]} plot was not opened successfully`);
+        await page.waitFor(500);
 
         await toggleGivenObjectPath(page, path.reverse());
       });

--- a/QualityControl/test/integration/online-mode.js
+++ b/QualityControl/test/integration/online-mode.js
@@ -46,7 +46,9 @@ describe('`ONLINE` test-suite', async () => {
 
         await toggleGivenObjectPath(page, path);
 
+        await page.waitFor(500);
         const panelWidth = await page.evaluate(() => document.querySelector('section > div > div > div:nth-child(2)').style.width);
+        await page.waitFor(500);
         assert.strictEqual(panelWidth, '50%', `Panel containing object ${objects[i]} plot was not opened successfully`);
 
         await toggleGivenObjectPath(page, path.reverse());


### PR DESCRIPTION
Add half a second before and after opening JSRoot plot to allow for rendering to be completed before checking if it was opened successfully .

