### PR TITLE
[OGUI-723] Improve 404 message consul for links configuration page

### DIFF
--- a/Control/lib/ConsulConnector.js
+++ b/Control/lib/ConsulConnector.js
@@ -132,8 +132,8 @@ class ConsulConnector {
         res.status(200).json(crusWithConfigByHost);
       } catch (error) {
         if (error.toString().includes('404')) {
-          const missingKVErrorMessage = `No value found for one of the keys:
-          ${this.flpHardwarePath}\nor\n${this.readoutCardPath}`;
+          const missingKVErrorMessage = 'No value found for one of the keys:\n' +
+            `${this.flpHardwarePath}\nor\n${this.readoutCardPath}`;
           errorHandler(missingKVErrorMessage, res, 404);
         } else {
           errorHandler(error, res, 502);

--- a/Control/lib/ConsulConnector.js
+++ b/Control/lib/ConsulConnector.js
@@ -131,7 +131,13 @@ class ConsulConnector {
         const crusWithConfigByHost = await this._getCrusConfigById(crusByHost);
         res.status(200).json(crusWithConfigByHost);
       } catch (error) {
-        errorHandler(error, res, 502);
+        if (error.toString().includes('404')) {
+          const missingKVErrorMessage = `No value found for one of the keys:
+          ${this.flpHardwarePath}\nor\n${this.readoutCardPath}`;
+          errorHandler(missingKVErrorMessage, res, 404);
+        } else {
+          errorHandler(error, res, 502);
+        }
       }
     } else {
       errorHandler('Unable to retrieve configuration of the CRUs', res, 502);

--- a/Control/public/app.css
+++ b/Control/public/app.css
@@ -15,8 +15,8 @@
 /*
  * App specific CSS styles
  */
-.pageLoading { font-size: 10em; color: var(--color-dark); margin: var(--space-l); line-height: 1; }
-.errorPage { font-size: 10em; color: var(--color-dark); margin: var(--space-l); line-height: 1; }
+.pageLoading { font-size: 5em; color: var(--color-dark); margin: var(--space-l); line-height: 1; }
+.errorPage { font-size: 3em; color: var(--color-dark); margin: var(--space-l); line-height: 1; }
 
 .disabled-content { pointer-events: none; opacity: 0.5; }
 

--- a/Control/public/common/errorPage.js
+++ b/Control/public/common/errorPage.js
@@ -21,5 +21,5 @@ import {h, iconCircleX} from '/js/src/index.js';
  */
 export default (error) => h('.flex-column items-center justify-center', [
   h('span.errorPage', iconCircleX()),
-  h('p.text-center.danger.measure-narrow', error)
+  h('span.text-center.danger.measure-narrow', {style: 'white-space: pre-line'},error)
 ]);

--- a/Control/test/lib/mocha-consul-connector.js
+++ b/Control/test/lib/mocha-consul-connector.js
@@ -219,7 +219,7 @@ describe('ConsulConnector test suite', () => {
         consulKvStoreReadout: 'localhost:8550/test/ui/some-cluster/kv/test/o2/readout/components',
         consulQcPrefix: 'localhost:8550/test/o2/qc/components/',
         consulReadoutPrefix: 'localhost:8550/test/o2/readout/components/',
-        flps: [ 'flpTwo' ]
+        flps: ['flpTwo']
       }));
     });
 
@@ -247,6 +247,28 @@ describe('ConsulConnector test suite', () => {
 
       assert.ok(res.status.calledWith(502));
       assert.ok(res.send.calledWith({message: 'Unable to retrieve configuration of consul service'}));
+    });
+  });
+
+  describe('Request CRUs with Configuration', async () => {
+    let consulService;
+    beforeEach(() => {
+      res = {
+        status: sinon.stub(),
+        json: sinon.stub(),
+        send: sinon.stub()
+      };
+      consulService = {};
+    });
+    it('should successfully respond with 404 when key is not found', async () => {
+      consulService.getOnlyRawValuesByKeyPrefix = sinon.stub().rejects(new Error('404-key not found'))
+
+      const connector = new ConsulConnector(consulService, config);
+      await connector.getCRUsWithConfiguration(null, res);
+
+      assert.ok(res.status.calledWith(404));
+      assert.ok(res.send.calledWith({
+        message: `No value found for one of the keys:\ntest/o2/hardware/flps\nor\ntest/o2/readoutcard/components`}));
     });
   });
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

By default, Consul will respond with 404 if no key is found with the requested prefix. Due to this, an error message will be shown to the user that there was a problem with Consul.

This PR will improve the message on the links configuration page so that if Consul replies with 404, a custom error message will be displayed informing the user about the keys that we tried to retrieve information for and the fact that there were none. 

By doing so, the user will be able to check themselves if the FLP deployment was correct and why the configurations are not stored as expected.

Moreover, the sizes of the `error` and `loading` icon pages were reduced. 