### PR TITLE
[OGUI-628] Allow objects with same name as sub-path

### DIFF
--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "O2 Quality Control Web User Interface",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/QualityControl/public/object/ObjectTree.class.js
+++ b/QualityControl/public/object/ObjectTree.class.js
@@ -29,7 +29,6 @@ export default class ObjectTree extends Observable {
     this.parent = parent || null; // <ObjectTree>
     this.path = []; // like ['A', 'B'] for node at path 'A/B' called 'B'
     this.pathString = ''; // 'A/B'
-    this.quality = null; // most negative quality from this subtree
   }
   /**
    * Toggle this node (open/close)
@@ -86,12 +85,6 @@ export default class ObjectTree extends Observable {
       this.addChild(object, path, []);
       this.notify();
       return;
-    }
-
-    // Keep quality of wrost quality of all leaf
-    // so the root has the wrost quality, easy to monitor
-    if (!this.quality || object.quality === 'bad') {
-      this.quality = object.quality;
     }
 
     // Case end of path, associate the object to 'this' node

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -104,7 +104,6 @@ const tableShow = (model) =>
     h('thead', [
       h('tr', [
         h('th', 'Name'),
-        h('th', {style: {width: '6em'}}, 'Quality'),
       ])
     ]),
     h('tbody', [

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -139,25 +139,60 @@ const treeRows = (model) => !model.object.tree ?
  * @return {vnode}
  */
 function treeRow(model, tree, level) {
-  const color = tree.quality === 'good' ? 'success' : 'danger';
   const padding = `${level}em`;
   const levelDeeper = level + 1;
-  const icon = tree.object ? iconBarChart() : (tree.open ? iconCaretBottom() : iconCaretRight()); // 1 of 3 icons
-  const iconWrapper = h('span', {style: {paddingLeft: padding}}, icon);
   const children = tree.open ? tree.children.map((children) => treeRow(model, children, levelDeeper)) : [];
   const path = tree.path.join('/');
-  const selectItem = tree.object ? () => model.object.select(tree.object) : () => tree.toggle();
   const className = tree.object && tree.object === model.object.selected ? 'table-primary' : '';
 
-  return model.object.searchInput ? [] : [
-    h('tr.object-selectable', {key: path, title: path, onclick: selectItem, class: className}, [
-      h('td.highlight', [
-        iconWrapper,
-        ' ',
-        tree.name
-      ]),
-      h('td.highlight', {class: color}, tree.quality),
-    ]),
-    children
-  ];
+  if (model.object.searchInput) {
+    return [];
+  } else {
+    if (tree.object && tree.children.length === 0) {
+      return [leafRow(path, () => model.object.select(tree.object), className, padding, tree.name)];
+    } else if (tree.object && tree.children.length > 0) {
+      return [
+        leafRow(path, () => model.object.select(tree.object), className, padding, tree.name),
+        branchRow(path, tree, padding),
+        children
+      ];
+    }
+    return [
+      branchRow(path, tree, padding),
+      children
+    ];
+  }
 }
+
+/**
+ * Creates a row containing specific visuals for leaf object and on selection
+ * it will plot the object with JSRoot
+ * @param {String} path - full name of the object
+ * @param {Action} selectItem - action for plotting the object
+ * @param {String} className - name of the row class
+ * @param {number} padding - space needed to be displayed so that leaf is within its parent
+ * @param {String} leafName - name of the object
+ * @return {vnode}
+ */
+const leafRow = (path, selectItem, className, padding, leafName) =>
+  h('tr.object-selectable', {key: path, title: path, onclick: selectItem, class: className}, [
+    h('td.highlight', [
+      h('span', {style: {paddingLeft: padding}}, iconBarChart()), ' ', leafName]),
+  ]);
+
+/**
+ * Creates a row containing specific visuals for branch object and on selection
+ * it will open its children
+ * @param {String} path - full name of the object
+ * @param {ObjectTree} tree - current selected tree
+ * @param {number} padding - space needed to be displayed so that branch is within its parent
+ * @return {vnode}
+ */
+const branchRow = (path, tree, padding) =>
+  h('tr.object-selectable', {key: path, title: path, onclick: () => tree.toggle()}, [
+    h('td.highlight', [
+      h('span', {style: {paddingLeft: padding}}, tree.open ? iconCaretBottom() : iconCaretRight()),
+      ' ',
+      tree.name
+    ]),
+  ]);

