### PR TITLE
[OGUI-598] Split drawing options

### DIFF
--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -391,8 +391,16 @@ export default class QCObject extends Observable {
   generateDrawingOptions(tabObject, objectRemoteData) {
     let objectOptionList = [];
     let drawingOptions = [];
-    if (objectRemoteData.payload.fOption && objectRemoteData.payload.fOption !== '') {
+    if (objectRemoteData.payload.fOption) {
       objectOptionList = objectRemoteData.payload.fOption.split(' ');
+    }
+    if (objectRemoteData.payload.metadata && objectRemoteData.payload.metadata.drawOptions) {
+      const metaOpt = objectRemoteData.payload.metadata.drawOptions.split(' ');
+      objectOptionList = objectOptionList.concat(metaOpt);
+    }
+    if (objectRemoteData.payload.metadata && objectRemoteData.payload.metadata.displayHints) {
+      const metaHints = objectRemoteData.payload.metadata.displayHints.split(' ');
+      objectOptionList = objectOptionList.concat(metaHints);
     }
     switch (this.model.page) {
       case 'objectTree':
@@ -417,8 +425,10 @@ export default class QCObject extends Observable {
         const objectId = this.model.router.params.objectId;
 
         if (!layoutId || !objectId) {
+          // object opened from tree view -> use only its own options
           drawingOptions = JSON.parse(JSON.stringify(objectOptionList));
         } else {
+          // object opened from layout view -> use the layout/tab configuration
           if (this.model.layout.requestedLayout.isSuccess()) {
             let objectData = {};
             this.model.layout.requestedLayout.payload.tabs.forEach((tab) => {

--- a/QualityControl/public/object/objectPropertiesSidebar.js
+++ b/QualityControl/public/object/objectPropertiesSidebar.js
@@ -22,10 +22,27 @@ export default function objectPropertiesSidebar(model) {
     h('hr'),
 
     h('.flex-row', [
-      h('span', 'Options'),
+      h('span', 'Object Configuration:'),
       btnIgnoreOptions(model, tabObject)
     ]),
-    h('.p3', [
+    h('.ph3', [
+      h('.flex-row',
+        h('.tooltip.mv2', [
+          h('label.m0', 'Drawing Options:'),
+          h('.tooltiptext', ' ROOT draw options')
+        ])
+      ),
+      h('.flex-row', [
+        btnOption(model, tabObject, 'lego'), ' ',
+        btnOption(model, tabObject, 'colz'), ' ',
+        btnOption(model, tabObject, 'text'), ' ',
+      ]),
+      h('.flex-row',
+        h('.tooltip.mv2', [
+          h('label.m0', 'Display Hints:'),
+          h('.tooltiptext', 'Canvas options')
+        ])
+      ),
       h('.flex-row', [
         btnOption(model, tabObject, 'logx'), ' ',
         btnOption(model, tabObject, 'logy'), ' ',
@@ -34,14 +51,10 @@ export default function objectPropertiesSidebar(model) {
       h('.flex-row', [
         btnOption(model, tabObject, 'gridx'), ' ',
         btnOption(model, tabObject, 'gridy'), ' ',
+        btnOption(model, tabObject, 'gridz'), ' ',
       ]),
       h('.flex-row', [
-        btnOption(model, tabObject, 'lego'), ' ',
-        btnOption(model, tabObject, 'colz'), ' ',
-      ]),
-      h('', [
         btnOption(model, tabObject, 'stat'), ' ',
-        btnOption(model, tabObject, 'text'), ' ',
       ]),
     ]),
 
@@ -109,7 +122,7 @@ const btnIgnoreOptions = (model, tabObject) =>
         onchange: () => model.layout.toggleDefaultOptions(tabObject)
       }),
       h('label.m0', {for: tabObject.id + 'defaults'}, 'Ignore defaults'),
-      h('span.tooltiptext', 'Set on the histogram in C++')
+      h('span.tooltiptext', 'Set on the histogram in ROOT - fOption and QC Metadata')
     ]
     )
   );

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -656,18 +656,18 @@ describe('QCG', function() {
       assert.deepStrictEqual(drawingOptions, expDrawingOpts);
     });
 
-    it('should use only default options on objectView when no layoutId or objectId is set', async () => {
+    it('should use only default options(foption and metadata) on objectView when no layoutId or objectId is set', async () => {
       const drawingOptions = await page.evaluate(() => {
         window.model.page = 'objectView';
         window.model.router.params.objectId = undefined;
         window.model.router.params.layoutId = undefined;
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {fOption: 'lego colz', metadata: {displayHints: 'hint hint2', drawOptions: 'option option2'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
-      const expDrawingOpts = ['lego', 'colz'];
-      assert.deepStrictEqual(drawingOptions, expDrawingOpts);
+      const expDrawingOpts = ['lego', 'colz', 'option', 'option2', 'hint', 'hint2'];
+      assert.deepStrictEqual(expDrawingOpts, drawingOptions);
     });
 
     it('should use only default options on objectView when no layoutId is set', async () => {


### PR DESCRIPTION
Configuration of an object has now been split in 2 sections:
* Drawing Options
* Display hints

These are taken from `foption` field for the older QC(prior 1.0) generated objects and from `metadata.drawOptions` and `metadata.displayHints` for newer QC