### PR TITLE
[OGUI-794] Add retry to bad MySQL Connections

### DIFF
--- a/InfoLogger/config-default.js
+++ b/InfoLogger/config-default.js
@@ -31,7 +31,8 @@ module.exports = {
     password: 'root',
     database: 'INFOLOGGER',
     port: 3306,
-    timeout: 60000
+    timeout: 60000,
+    retryMs: 5000
   },
 
   // optional data source, comment object if not used

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Infologger GUI to query and stream log events",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -274,7 +274,7 @@ export default class Model extends Observable {
           this.frameworkInfo.payload.mysql.status = message.payload;
         }
         this.notify();
-        if (!message.payload.ok) {
+        if (!message.payload.ok && this.log.activeMode === MODE.QUERY) {
           this.notification.show(
             `SQL QUERY System is unavailable. Retrying in 5 seconds`, 'warning', 2000);
         } else {

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -299,7 +299,7 @@ export default class Log extends Observable {
    * `list` is then reset and filled with result.
    */
   async query() {
-    if (!this.model.servicesResult.isSuccess() || !this.model.servicesResult.payload.query) {
+    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
       throw new Error('Query service is not available');
     }
     this.queryResult = RemoteData.loading();
@@ -373,8 +373,8 @@ export default class Log extends Observable {
     if (!this.model.ws.authed) {
       throw new Error('WS is not yet ready');
     }
-    if (!this.model.servicesResult.isSuccess() || !this.model.servicesResult.payload.live) {
-      throw new Error(`Live service is not available due to: ${JSON.stringify(this.model.servicesResult)}`);
+    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.infoLoggerServer.status.ok) {
+      throw new Error(`Live service is not available`);
     }
     if (this.isLiveModeRunning()) {
       throw new Error('Live already enabled');

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -103,12 +103,12 @@ const saveUserProfileMenuItem = (model) =>
  * @param {Object} model
  * @return {vnode}
  */
-const queryButton = (model) => h('button.btn', model.servicesResult.match({
+const queryButton = (model) => h('button.btn', model.frameworkInfo.match({
   NotAsked: () => ({disabled: true}),
   Loading: () => ({disabled: true, className: 'loading'}),
-  Success: (services) => ({
-    title: services.query ? 'Query database with filters (Enter)' : 'Query service not configured',
-    disabled: !services.query || model.log.queryResult.isLoading(),
+  Success: (frameworkInfo) => ({
+    title: frameworkInfo.mysql.status.ok ? 'Query database with filters (Enter)' : 'Query service not configured',
+    disabled: !frameworkInfo.mysql.status.ok || model.log.queryResult.isLoading(),
     className: model.log.queryResult.isLoading() ? 'loading' : queryButtonType,
     onclick: () => toggleButtonStates(model, false)
   }),
@@ -124,12 +124,12 @@ const queryButton = (model) => h('button.btn', model.servicesResult.match({
  * @param {Object} model
  * @return {vnode}
  */
-const liveButton = (model) => h('button.btn', model.servicesResult.match({
+const liveButton = (model) => h('button.btn', model.frameworkInfo.match({
   NotAsked: () => ({disabled: true}),
   Loading: () => ({disabled: true, className: 'loading'}),
-  Success: (services) => ({
-    title: services.live ? 'Stream logs with filtering' : 'Live service not configured',
-    disabled: !services.live || model.log.queryResult.isLoading(),
+  Success: (frameworkInfo) => ({
+    title: frameworkInfo.infoLoggerServer.status.ok ? 'Stream logs with filtering' : 'Live service not configured',
+    disabled: !frameworkInfo.infoLoggerServer.status.ok || model.log.queryResult.isLoading(),
     className: !model.ws.authed ? 'loading' : liveButtonType,
     onclick: () => toggleButtonStates(model, true)
   }),

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -107,8 +107,9 @@ const queryButton = (model) => h('button.btn', model.frameworkInfo.match({
   NotAsked: () => ({disabled: true}),
   Loading: () => ({disabled: true, className: 'loading'}),
   Success: (frameworkInfo) => ({
-    title: frameworkInfo.mysql.status.ok ? 'Query database with filters (Enter)' : 'Query service not configured',
-    disabled: !frameworkInfo.mysql.status.ok || model.log.queryResult.isLoading(),
+    title: (frameworkInfo.mysql && frameworkInfo.mysql.status.ok)
+      ? 'Query database with filters (Enter)' : 'Query service not configured',
+    disabled: !frameworkInfo.mysql || !frameworkInfo.mysql.status.ok || model.log.queryResult.isLoading(),
     className: model.log.queryResult.isLoading() ? 'loading' : queryButtonType,
     onclick: () => toggleButtonStates(model, false)
   }),

--- a/InfoLogger/public/log/statusBar.js
+++ b/InfoLogger/public/log/statusBar.js
@@ -36,12 +36,12 @@ export default (model) => [
  * @param {object} model
  * @return {vnode}
  */
-const statusLogs = (model) => model.servicesResult.match({
+const statusLogs = (model) => model.frameworkInfo.match({
   NotAsked: () => 'Loading services...',
   Loading: () => 'Loading services...',
-  Success: (services) => [
+  Success: (frameworkInfo) => [
     statusStats(model),
-    model.log.isLiveModeRunning() && statusLive(model, services),
+    model.log.isLiveModeRunning() && statusLive(model, frameworkInfo),
   ],
   Failure: () => h('span.danger', 'Unable to load services'),
 });
@@ -111,11 +111,11 @@ in ${(result.time / 1000).toFixed(2)} second(s)${(result.time / 1000) >= 2 ? 's'
 /**
  * Status of live mode with hostname of streaming source and date it started
  * @param {Object} model
- * @param {Object} services - service discovery information of what is enabled in this ILG instance
+ * @param {Object} frameworkInfo - service discovery information of what is enabled in this ILG instance
  * @return {vnode}
  */
-const statusLive = (model, services) => [
-  `(Connected to ${services.streamHostname} for ${model.timezone.formatDuration(model.log.liveStartedAt)})`
+const statusLive = (model, frameworkInfo) => [
+  `(Connected to ${frameworkInfo.mysql.host} for ${model.timezone.formatDuration(model.log.liveStartedAt)})`
 ];
 
 /**

--- a/InfoLogger/test/public/live-mode-mocha.js
+++ b/InfoLogger/test/public/live-mode-mocha.js
@@ -27,10 +27,13 @@ describe('Live Mode test-suite', async () => {
     page = test.page;
     // Start infologgerserver simulator
     ilgServer = createServer();
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(5000);
   });
 
-  after(() => closeServer(ilgServer));
+  after(async () => {
+    closeServer(ilgServer);
+    await page.waitForTimeout(5000);
+  });
 
   it('should go to homepage', async function() {
     await page.goto(baseUrl, {waitUntil: 'networkidle0'});


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* Makes use of `setInterval` method from NodeJs to retry to connect to MySQL server if it did not manage to do so from the first time
* If a query throws an error, the system will try to reconnect every 5 seconds (configurable from config file)
* Status of the MySQL connection is being sent to GUI on every update with the `Status` Panel being updated as well accordingly. 
* A warning popup will be shown to the user if connection is lost(either SQL or InfoLogger server) only if the user is that respective mode:
    * If user is in Query Mode:
         * Status panel will still update for both services
         * Notification will be displayed about retrying only for query service
    * If user is in Live Mode (paused/running) 
         * Status panel will still update for both services
         * Notification will be displayed about retrying only for live service    
* Merges the 2 API calls (`getFrameworkInfo` and `services`) into one
* Increases waiting times after the `create` and `close` server operations in unit tests