### PR TITLE
[OGUI-330] navigate object timestamp history

### DIFF
--- a/QualityControl/lib/CCDBConnector.js
+++ b/QualityControl/lib/CCDBConnector.js
@@ -13,7 +13,7 @@
 */
 
 const http = require('http');
-const log = new (require('@aliceo2/web-ui').Log)('CCDBConnector');
+const log = new (require('@aliceo2/web-ui').Log)('QCG-CCDBConnector');
 
 /**
  * Gateway for all CCDB calls
@@ -142,7 +142,7 @@ class CCDBConnector {
   }
 
   /**
-   * Check if received object from CCDB is valid
+   * Check if received object's path from CCDB is valid
    * @param {JSON} item
    * @return {JSON}
    */

--- a/QualityControl/lib/QCModel.js
+++ b/QualityControl/lib/QCModel.js
@@ -34,6 +34,7 @@ if (config.listingConnector === 'ccdb') {
   const ccdb = new CCDBConnector(config.ccdb);
   ccdb.testConnection();
   module.exports.listObjects = ccdb.listObjects.bind(ccdb);
+  module.exports.getObjectTimestampList = ccdb.getObjectTimestampList.bind(ccdb);
   module.exports.queryPrefix = ccdb.prefix;
 
   const tObject2JsonClient = new TObject2JsonClient('ccdb', config.ccdb);

--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -74,6 +74,13 @@ function listObjects() {
 }
 
 /**
+ * Return an empty array
+ * @return {Array<Layout>}
+ */
+function getObjectTimestampList() {
+  return promiseResolveWithLatency([]);
+}
+/**
  * WC
  * @return {Array<Layout>}
  */
@@ -211,28 +218,50 @@ const objects = [
 ];
 
 const tabObject = [
-  {id: '5aba4a059b755d517e76ef51',
-    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1},
-  {id: '5aba4a059b755d517e76ef52',
-    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef53',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef54',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef55',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef56',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef57',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef58',
-    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef59',
-    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef50',
-    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef60',
-    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
+  {
+    id: '5aba4a059b755d517e76ef51',
+    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef52',
+    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef53',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef54',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef55',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef56',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef57',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef58',
+    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef59',
+    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef50',
+    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef60',
+    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+  },
 ];
 
 const tabs = [
@@ -244,38 +273,70 @@ const tabs = [
 ];
 
 const layouts = [
-  {id: '5aba4a059b755d517e76ea10',
-    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea11',
-    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea12',
-    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea13',
-    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea14',
-    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea15',
-    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea16',
-    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea17',
-    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea18',
-    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea19',
-    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea21',
-    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea22',
-    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea23',
-    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea24',
-    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea25',
-    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea26',
-    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs},
+  {
+    id: '5aba4a059b755d517e76ea10',
+    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea11',
+    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea12',
+    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea13',
+    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea14',
+    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea15',
+    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea16',
+    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea17',
+    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea18',
+    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea19',
+    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea21',
+    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea22',
+    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea23',
+    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea24',
+    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea25',
+    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea26',
+    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs
+  },
 ];
 
 // --------------------------------------------------------
@@ -294,3 +355,4 @@ const dataConnector = {
 };
 
 module.exports.layoutConnector = new LayoutConnector(dataConnector);
+module.exports.getObjectTimestampList = getObjectTimestampList;

--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -32,6 +32,7 @@ function promiseResolveWithLatency(data) {
  */
 function readObjectData(name) {
   const object = objects.find((object) => object.name === `${name}`);
+  // TODO Add timestamp for testing
   return promiseResolveWithLatency(object ? object.data : 'Object not found');
 }
 
@@ -190,28 +191,50 @@ const objects = [
 ];
 
 const tabObject = [
-  {id: '5aba4a059b755d517e76ef51',
-    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1},
-  {id: '5aba4a059b755d517e76ef52',
-    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef53',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef54',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef55',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef56',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef57',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef58',
-    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef59',
-    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef50',
-    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
-  {id: '5aba4a059b755d517e76ef60',
-    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
+  {
+    id: '5aba4a059b755d517e76ef51',
+    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef52',
+    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef53',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef54',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef55',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef56',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef57',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef58',
+    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef59',
+    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef50',
+    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
+  },
+  {
+    id: '5aba4a059b755d517e76ef60',
+    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
+  },
 ];
 
 const tabs = [
@@ -223,38 +246,70 @@ const tabs = [
 ];
 
 const layouts = [
-  {id: '5aba4a059b755d517e76ea10',
-    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea11',
-    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea12',
-    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea13',
-    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea14',
-    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea15',
-    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea16',
-    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea17',
-    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea18',
-    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea19',
-    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea21',
-    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea22',
-    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea23',
-    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea24',
-    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea25',
-    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs},
-  {id: '5aba4a059b755d517e76ea26',
-    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs},
+  {
+    id: '5aba4a059b755d517e76ea10',
+    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea11',
+    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea12',
+    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea13',
+    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea14',
+    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea15',
+    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea16',
+    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea17',
+    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea18',
+    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea19',
+    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea21',
+    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea22',
+    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea23',
+    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea24',
+    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea25',
+    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs
+  },
+  {
+    id: '5aba4a059b755d517e76ea26',
+    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs
+  },
 ];
 
 // --------------------------------------------------------

--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -211,50 +211,28 @@ const objects = [
 ];
 
 const tabObject = [
-  {
-    id: '5aba4a059b755d517e76ef51',
-    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef52',
-    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef53',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef54',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef55',
-    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef56',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef57',
-    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef58',
-    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef59',
-    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef50',
-    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1
-  },
-  {
-    id: '5aba4a059b755d517e76ef60',
-    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
-  },
+  {id: '5aba4a059b755d517e76ef51',
+    options: ['logx'], name: 'DAQ01/EventSizeClasses/class_C0AMU-ABC', x: 0, y: 0, w: 2, h: 1},
+  {id: '5aba4a059b755d517e76ef52',
+    options: ['logy'], name: 'DAQ01/EventSizeClasses/class_C0ALSR-ABC', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef53',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef54',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef55',
+    options: ['gridx'], name: 'DAQ01/EquipmentSize/HMPID/HMPID', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef56',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSDD/ITSSDD', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef57',
+    options: [], name: 'DAQ01/EquipmentSize/ITSSSD/ITSSSD', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef58',
+    options: [], name: 'DAQ01/EquipmentSize/TOF/TOF', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef59',
+    options: [], name: 'DAQ01/EquipmentSize/TPC/TPC', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef50',
+    options: [], name: 'DAQ01/EventSize/ACORDE/ACORDE', x: 0, y: 0, w: 1, h: 1},
+  {id: '5aba4a059b755d517e76ef60',
+    options: [], name: 'DAQ01/EventSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1},
 ];
 
 const tabs = [
@@ -266,70 +244,38 @@ const tabs = [
 ];
 
 const layouts = [
-  {
-    id: '5aba4a059b755d517e76ea10',
-    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea11',
-    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea12',
-    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea13',
-    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea14',
-    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea15',
-    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea16',
-    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea17',
-    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea18',
-    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea19',
-    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea21',
-    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea22',
-    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea23',
-    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea24',
-    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea25',
-    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs
-  },
-  {
-    id: '5aba4a059b755d517e76ea26',
-    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs
-  },
+  {id: '5aba4a059b755d517e76ea10',
+    owner_id: ownerIdUser1, name: 'AliRoot', owner_name: ownerNameUser1, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea11',
+    owner_id: ownerIdUser1, name: 'PWG-GA', owner_name: ownerNameUser1, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea12',
+    owner_id: ownerIdUser1, name: 'PWG-HF', owner_name: ownerNameUser1, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea13',
+    owner_id: ownerIdUser1, name: 'PWG-CF', owner_name: ownerNameUser1, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea14',
+    owner_id: ownerIdUser1, name: 'PWG-PP', owner_name: ownerNameUser1, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea15',
+    owner_id: ownerIdUser2, name: 'Run Coordination', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea16',
+    owner_id: ownerIdUser2, name: 'PWG-LF', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea17',
+    owner_id: ownerIdUser2, name: 'PWG-DQ', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea18',
+    owner_id: ownerIdUser2, name: 'PWG-JE', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea19',
+    owner_id: ownerIdUser2, name: 'MC productions', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea21',
+    owner_id: ownerIdUser2, name: 'Run Coordination 2017', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea22',
+    owner_id: ownerIdUser2, name: 'O2 Milestones', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea23',
+    owner_id: ownerIdUser2, name: 'O2 TDR', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea24',
+    owner_id: ownerIdUser2, name: 'MC prod dashboard', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea25',
+    owner_id: ownerIdUser2, name: 'DAQ System Dashboard', owner_name: ownerNameUser2, tabs: tabs},
+  {id: '5aba4a059b755d517e76ea26',
+    owner_id: ownerIdUser2, name: 'PWG-LF (2)', owner_name: ownerNameUser2, tabs: tabs},
 ];
 
 // --------------------------------------------------------

--- a/QualityControl/lib/QCModelDemo.js
+++ b/QualityControl/lib/QCModelDemo.js
@@ -59,7 +59,6 @@ function readObjectData(name) {
     return promiseRejectWithLatency();
   }
   const object = objects.find((object) => object.name === `${name}`);
-  // TODO Add timestamp for testing
   return promiseResolveWithLatency(object ? object.data : 'Object not found');
 }
 
@@ -80,8 +79,9 @@ function listObjects() {
 function getObjectTimestampList() {
   return promiseResolveWithLatency([]);
 }
+
 /**
- * WC
+ * Return true for checking online mode connection
  * @return {Array<Layout>}
  */
 function isOnlineModeConnectionAlive() {

--- a/QualityControl/lib/TObject2JsonClient.js
+++ b/QualityControl/lib/TObject2JsonClient.js
@@ -23,15 +23,19 @@ class TObject2JsonClient {
   /**
    * Get JSON-encoded ROOT object using QualityControl/TObject2Json C++ module
    * @param {string} path - object's path (agentName/objectName)
+   * @param {number} timestamp - object's timestamp
    * @return {Promise.<Object|null, string>} The root data, null is not found
    */
-  retrieve(path) {
+  retrieve(path, timestamp = 0) {
     if (!path || path.indexOf('/') === -1) {
       return Promise.reject(new Error('Path should contain a slash at least'));
     }
+    if (typeof timestamp !== 'number') {
+      return Promise.reject(new Error('Timestamp should be a number'));
+    }
 
     return new Promise((resolve, fail) => {
-      tobject2json.get(path, (error, result) => {
+      tobject2json.get(path, timestamp, (error, result) => {
         if (error) {
           fail(new Error('TObject2Json C++ module failed'));
         } else {

--- a/QualityControl/lib/TObject2JsonClient.js
+++ b/QualityControl/lib/TObject2JsonClient.js
@@ -40,7 +40,7 @@ class TObject2JsonClient {
    * @param {number} timestamp - object's timestamp
    * @return {Promise.<Object|null, string>} The root data, null is not found
    */
-  retrieve(path, timestamp = 0) {
+  retrieve(path, timestamp = -1) {
     if (!path || path.indexOf('/') === -1) {
       return Promise.reject(new Error('Path should contain a slash at least'));
     }

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -138,7 +138,8 @@ function readObjectsData(req, res) {
 }
 
 /**
- * Read only data of an object specified by objectName
+ * Request data of an object based on name and optionally timestamp
+ * Returned data will contained the QC Object and a list of its corresponding timestamps
  * @param {Request} req
  * @param {Response} res
  */

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -158,7 +158,7 @@ async function readObjectData(req, res) {
   try {
     const qcObject = await model.readObjectData(objectName, timestamp);
     const timestamps = await model.getObjectTimestampList(objectName);
-    res.status(qcObject ? 200 : 404).json({qcObject: qcObject, timestamps: timestamps.slice(0, 20)});
+    res.status(qcObject ? 200 : 404).json({qcObject: qcObject, timestamps: timestamps.slice(0, 50)});
   } catch (err) {
     errorHandler('Reading object data: ' + err, res);
   }

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -14,6 +14,7 @@ module.exports.setup = (http) => {
   http.get('/readObjectData', readObjectData, {public: true});
   http.post('/readObjectsData', readObjectsData);
   http.get('/listObjects', listObjects, {public: true});
+  http.get('/objectTimestampList', getObjectTimestampList, {public: true});
   http.get('/listOnlineObjects', listOnlineObjects);
   http.get('/isOnlineModeConnectionAlive', isOnlineModeConnectionAlive);
   http.post('/readLayout', readLayout);
@@ -33,6 +34,20 @@ module.exports.setup = (http) => {
 function listObjects(req, res) {
   model.listObjects()
     .then((data) => res.status(200).json(data))
+    .catch((err) => errorHandler(err, res));
+}
+
+/**
+ * Method to retrieve a list of timestamps for the requested objectName
+ * @param {Request} req
+ * @param {Response} res
+ */
+function getObjectTimestampList(req, res) {
+  model.getObjectTimestampList(req.query.objectName)
+    .then((data) => {
+      res.status(200);
+      res.json(data);
+    })
     .catch((err) => errorHandler(err, res));
 }
 
@@ -115,13 +130,17 @@ function readObjectsData(req, res) {
  */
 function readObjectData(req, res) {
   const objectName = req.query.objectName;
-
+  let timestamp = 0;
+  if (req.query.timestamp) {
+    const ts = req.query.timestamp;
+    timestamp = typeof ts === 'string' ? parseInt(ts) : ts;
+  }
   if (!objectName) {
     res.status(400).send('parameter objectName is needed');
     return;
   }
 
-  model.readObjectData(objectName)
+  model.readObjectData(objectName, timestamp)
     .then((data) => res.status(data ? 200 : 404).json(data))
     .catch((err) => errorHandler('Reading object data: ' + err, res));
 }

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aliceo2/web-ui": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-1.11.3.tgz",
-      "integrity": "sha512-ecmwqQjmIVKdPo7Pw+CMZ7N9tTdEmKQSHZiuAGAI65S8FZMnGmlmD/7d1kAj+UuGB3PY/cqvZeJSkQw1XLmpSQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-1.12.0.tgz",
+      "integrity": "sha512-tabd8h6KeMXY23WIMezWtFBmUboqljVTt63dAmvVZLS6cX1VSThVkmsu8A3XX1puITmP0UawNVxKjig0eAN3Pw==",
       "requires": {
         "express": "^4.17.1",
         "helmet": "^3.21.2",
@@ -235,9 +235,9 @@
       }
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
@@ -293,9 +293,9 @@
       }
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -549,9 +549,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -1583,11 +1583,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "expect-ct": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
-      "integrity": "sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g=="
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1826,11 +1821,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
-    "frameguard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
-      "integrity": "sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g=="
-    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1993,15 +1983,13 @@
       "dev": true
     },
     "helmet": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.2.tgz",
-      "integrity": "sha512-pe0UiHw3aHbP8Lon9McCq4AN2XLUMSbhwxJnUY6U2t8wTda7F1SsYg0/pBa1BPugaRqAtx9e1/FyF6E9PsUU5A==",
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.3.tgz",
+      "integrity": "sha512-U3MeYdzPJQhtvqAVBPntVgAvNSOJyagwZwyKsFdyRa8TV3pOKVFljalPOCxbw5Wwf2kncGhmP0qHjyazIdNdSA==",
       "requires": {
         "depd": "2.0.0",
         "dont-sniff-mimetype": "1.1.0",
-        "expect-ct": "0.2.0",
         "feature-policy": "0.3.0",
-        "frameguard": "3.1.0",
         "helmet-crossdomain": "0.4.0",
         "helmet-csp": "2.10.0",
         "hide-powered-by": "1.1.0",
@@ -2441,9 +2429,9 @@
       }
     },
     "jose": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-1.27.1.tgz",
-      "integrity": "sha512-VyHM6IJPw0TTGqHVNlPWg16/ASDPAmcChcLqSb3WNBvwWFoWPeFqlmAUCm8/oIG1GjZwAlUDuRKFfycowarcVA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.28.0.tgz",
+      "integrity": "sha512-JmfDRzt/HSj8ipd9TsDtEHoLUnLYavG+7e8F6s1mx2jfVSfXOTaFQsJUydbjJpTnTDHP1+yKL9Ke7ktS/a0Eiw==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -3520,16 +3508,15 @@
       }
     },
     "openid-client": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.15.3.tgz",
-      "integrity": "sha512-KCwr4CgRWcw7BRuZHGdZ3vuqt2oRQ1WbQfcwvxnLBwcyqOXB+QljNiiB9m3hIzlarVKKIIVpFukOZo583kuzTA==",
+      "version": "3.15.9",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.15.9.tgz",
+      "integrity": "sha512-CNKMxM1oj4+JIWi/TQ4kGQuG2l5S/5yvSZ1wzz1fg+/fhD/MWRmqRB8GHW0EV+fbbSncDx9Lhoq04mu7S0/fbw==",
       "requires": {
         "@types/got": "^9.6.9",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
         "jose": "^1.27.1",
-        "lodash": "^4.17.15",
-        "lru-cache": "^5.1.1",
+        "lru-cache": "^6.0.0",
         "make-error": "^1.3.6",
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.0",
@@ -3537,17 +3524,17 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "^4.0.0"
           }
         },
         "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -4921,9 +4908,9 @@
       }
     },
     "ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "x-xss-protection": {
       "version": "1.3.0",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -29,7 +29,7 @@
     "mocha": "mocha --exit test/**/mocha-* --retries 2"
   },
   "dependencies": {
-    "@aliceo2/web-ui": "1.11.3",
+    "@aliceo2/web-ui": "1.12.0",
     "jsroot": "^5.8.0",
     "node-addon-api": "^1.6.3"
   },

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "description": "O2 Quality Control Web User Interface",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -35,8 +35,8 @@
 .resize-button { position: absolute; right: 0%; z-index: 100 }
 
 /* Removing borders and arrows from select-dropdown */
-select {-webkit-appearance: none;-moz-appearance: none;text-indent: 1px;text-overflow: '';}
-.select-tab {border: 0;border-bottom: 2px solid var(--color-blue);border-radius: 0;margin-bottom: -2px;color: var(--color-blue);}
+/* select {-webkit-appearance: none;-moz-appearance: none;text-indent: 1px;text-overflow: '';} */
+.select-tab {-webkit-appearance: none;-moz-appearance: none;text-indent: 1px;text-overflow: '';border: 0;border-bottom: 2px solid var(--color-blue);border-radius: 0;margin-bottom: -2px;color: var(--color-blue);}
 
 .checker-label{font-weight: bold; margin-bottom: 0; color: var(--color-gray-dark) }
 

--- a/QualityControl/public/common/infoButton.js
+++ b/QualityControl/public/common/infoButton.js
@@ -18,6 +18,10 @@ export default (object) => object.selected && !object.isOnlineModeEnabled &&
       h('.dropdown-menu', {style: 'right:0.1em; left: auto; white-space: nowrap;'}, [
         h('.m2.gray-darker.text-center', [
           h('.menu-title', {style: 'font-weight: bold; margin-bottom: 0'}, 'PATH'),
+          h('select.form-control', h('option', '2/3/2020, 1:54:05 PM'))
+        ]),
+        h('.m2.gray-darker.text-center', [
+          h('.menu-title', {style: 'font-weight: bold; margin-bottom: 0'}, 'PATH'),
           object.selected.name
         ]),
         h('.m2.gray-darker.text-center', [

--- a/QualityControl/public/common/infoButton.js
+++ b/QualityControl/public/common/infoButton.js
@@ -33,10 +33,6 @@ export default (object, isOnlineModeEnabled) => object.selected && !isOnlineMode
       h('.dropdown-menu', {style: 'right:0.1em; left: auto; white-space: nowrap;'}, [
         h('.m2.gray-darker.text-center', [
           h('.menu-title', {style: 'font-weight: bold; margin-bottom: 0'}, 'PATH'),
-          h('select.form-control', h('option', '2/3/2020, 1:54:05 PM'))
-        ]),
-        h('.m2.gray-darker.text-center', [
-          h('.menu-title', {style: 'font-weight: bold; margin-bottom: 0'}, 'PATH'),
           object.selected.name
         ]),
         h('.m2.gray-darker.text-center', [

--- a/QualityControl/public/common/infoButton.js
+++ b/QualityControl/public/common/infoButton.js
@@ -38,7 +38,7 @@ export default (object, isOnlineModeEnabled) => object.selected && !isOnlineMode
         h('.m2.gray-darker.text-center', [
           h('.menu-title', {style: 'font-weight: bold; margin-bottom: 0'}, 'LAST MODIFIED'),
           object.selected.lastModified ?
-            `${new Date(object.selected.lastModified).toLocaleString()}`
+            `${new Date(object.selected.lastModified).toLocaleString('en-UK')}`
             :
             'Loading...'
         ]),

--- a/QualityControl/public/common/timestampSelectForm.js
+++ b/QualityControl/public/common/timestampSelectForm.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {h} from '/js/src/index.js';
+
+/**
+ * Display a select form with the latest timestamps of the current selected object
+ * @param {Object} model
+ * @return {vnode}
+ */
+export default (model) => h('.w-100.flex-row',
+  model.object.selected && model.object.objects && model.object.objects[model.object.selected.name]
+  && model.object.objects[model.object.selected.name].kind === 'Success' &&
+  h('select.form-control.gray-darker.text-center.w-25', {
+    onchange: (e) => {
+      const value = e.target.value;
+      if (value !== 'Invalid Timestamp') {
+        model.object.loadObjectByName(model.object.selected.name, value);
+      }
+    }
+  }, [
+    model.object.getObjectTimestamps(model.object.selected.name)
+      .map((timestamp) => {
+        return h('option.text-center', {
+          value: timestamp,
+          selected: timestamp === model.object.selected.version ? true : false
+        }, [
+          model.object.getDateFromTimestamp(timestamp),
+          ' (',
+          timestamp,
+          ')'
+        ]);
+      })
+  ])
+);

--- a/QualityControl/public/common/timestampSelectForm.js
+++ b/QualityControl/public/common/timestampSelectForm.js
@@ -37,9 +37,7 @@ export default (model) => h('.w-100.flex-row',
           selected: timestamp === model.object.selected.version ? true : false
         }, [
           model.object.getDateFromTimestamp(timestamp),
-          ' (',
-          timestamp,
-          ')'
+          ' (', timestamp, ')'
         ]);
       })
   ])

--- a/QualityControl/public/common/timestampSelectForm.js
+++ b/QualityControl/public/common/timestampSelectForm.js
@@ -25,7 +25,7 @@ export default (model) => h('.w-100.flex-row',
   h('select.form-control.gray-darker.text-center.w-25', {
     onchange: (e) => {
       const value = e.target.value;
-      if (value !== 'Invalid Timestamp') {
+      if (model.object.selected && value !== 'Invalid Timestamp') {
         model.object.loadObjectByName(model.object.selected.name, value);
       }
     }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -511,7 +511,7 @@ export default class QCObject extends Observable {
     }
     const object = this.currentList.find((object) => object.name === objectName);
     if (object) {
-      return new Date(object.lastModified).toLocaleString();
+      return new Date(object.lastModified).toLocaleString('en-UK');
     }
     return '-';
   }
@@ -525,7 +525,7 @@ export default class QCObject extends Observable {
   getLastModifiedForSelected(displayDate = false) {
     if (this.selected && this.selected.lastModified) {
       return displayDate === 'date' ?
-        new Date(this.selected.lastModified).toLocaleString() : this.selected.lastModified.toString();
+        new Date(this.selected.lastModified).toLocaleString('en-UK') : this.selected.lastModified.toString();
     } else {
       return '-';
     }
@@ -551,7 +551,7 @@ export default class QCObject extends Observable {
    */
   getDateFromTimestamp(timestamp) {
     try {
-      return new Date(timestamp).toLocaleString();
+      return new Date(timestamp).toLocaleString('en-UK');
     } catch (_err) {
       return 'Invalid Timestamp';
     }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -287,10 +287,9 @@ export default class QCObject extends Observable {
         // eslint-disable-next-line
         this.objects[objectName] = RemoteData.success(JSROOT.JSONR_unref(result.payload));
       }
-      if (timestamp === -1) {
-        this.selected.version = parseInt(this.objects[objectName].payload.timestamps[0]);
-      } else {
-        this.selected.version = parseInt(timestamp);
+      if (this.selected) {
+        this.selected.version = timestamp === -1 ?
+          parseInt(this.objects[objectName].payload.timestamps[0]) : parseInt(timestamp);
       }
     } else {
       this.objects[objectName] = result;
@@ -416,15 +415,16 @@ export default class QCObject extends Observable {
   generateDrawingOptions(tabObject, objectRemoteData) {
     let objectOptionList = [];
     let drawingOptions = [];
-    if (objectRemoteData.payload.qcObject.fOption) {
-      objectOptionList = objectRemoteData.payload.qcObject.fOption.split(' ');
+    const qcObject = objectRemoteData.payload.qcObject;
+    if (qcObject.fOption) {
+      objectOptionList = qcObject.fOption.split(' ');
     }
-    if (objectRemoteData.payload.qcObject.metadata && objectRemoteData.payload.qcObject.metadata.drawOptions) {
-      const metaOpt = objectRemoteData.payload.qcObject.metadata.drawOptions.split(' ');
+    if (qcObject.metadata && qcObject.metadata.drawOptions) {
+      const metaOpt = qcObject.metadata.drawOptions.split(' ');
       objectOptionList = objectOptionList.concat(metaOpt);
     }
-    if (objectRemoteData.payload.qcObject.metadata && objectRemoteData.payload.qcObject.metadata.displayHints) {
-      const metaHints = objectRemoteData.payload.qcObject.metadata.displayHints.split(' ');
+    if (qcObject.metadata && qcObject.metadata.displayHints) {
+      const metaHints = qcObject.metadata.displayHints.split(' ');
       objectOptionList = objectOptionList.concat(metaHints);
     }
     switch (this.model.page) {

--- a/QualityControl/public/object/objectDraw.js
+++ b/QualityControl/public/object/objectDraw.js
@@ -130,8 +130,8 @@ export function draw(model, tabObject, options, location = '') {
       style: 'word-break: break-all;'
     }, objectRemoteData.payload);
   } else {
-    if (model.object.isObjectChecker(objectRemoteData.payload)) {
-      return checkersPanel(objectRemoteData.payload, location);
+    if (model.object.isObjectChecker(objectRemoteData.payload.qcObject)) {
+      return checkersPanel(objectRemoteData.payload.qcObject, location);
     }
   }
   // on success, JSROOT will erase all DOM inside div and put its own
@@ -175,7 +175,7 @@ function redrawOnDataUpdate(model, dom, tabObject) {
   if (
     objectRemoteData &&
     objectRemoteData.isSuccess() &&
-    !model.object.isObjectChecker(objectRemoteData.payload) &&
+    !model.object.isObjectChecker(objectRemoteData.payload.qcObject) &&
     (shouldRedraw || shouldCleanRedraw)
   ) {
     setTimeout(() => {
@@ -186,20 +186,20 @@ function redrawOnDataUpdate(model, dom, tabObject) {
         JSROOT.cleanup(dom);
       }
 
-      if (objectRemoteData.payload._typename === 'TGraph' &&
-        (objectRemoteData.payload.fOption === '' || objectRemoteData.payload.fOption === undefined)) {
-        objectRemoteData.payload.fOption = 'alp';
+      if (objectRemoteData.payload.qcObject._typename === 'TGraph' &&
+        (objectRemoteData.payload.qcObject.fOption === '' || objectRemoteData.payload.qcObject.fOption === undefined)) {
+        objectRemoteData.payload.qcObject.fOption = 'alp';
       }
 
       let drawingOptions = model.object.generateDrawingOptions(tabObject, objectRemoteData);
       drawingOptions = drawingOptions.join(';');
       drawingOptions += ';stat';
-      if (objectRemoteData.payload._typename !== 'TGraph') {
+      if (objectRemoteData.payload.qcObject._typename !== 'TGraph') {
         // Use user's defined options and add undocumented option "f" allowing color changing on redraw (color is fixed without it)
         drawingOptions += ';f';
       }
 
-      JSROOT.draw(dom, objectRemoteData.payload,"px:py::pz>5", (painter) => {
+      JSROOT.draw(dom, objectRemoteData.payload.qcObject, drawingOptions, (painter) => {
         if (painter === null) {
           // jsroot failed to paint it
           model.object.invalidObject(tabObject.name);

--- a/QualityControl/public/object/objectDraw.js
+++ b/QualityControl/public/object/objectDraw.js
@@ -189,7 +189,7 @@ function redrawOnDataUpdate(model, dom, tabObject) {
         drawingOptions += ';f';
       }
 
-      JSROOT.redraw(dom, objectRemoteData.payload, drawingOptions, (painter) => {
+      JSROOT.draw(dom, objectRemoteData.payload,"px:py::pz>5", (painter) => {
         if (painter === null) {
           // jsroot failed to paint it
           model.object.invalidObject(tabObject.name);

--- a/QualityControl/public/object/objectDraw.js
+++ b/QualityControl/public/object/objectDraw.js
@@ -178,6 +178,7 @@ function redrawOnDataUpdate(model, dom, tabObject) {
     !model.object.isObjectChecker(objectRemoteData.payload.qcObject) &&
     (shouldRedraw || shouldCleanRedraw)
   ) {
+    const qcObject = objectRemoteData.payload.qcObject;
     setTimeout(() => {
       if (JSROOT.cleanup) {
         // Remove previous JSROOT content before draw to do a real redraw.
@@ -186,20 +187,19 @@ function redrawOnDataUpdate(model, dom, tabObject) {
         JSROOT.cleanup(dom);
       }
 
-      if (objectRemoteData.payload.qcObject._typename === 'TGraph' &&
-        (objectRemoteData.payload.qcObject.fOption === '' || objectRemoteData.payload.qcObject.fOption === undefined)) {
-        objectRemoteData.payload.qcObject.fOption = 'alp';
+      if (qcObject._typename === 'TGraph' && (qcObject.fOption === '' || qcObject.fOption === undefined)) {
+        qcObject.fOption = 'alp';
       }
 
       let drawingOptions = model.object.generateDrawingOptions(tabObject, objectRemoteData);
       drawingOptions = drawingOptions.join(';');
       drawingOptions += ';stat';
-      if (objectRemoteData.payload.qcObject._typename !== 'TGraph') {
+      if (qcObject._typename !== 'TGraph') {
         // Use user's defined options and add undocumented option "f" allowing color changing on redraw (color is fixed without it)
         drawingOptions += ';f';
       }
 
-      JSROOT.draw(dom, objectRemoteData.payload.qcObject, drawingOptions, (painter) => {
+      JSROOT.draw(dom, qcObject, drawingOptions, (painter) => {
         if (painter === null) {
           // jsroot failed to paint it
           model.object.invalidObject(tabObject.name);

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -157,7 +157,9 @@ function treeRow(model, tree, level) {
         ' ',
         tree.name
       ]),
-      h('td.highlight.w-33', h('.w-100.text-center', lastModified)),
+      h('td.highlight.w-33',
+          lastModified && h('select.form-control.text-center',
+            h('option', lastModified))),
     ]),
     children
   ];

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -51,6 +51,9 @@ function drawComponent(model) {
   return h('', {style: 'height:100%; display: flex; flex-direction: column'},
     [
       h('.resize-button.flex-row', [
+        h('.p1.text-left', {style: 'padding-bottom: 0;'},
+          h('select.form-control', h('option', '2/3/2020, 1:54:05 PM'))
+        ),
         infoButton(model.object),
         h('.p1.text-left', {style: 'padding-bottom: 0;'},
           h('a.btn',
@@ -157,9 +160,7 @@ function treeRow(model, tree, level) {
         ' ',
         tree.name
       ]),
-      h('td.highlight.w-33',
-          lastModified && h('select.form-control.text-center',
-            h('option', lastModified))),
+      h('td.highlight.w-33', h('.w-100.text-center', lastModified)),
     ]),
     children
   ];

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -16,6 +16,7 @@ import {h, iconBarChart, iconCaretRight, iconResizeBoth, iconCaretBottom} from '
 import spinner from '../loader/spinner.js';
 import {draw} from './objectDraw.js';
 import infoButton from './../common/infoButton.js';
+import timestampSelectForm from './../common/timestampSelectForm.js';
 import virtualTable from './virtualTable.js';
 
 /**
@@ -77,7 +78,7 @@ function drawComponent(model) {
       h('', {style: 'height:100%; display: flex; flex-direction: column'},
         draw(model, model.object.selected.name, {stat: true}, 'treePage')
       ),
-      h('.gray-darker.text-center', model.object.getLastModifiedForSelected('date')),
+      h('.w-100.flex-row', {style: 'justify-content: center'}, h('.w-50', timestampSelectForm(model)))
     ]
   );
 }
@@ -158,7 +159,6 @@ function treeRow(model, tree, level) {
   const children = tree.open ? tree.children.map((children) => treeRow(model, children, levelDeeper)) : [];
   const path = tree.path.join('/');
   const className = tree.object && tree.object === model.object.selected ? 'table-primary' : '';
-  const lastModified = tree.object ? new Date(tree.object.lastModified).toLocaleString() : '';
 
   if (model.object.searchInput) {
     return [];

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -105,7 +105,7 @@ const tableShow = (model) =>
     h('thead', [
       h('tr', [
         h('th', 'Name'),
-        h('th', {style: {width: '6em'}}, 'Quality'),
+        h('th.w-33.text-right', {}, h('.w-100.text-center', 'Last Modified')),
       ])
     ]),
     h('tbody', [
@@ -140,7 +140,6 @@ const treeRows = (model) => !model.object.tree ?
  * @return {vnode}
  */
 function treeRow(model, tree, level) {
-  const color = tree.quality === 'good' ? 'success' : 'danger';
   const padding = `${level}em`;
   const levelDeeper = level + 1;
   const icon = tree.object ? iconBarChart() : (tree.open ? iconCaretBottom() : iconCaretRight()); // 1 of 3 icons
@@ -149,6 +148,7 @@ function treeRow(model, tree, level) {
   const path = tree.path.join('/');
   const selectItem = tree.object ? () => model.object.select(tree.object) : () => tree.toggle();
   const className = tree.object && tree.object === model.object.selected ? 'table-primary' : '';
+  const lastModified = tree.object ? new Date(tree.object.lastModified).toLocaleString() : '';
 
   return model.object.searchInput ? [] : [
     h('tr.object-selectable', {key: path, title: path, onclick: selectItem, class: className}, [
@@ -157,7 +157,7 @@ function treeRow(model, tree, level) {
         ' ',
         tree.name
       ]),
-      h('td.highlight', {class: color}, tree.quality),
+      h('td.highlight.w-33', h('.w-100.text-center', lastModified)),
     ]),
     children
   ];

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -65,7 +65,6 @@ function getActionsHeader(model) {
       getBackToQCGButton(model),
       h('.text-center.flex-column', {style: 'flex-grow:1'}, [
         h('b', getObjectTitle(model)),
-        // h('.gray-darker.text-center.f6', model.object.getLastModifiedForSelected('date')),
         h('.w-100.flex-row', {style: 'justify-content: center'},
           h('.w-25.p2.f6', timestampSelectForm(model))
         )

--- a/QualityControl/public/object/view/objectViewPage.js
+++ b/QualityControl/public/object/view/objectViewPage.js
@@ -15,6 +15,7 @@
 import {h, iconBook, iconCircleX, iconArrowThickLeft} from '/js/src/index.js';
 import {draw} from './../objectDraw.js';
 import infoButton from './../../common/infoButton.js';
+import timestampSelectForm from '../../common/timestampSelectForm.js';
 
 /**
  * Shows a page to view an object on the whole page
@@ -64,7 +65,10 @@ function getActionsHeader(model) {
       getBackToQCGButton(model),
       h('.text-center.flex-column', {style: 'flex-grow:1'}, [
         h('b', getObjectTitle(model)),
-        h('.gray-darker.text-center.f6', model.object.getLastModifiedForSelected('date')),
+        // h('.gray-darker.text-center.f6', model.object.getLastModifiedForSelected('date')),
+        h('.w-100.flex-row', {style: 'justify-content: center'},
+          h('.w-25.p2.f6', timestampSelectForm(model))
+        )
       ]),
       h('.flex-row', [
         infoButton(model.object, model.isOnlineModeEnabled),

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -65,12 +65,14 @@ export default class QCObjectService {
   }
 
   /**
-  * Ask server for an object by name
-  * @param {string} objectName
-  * @return {JSON} {result, ok, status}
-  */
-  async getObjectByName(objectName) {
-    const {result, ok, status} = await this.model.loader.get(`/api/readObjectData?objectName=${objectName}`);
+   * Ask server for an object by name
+   * @param {string} objectName
+   * @param {number} timestamp
+   * @return {JSON} {result, ok, status}
+   */
+  async getObjectByName(objectName, timestamp = -1) {
+    const {result, ok, status} =
+      await this.model.loader.get(`/api/readObjectData?objectName=${objectName}&timestamp=${timestamp}`);
     if (ok) {
       return RemoteData.success(result);
     } else if (status === 404) {

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -65,7 +65,8 @@ export default class QCObjectService {
   }
 
   /**
-   * Ask server for an object by name
+   * Ask server for an object by name and optionally timestamp
+   * If timestamp is not provided, -1 will be used to request latest version of the object
    * @param {string} objectName
    * @param {number} timestamp
    * @return {JSON} {result, ok, status}

--- a/QualityControl/test/lib/mocha-ccdb-connector.js
+++ b/QualityControl/test/lib/mocha-ccdb-connector.js
@@ -87,19 +87,58 @@ describe('CCDB Connector test suite', () => {
     });
   });
 
-  describe('`itemTransform()` tests', () => {
+  describe('`getObjectTimestampList()` tests', () => {
+    it('should successfully return a list of timestamps for a specific object', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      const objects = [
+        {path: 'object/one', createTime: '101', lastModified: '102', id: 'id', metadata: []},
+        {path: 'object/one', createTime: '101', lastModified: '103', id: 'id', metadata: []},
+        {path: 'object/one', createTime: '101', lastModified: '104', id: 'id', metadata: []},
+      ];
+      const expectedTimestamps = [102, 103, 104];
+      nock('http://ccdb:8500')
+        .get('/browse/object/one')
+        .reply(200, {objects: objects, subfolders: []});
+
+      await ccdb.getObjectTimestampList('object/one').then((result) => {
+        assert.deepStrictEqual(result, expectedTimestamps);
+      });
+    });
+
+    it('should successfully return an empty list due to empty reply from CCDB', async () => {
+      const ccdb = new CCDBConnector(config.ccdb);
+      nock('http://ccdb:8500')
+        .get('/browse/object/one')
+        .reply(200, {objects: [], subfolders: []});
+
+      await ccdb.getObjectTimestampList('object/one').then((result) => {
+        assert.deepStrictEqual(result, []);
+      });
+    });
+  });
+
+  describe('`itemTransform()` & `isItemValid() tests', () => {
     let ccdb;
     before(() => ccdb = new CCDBConnector(config.ccdb));
 
-    it('should successfully return null for an item with missing path', () => {
-      assert.strictEqual(ccdb.itemTransform({}), null);
-      assert.strictEqual(ccdb.itemTransform({path: undefined}), null);
-      assert.strictEqual(ccdb.itemTransform({path: null}), null);
-      assert.strictEqual(ccdb.itemTransform({path: ''}), null);
+    it('should successfully return false for an item with missing path', () => {
+      assert.strictEqual(ccdb.isItemValid({}), false);
+      assert.strictEqual(ccdb.isItemValid({path: undefined}), false);
+      assert.strictEqual(ccdb.isItemValid({path: false}), false);
+      assert.strictEqual(ccdb.isItemValid({path: ''}), false);
     });
-    it('should successfully return null for an item with a path missing a forward slash(/)', () => {
-      assert.strictEqual(ccdb.itemTransform({path: 'wrongPath'}), null);
+
+    it('should successfully return false for an item with a path missing a forward slash(/)', () => {
+      assert.strictEqual(ccdb.isItemValid({path: 'wrongPath'}), false);
     });
+
+    it('should successfully return true for an item that fits criteria', () => {
+      const item = {
+        path: 'correct/path', createTime: '101', lastModified: '102', id: 'id', metadata: []
+      };
+      assert.deepStrictEqual(ccdb.isItemValid(item), true);
+    });
+
     it('should successfully return a JSON with 3 fields if item fits criteria', () => {
       const item = {
         path: 'correct/path', createTime: '101', lastModified: '102', id: 'id', metadata: []

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -420,7 +420,7 @@ describe('QCG', function() {
         });
         assert.strictEqual(result.title, objectName);
         assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-        assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100});
+        assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 3, lastModified: 100, version: null});
       });
 
       it('should have an info button with full path and last modified when clicked (plot success)', async () => {
@@ -459,7 +459,7 @@ describe('QCG', function() {
         });
         assert.strictEqual(result.title, objectName);
         assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'p2', 2: 'flex-column', 3: 'scroll-y'});
-        assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 2, lastModified: 100});
+        assert.deepStrictEqual(result.objectSelected, {name: objectName, createTime: 2, lastModified: 100, version: null});
       });
     });
 
@@ -562,7 +562,7 @@ describe('QCG', function() {
         await page.waitFor(7000);
         assert.strictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(AliRoot)');
         assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-        assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
+        assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100, version: null});
       });
 
       it('should have an info button with full path and last modified when clicked (plot success)', async () => {
@@ -628,7 +628,7 @@ describe('QCG', function() {
     it('should merge options on layoutShow and no ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -639,7 +639,7 @@ describe('QCG', function() {
     it('should merge options on layoutShow and false ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {
         const tabObject = {ignoreDefaults: false, options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -650,7 +650,7 @@ describe('QCG', function() {
     it('should ignore default options on layoutShow and true ignoreDefaults field', async () => {
       const drawingOptions = await page.evaluate(() => {
         const tabObject = {ignoreDefaults: true, options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -662,7 +662,7 @@ describe('QCG', function() {
       const drawingOptions = await page.evaluate(() => {
         window.model.page = 'objectTree';
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -676,7 +676,7 @@ describe('QCG', function() {
         window.model.router.params.objectId = undefined;
         window.model.router.params.layoutId = undefined;
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz', metadata: {displayHints: 'hint hint2', drawOptions: 'option option2'}}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz', metadata: {displayHints: 'hint hint2', drawOptions: 'option option2'}}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -690,7 +690,7 @@ describe('QCG', function() {
         window.model.router.params.layoutId = undefined;
         window.model.router.params.objectId = '123';
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -705,7 +705,7 @@ describe('QCG', function() {
         window.model.router.params.objectId = undefined;
         window.model.router.params.layoutId = '123';
         const tabObject = {options: ['args', 'coly']};
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(tabObject, objectRemoteData);
       });
 
@@ -726,7 +726,7 @@ describe('QCG', function() {
             options: ['gridx'], name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
           }]
         }];
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 
@@ -747,7 +747,7 @@ describe('QCG', function() {
             options: ['gridx'], ignoreDefaults: false, name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
           }]
         }];
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 
@@ -768,7 +768,7 @@ describe('QCG', function() {
             options: ['gridx'], ignoreDefaults: true, name: 'DAQ01/EquipmentSize/CPV/CPV', x: 0, y: 0, w: 1, h: 1
           }]
         }];
-        const objectRemoteData = {payload: {fOption: 'lego colz'}};
+        const objectRemoteData = {payload: {qcObject: {fOption: 'lego colz'}}};
         return window.model.object.generateDrawingOptions(null, objectRemoteData);
       });
 

--- a/QualityControl/tobject2json.cc
+++ b/QualityControl/tobject2json.cc
@@ -19,9 +19,7 @@ public:
 protected:
   void Execute() override
   {
-    const auto slashIndex = path.find_first_of('/');
-    // output = BackendInstance->retrieveMOJson(path.substr(0, slashIndex), path.substr(slashIndex + 1), timestamp);
-    output = BackendInstance->retrieveJson(path);
+    output = BackendInstance->retrieveJson(path, timestamp);
   }
 
   void OnOK() override

--- a/QualityControl/tobject2json.cc
+++ b/QualityControl/tobject2json.cc
@@ -19,7 +19,8 @@ public:
 protected:
   void Execute() override
   {
-    output = BackendInstance->retrieveJson(path, timestamp);
+    std::map<std::string, std::string> metadata;
+    output = BackendInstance->retrieveJson(path, timestamp, metadata);
   }
 
   void OnOK() override
@@ -89,8 +90,7 @@ void GetObject(const Napi::CallbackInfo& info) {
 
   Napi::Function cb = info[2].As<Napi::Function>();
   std::string path = info[0].As<Napi::String>();
-  long timestamp = info[1].As<Napi::Number>().Int32Value();
-
+  uint64_t timestamp = info[1].As<Napi::Number>().Int64Value();
   (new TObjectAsyncWorker(cb, path, timestamp))->Queue();
 
   return;


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

**Acceptance Criteria:**
History of a timestamp feature is present on pages `objectTree` and `objectView`.  
For both pages:
* Select an object to display (e.g  `qc/TST/External-1/hello_0`)
* Click `i` (info) button to see last modified timestamp
* Ensure last modified timestamp from info panel is the same as the timestamp from the dropdown
* Select a different timestamp (preferably a few hours older so that plot difference it's easily seen) from the dropdown (bottom in the `objectTree` page and top for `objectView`)
* Ensure plot changed
* Ensure  info panel still displays the correct last modified timestamp. It  should not change
* Select a different object (this will request latest information of the object)
* Ensure last modified timestamp from info panel is the same as the timestamp from the dropdown
