### PR TITLE
[OGUI-705] Improve show of user vars

### DIFF
--- a/Control/public/app.css
+++ b/Control/public/app.css
@@ -40,4 +40,5 @@ tr:hover td { background-color: var(--color-gray-light)}
 .none-selected-btn:hover  { background-color: var(--color-gray);}
 .selected-btn { margin-left: .7em; background-color: var(--color-primary); color: var(--color-white); padding: .4em .5em;}
 
+.overflow { height: 1.5rem; overflow: hidden; text-overflow: ellipsis; word-break: break-all; }
 .w-15 { width: 15%; }

--- a/Control/public/app.css
+++ b/Control/public/app.css
@@ -39,3 +39,5 @@ tr:hover td { background-color: var(--color-gray-light)}
 .none-selected-btn { margin-left: .7em; background-color: var(--color-gray-darker); color: var(--color-white); padding: .4em .5em;}
 .none-selected-btn:hover  { background-color: var(--color-gray);}
 .selected-btn { margin-left: .7em; background-color: var(--color-primary); color: var(--color-white); padding: .4em .5em;}
+
+.w-15 { width: 15%; }

--- a/Control/public/environment/Environment.js
+++ b/Control/public/environment/Environment.js
@@ -36,6 +36,8 @@ export default class Environment extends Observable {
     this.itemNew = RemoteData.notAsked();
     this.plots = RemoteData.notAsked();
 
+    this.expandUserVars = false;
+
     this.getPlotsList();
   }
 

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -180,14 +180,7 @@ const showEnvDetailsTable = (item, environment) =>
             )
           ),
           h('td.flex-row', !environment.expandUserVars ?
-            h('.mh2.overflow', [
-              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
-              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
-              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
-              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
-              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
-
-            ])
+            h('.mh2.overflow', JSON.stringify(item.userVars))
             :
             h('.flex-column', [
               Object.keys(item.userVars).map((key) =>

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -180,7 +180,14 @@ const showEnvDetailsTable = (item, environment) =>
             )
           ),
           h('td.flex-row', !environment.expandUserVars ?
-            h('.mh2', JSON.stringify(item.userVars))
+            h('.mh2.overflow', [
+              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
+              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
+              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
+              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
+              JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),JSON.stringify(item.userVars),
+
+            ])
             :
             h('.flex-column', [
               Object.keys(item.userVars).map((key) =>

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -86,7 +86,7 @@ const showContent = (environment, item) => [
       })
     ]
   ),
-  showEnvDetailsTable(item),
+  showEnvDetailsTable(item, environment),
   h('.m2', [
     h('h4', 'Tasks'),
     h('.flex-row.flex-grow',
@@ -132,44 +132,70 @@ const showEmbeddedGraphs = (data) =>
 /**
  * Table to display Environment details
  * @param {Object} item - object to be shown
+ * @param {Environment} environment
  * @return {vnode} table view
  */
-const showEnvDetailsTable = (item) =>
+const showEnvDetailsTable = (item, environment) =>
   h('.m2.mv4.shadow-level1',
     h('table.table', [
       h('tbody', [
         h('tr', [
-          h('th', 'Number of Tasks'),
+          h('th.w-15', 'Number of Tasks'),
           h('td', item.tasks.length)
         ]),
         h('tr', [
-          h('th', 'ID'),
+          h('th.w-15', 'ID'),
           h('td', item.id)
         ]),
         h('tr', [
-          h('th', 'Created'),
+          h('th.w-15', 'Created'),
           h('td', new Date(item.createdWhen).toLocaleString())
         ]),
         h('tr', [
-          h('th', 'State'),
+          h('th.w-15', 'State'),
           h('td',
             {
-              class: item.state === 'RUNNING' ? 'success' : (item.state === 'CONFIGURED' ? 'warning' : ''),
+              class: item.state === 'RUNNING' ?
+                'success' :
+                (item.state === 'CONFIGURED' ? 'warning' : (item.state === 'ERROR' ? 'danger' : '')),
               style: 'font-weight: bold;'
             },
             item.state)
         ]),
         h('tr', [
-          h('th', 'Root Role'),
+          h('th.w-15', 'Root Role'),
           h('td', item.rootRole)
         ]),
         h('tr', [
-          h('th', 'User Vars'),
-          h('td', JSON.stringify(item.userVars))
+          h('th.w-15',
+            h('.flex-row', [
+              h('.w-75', 'User Vars'),
+              h('.w-25.text-right.mh2.actionable-icon', {
+                onclick: () => {
+                  environment.expandUserVars = !environment.expandUserVars;
+                  environment.notify();
+                }
+              }, environment.expandUserVars ? iconChevronTop() : iconChevronBottom()
+              )]
+            )
+          ),
+          h('td.flex-row', !environment.expandUserVars ?
+            h('.mh2', JSON.stringify(item.userVars))
+            :
+            h('.flex-column', [
+              Object.keys(item.userVars).map((key) =>
+                h('.mh2.flex-row', [
+                  h('', {style: 'font-weight: bold'}, key + ':'),
+                  h('', {
+                    style: 'word-break: break-word'
+                  }, JSON.stringify(item.userVars[key]))
+                ])
+              ),
+            ]),
+          )
         ])
       ])
-    ]
-    )
+    ])
   );
 
 /**
@@ -264,7 +290,7 @@ const showEnvTasksTable = (environment, tasks) => h('.scroll-auto.shadow-level1'
         h('td', task.status),
         h('td', {
           class: (task.state === 'RUNNING' ?
-            'success' : (task.state === 'CONFIGURED' ? 'warning' : '')),
+            'success' : (task.state === 'CONFIGURED' ? 'warning' : (task.state === 'ERROR' ? 'danger' : ''))),
           style: 'font-weight: bold;'
         }, task.state),
         h('td', task.deploymentInfo.hostname),

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -83,7 +83,7 @@ const environmentsTable = (model, list) => {
         h('td', {
           class: (item.state === 'RUNNING' ?
             'success'
-            : (item.state === 'CONFIGURED' ? 'warning' : '')),
+            : (item.state === 'CONFIGURED' ? 'warning' : (item.state === 'ERROR' ? 'danger' : ''))),
           style: 'font-weight: bold; text-align: center;'
         }, item.state
         ),


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

`ERROR` state will now be displayed with red 
`UserVars` row will be displayed by default as one fixed row and the user will be able to expand it so that it can see all the information if needed. This was done so that configurations with more than 100 machines will not take a big size of the screen
