### PR TITLE
[OGUI-811] Update workflow to simply use npm i

### DIFF
--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -82,8 +82,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: (cd QualityControl/lib; sed -i -e "s/require('..\/build\/Release\/tobject2json.node')/null/g" TObject2JsonClient.js)
-      - run: (cd QualityControl; rm -f binding.gyp; sed -i.bak -e '20,21d' package.json)
       - run: (cd QualityControl; npm ci)
       - run: (cd QualityControl; npm i --save ../Framework)
       - name: Check @aliceo2/web-ui was successfully linked locally


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Workflow for checking Framework compatibility with QC should not modify the `package.json` file anymore since we migrated to `JSROOT 6.0`