--- a/QualityControl/public/object/objectTreeSidebar.js
+++ b/QualityControl/public/object/objectTreeSidebar.js
@@ -120,42 +120,49 @@ const treeRows = (model) => !model.object.sideTree
 
 /**
  * Shows a line <tr> of object represented by parent node `tree`, also shows
- * sub-nodes of `tree` as additionnals lines if they are open in the tree.
- * Indentation is added according to tree level during recurcive call of treeRow
+ * sub-nodes of `tree` as additional lines if they are open in the tree.
+ * Indentation is added according to tree level during recursive call of treeRow
  * Tree is traversed in depth-first with pre-order (root then subtrees)
  * @param {Object} model
- * @param {ObjectTree} sideTree - data-structure containaing an object per node
- * @param {number} level - used for indentation within recurcive call of treeRow
+ * @param {ObjectTree} sideTree - data-structure containing an object per node
+ * @param {number} level - used for indentation within recursive call of treeRow
  * @return {vnode}
  */
 function treeRow(model, sideTree, level) {
-  // sideTree construction
+  if (sideTree.object && sideTree.children.length === 0) {
+    return [leafRow(model, sideTree, level)];
+  } else if (sideTree.object && sideTree.children.length > 0) {
+    return [
+      leafRow(model, sideTree, level),
+      branchRow(model, sideTree, level)
+    ];
+  } else {
+    return [branchRow(model, sideTree, level)];
+  }
+}
+
+/**
+ * Shows a line <tr> of object represented by parent node `tree`, also shows
+ * sub-nodes of `tree` as additional lines if they are open in the tree.
+ * Indentation is added according to tree level during recursive call of treeRow
+ * Tree is traversed in depth-first with pre-order (root then subtrees)
+ * @param {Object} model
+ * @param {ObjectTree} sideTree - data-structure containing an object per node
+ * @param {number} level - used for indentation within recursive call of treeRow
+ * @return {vnode}
+ */
+const branchRow = (model, sideTree, level) => {
   const levelDeeper = level + 1;
   const subtree = sideTree.open ? sideTree.children.map((children) => treeRow(model, children, levelDeeper)) : [];
 
-  // UI construction
-  const icon = sideTree.object ? iconBarChart() : (sideTree.open ? iconCaretBottom() : iconCaretRight()); // 1 of 3 icons
+  const icon = sideTree.open ? iconCaretBottom() : iconCaretRight();
   const iconWrapper = h('span', {style: {paddingLeft: `${level}em`}}, icon);
   const path = sideTree.path.join('/');
-  const className = sideTree.object && sideTree.object === model.object.selected ? 'table-primary' : '';
-  const draggable = !!sideTree.object;
-
-  // UI events
-  const onclick = sideTree.object ? () => model.object.select(sideTree.object) : () => sideTree.toggle();
-  const ondblclick = sideTree.object ? () => model.layout.addItem(sideTree.object.name) : null;
-  const ondragstart = sideTree.object ? () => {
-    const newItem = model.layout.addItem(sideTree.object.name);
-    model.layout.moveTabObjectStart(newItem);
-  } : null;
 
   const attr = {
     key: `key-sidebar-tree-${path}`,
     title: path,
-    onclick,
-    class: className,
-    draggable,
-    ondragstart,
-    ondblclick
+    onclick: () => sideTree.toggle(),
   };
 
   return [
@@ -164,4 +171,42 @@ function treeRow(model, sideTree, level) {
     ]),
     ...subtree
   ];
-}
+};
+
+
+/**
+ * Shows a line <tr> of object represented by parent node `tree`, also shows
+ * sub-nodes of `tree` as additional lines if they are open in the tree.
+ * Indentation is added according to tree level during recursive call of treeRow
+ * Tree is traversed in depth-first with pre-order (root then subtrees)
+ * @param {Object} model
+ * @param {ObjectTree} sideTree - data-structure containing an object per node
+ * @param {number} level - used for indentation within recursive call of treeRow
+ * @return {vnode}
+ */
+const leafRow = (model, sideTree, level) => {
+  // UI construction
+  const iconWrapper = h('span', {style: {paddingLeft: `${level}em`}}, iconBarChart());
+  const path = sideTree.path.join('/');
+  const className = sideTree.object && sideTree.object === model.object.selected ? 'table-primary' : '';
+  const draggable = !!sideTree.object;
+
+  const attr = {
+    key: `key-sidebar-tree-${path}`,
+    title: path,
+    onclick: () => model.object.select(sideTree.object),
+    class: className,
+    draggable,
+    ondragstart: () => {
+      const newItem = model.layout.addItem(sideTree.object.name);
+      model.layout.moveTabObjectStart(newItem);
+    },
+    ondblclick: () => model.layout.addItem(sideTree.object.name)
+  };
+
+  return [
+    h('tr.object-selectable', attr, [
+      h('td.text-ellipsis', [iconWrapper, ' ', sideTree.name])
+    ]),
+  ];
+};


### PR DESCRIPTION
PR tackles the bug raised on ALICE Talk blog: https://alice-talk.web.cern.ch/t/check-policy-oneachseparately/639 

QCG will not create a folder for objects if there is an object already with the same path
E.g:
```
qc/TST/PiotrTest/histo/histo1
qc/TST/PiotrTest/histo/histo2
qc/TST/PiotrTest/histo
```
would result in only `qc/TST/PiotrTest/histo` to be displayed. 

PR also removes the deprecated `quality` column from the object tree

#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected