### PR TITLE
Bump Control version to v1.11.2 to include newest Framework

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "ALICE O2 Control GUI",
   "author": "Adam Wegrzynek",
   "contributors": [


### PR DESCRIPTION
This was missed in https://github.com/AliceO2Group/WebUi/pull/669