### PR TITLE
[OGUI-825] Upload tared npm package into release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,28 @@ jobs:
     - run: (cd $PROJECT; npm publish)
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
- 
+upload-asset:
+    runs-on: ubuntu-latest
+    needs: deploy-npm-module
+    outputs:
+      ASSET_URL: ${{ steps.upload.outputs.asset_url }}
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Create package tarball
+      run: echo ::set-output name=tgz_name::$(npm pack ${GITHUB_REF/refs\/tags\/} -s)
+      id: tgz
+    - name: Upload tarball to release assets
+      uses: actions/upload-release-asset@v1
+      id: upload
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_content_type: application/tar+gzip
+        asset_path: ./${{ steps.tgz.outputs.tgz_name }}
+        asset_name: ${{ steps.tgz.outputs.tgz_name }}
+    - name: Set output
+      run: echo ::set-output name=asset_url::${{ steps.upload.browser_download_url }}

--- a/Control/package.json
+++ b/Control/package.json
@@ -32,6 +32,12 @@
     "@grpc/proto-loader": "^0.5.3",
     "kafka-node": "^4.1.3"
   },
+  "bundledDependencies": [
+    "@aliceo2/web-ui",
+    "@grpc/grpc-js",
+    "@grpc/proto-loader",
+    "kafka-node"
+  ],
   "devDependencies": {
     "eslint": "^5.15.0",
     "mocha": "^8.2.1",

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -38,5 +38,8 @@
     "puppeteer": "5.4.1",
     "sinon": "^9.2.1"
   },
+  "bundledDependencies": [
+    "@aliceo2/web-ui"
+  ],
   "main": "index.js"
 }

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -40,5 +40,9 @@
     "puppeteer": "5.4.1",
     "sinon": "9.2.1"
   },
+  "bundledDependencies": [
+    "@aliceo2/web-ui",
+    "jsroot"
+  ],
   "main": "export.js"
 }


### PR DESCRIPTION
This is meant to provide TARballs that can be cloned to P2, then used for "offline" installation: `npm install ${asset_url}`