### PR TITLE
[OGUI-685] Fix undefined if list is reloading

### DIFF
--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -63,14 +63,17 @@ export default (model) => h('.h-100.flex-column', {key: model.router.params.page
  */
 function objectPanel(model) {
   const selectedObjectName = model.object.selected.name;
-  return model.object.objects[selectedObjectName].match({
-    NotAsked: () => null,
-    Loading: () => h('.h-100.w-100.flex-column.items-center.justify-center.f5', [
-      spinner(3), h('', 'Loading Object')]),
-    Success: () => drawPlot(model),
-    Failure: () => h('.h-100.w-100.flex-column.items-center.justify-center.f5', [
-      h('.f1', iconCircleX()), 'Unable to get data for the selected object']),
-  });
+  if (model.object.objects && model.object.objects[selectedObjectName]) {
+    return model.object.objects[selectedObjectName].match({
+      NotAsked: () => null,
+      Loading: () => h('.h-100.w-100.flex-column.items-center.justify-center.f5', [
+        spinner(3), h('', 'Loading Object')]),
+      Success: () => drawPlot(model),
+      Failure: () => h('.h-100.w-100.flex-column.items-center.justify-center.f5', [
+        h('.f1', iconCircleX()), 'Unable to get data for the selected object']),
+    });
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

When the list of objects is reloading, the selected object to be plotted losses its content and throws an undefined error.
Added check to make sure the selected object panel is displayed only if content is present.