### PR TITLE
[OGUI-836] Fixes eslint issue && [OGUI-807] Loads layout objects in parallel

### DIFF
--- a/QualityControl/public/layout/layoutShowPage.js
+++ b/QualityControl/public/layout/layoutShowPage.js
@@ -231,7 +231,7 @@ const drawComponent = (model, tabObject) =>
           onclick: (e) => model.router.handleLinkEvent(e)
         }, iconResizeBoth())
       ]),
-      !model.isOnlineModeEnabled && model.layout.item.displayTimestamp
+      !model.isOnlineModeEnabled && model.layout.item && model.layout.item.displayTimestamp
       && h('.gray-darker.text-center.f6', {style: 'height:1.3em'}, model.object.getLastModifiedByName(tabObject.name))
     ]);
 

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -12,8 +12,6 @@
  * or submit itself to any jurisdiction.
 */
 
-/* global JSROOT, QCG */
-
 import {Observable, RemoteData, iconArrowTop} from '/js/src/index.js';
 import QCObjectService from './../services/QCObject.service.js';
 import ObjectTree from './ObjectTree.class.js';
@@ -320,7 +318,7 @@ export default class QCObject extends Observable {
    * Load objects provided by a list of paths
    * @param {Array.<string>} objectsName - e.g. /FULL/OBJECT/PATH
    */
-  loadObjects(objectsName) {
+  async loadObjects(objectsName) {
     this.objectsRemote = RemoteData.loading();
     this.objects = {}; // remove any in-memory loaded objects
     this.notify();
@@ -330,18 +328,11 @@ export default class QCObject extends Observable {
       return;
     }
 
-    Promise.allSettled(
+    await Promise.allSettled(
       objectsName.map(async (objectName) => {
-        const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${Date.now()}`;
         this.objects[objectName] = RemoteData.Loading()
         this.notify();
-        try {
-          const file = await JSROOT.openFile(filename);
-          const obj = await file.readObject("ccdb_object");
-          this.objects[objectName] = RemoteData.success({qcObject: obj});
-        } catch (error) {
-          this.objects[objectName] = RemoteData.failure(`Unable to load object ${objectName}`);
-        }
+        this.objects[objectName] = await this.qcObjectService.getObjectByNameOnly(objectName);
         this.notify();
       })
     );

--- a/QualityControl/public/object/objectDraw.js
+++ b/QualityControl/public/object/objectDraw.js
@@ -198,13 +198,7 @@ function redrawOnDataUpdate(model, dom, tabObject) {
         // Use user's defined options and add undocumented option "f" allowing color changing on redraw (color is fixed without it)
         drawingOptions += ';f';
       }
-
-      JSROOT.draw(dom, qcObject, drawingOptions).then((painter) => {
-        if (painter === null) {
-          // jsroot failed to paint it
-          model.object.invalidObject(tabObject.name);
-        }
-      }).catch(() => model.object.invalidObject(tabObject.name));
+      JSROOT.draw(dom, qcObject, drawingOptions);
     }, 0);
 
     dom.dataset.fingerprintRedraw = redrawHash;

--- a/QualityControl/public/object/objectDraw.js
+++ b/QualityControl/public/object/objectDraw.js
@@ -198,7 +198,13 @@ function redrawOnDataUpdate(model, dom, tabObject) {
         // Use user's defined options and add undocumented option "f" allowing color changing on redraw (color is fixed without it)
         drawingOptions += ';f';
       }
-      JSROOT.draw(dom, qcObject, drawingOptions);
+
+      JSROOT.draw(dom, qcObject, drawingOptions).then((painter) => {
+        if (painter === null) {
+          // jsroot failed to paint it
+          model.object.invalidObject(tabObject.name);
+        }
+      }).catch(() => model.object.invalidObject(tabObject.name));
     }, 0);
 
     dom.dataset.fingerprintRedraw = redrawHash;

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -79,7 +79,7 @@ export default class QCObjectService {
         timestamp = Date.now();
       }
       const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${timestamp}`;
-      let [qcObject, timeStampsReq] = await Promise.allSettled([
+      let [qcObject, timeStampsReq] = await Promise.all([
         JSROOT.openFile(filename).then((file) => file.readObject("ccdb_object")),
         this.model.loader.get(`/api/readObjectData?objectName=${objectName}&timestamp=${timestamp}`)
       ]);
@@ -95,6 +95,22 @@ export default class QCObjectService {
       }
     } catch (error) {
       return RemoteData.failure(`Object '${objectName}' could not be loaded`);
+    }
+  }
+
+  /**
+   * Retrieve the JSON version of a ROOT Object through JSROOT
+   * @param {string} objectName - full path object name
+   * @return {RemoteData}
+   */
+  async getObjectByNameOnly(objectName) {
+    try {
+      const url = `${QCG.CCDB_PLOT_URL}/${objectName}/${Date.now()}`;
+      const file = await JSROOT.openFile(url);
+      const obj = await file.readObject("ccdb_object");
+      return RemoteData.success({qcObject: obj});
+    } catch (error) {
+      return RemoteData.failure(`Unable to load object ${objectName}`);
     }
   }
 }

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -80,16 +80,9 @@ export default class QCObjectService {
       }
       const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${timestamp}`;
       let [qcObject, timeStampsReq] = await Promise.all([
-        /* eslint-disable no-async-promise-executor */
-        new Promise(async (resolve, reject) => {
-          try {
-            const file = await JSROOT.openFile(filename);
-            const obj = await file.readObject("ccdb_object");
-            resolve(obj);
-          } catch (error) {
-            reject({error: 'Could not load object'});
-          }
-        }),
+        JSROOT.openFile(filename)
+          .then((file) => file.readObject("ccdb_object"))
+          .then((object) => object),
         this.model.loader.get(`/api/readObjectData?objectName=${objectName}&timestamp=${timestamp}`)
       ]);
       const {result, ok, status} = timeStampsReq;

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -80,9 +80,7 @@ export default class QCObjectService {
       }
       const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${timestamp}`;
       let [qcObject, timeStampsReq] = await Promise.all([
-        JSROOT.openFile(filename)
-          .then((file) => file.readObject("ccdb_object"))
-          .then((object) => object),
+        JSROOT.openFile(filename).then((file) => file.readObject("ccdb_object")),
         this.model.loader.get(`/api/readObjectData?objectName=${objectName}&timestamp=${timestamp}`)
       ]);
       const {result, ok, status} = timeStampsReq;

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -79,7 +79,7 @@ export default class QCObjectService {
         timestamp = Date.now();
       }
       const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${timestamp}`;
-      let [qcObject, timeStampsReq] = await Promise.all([
+      let [qcObject, timeStampsReq] = await Promise.allSettled([
         JSROOT.openFile(filename).then((file) => file.readObject("ccdb_object")),
         this.model.loader.get(`/api/readObjectData?objectName=${objectName}&timestamp=${timestamp}`)
       ]);
@@ -96,30 +96,5 @@ export default class QCObjectService {
     } catch (error) {
       return RemoteData.failure(`Object '${objectName}' could not be loaded`);
     }
-  }
-
-  /**
-   * Make a set of requests to CCDB to get the object file through JSROOT
-   * It will return a map in which the value can contain:
-   * * qcObject - if request for receiving and opening the file was successfull
-   * * error - if request fails 'Unable to load object'
-   * @param {[string]} objectsNames
-   * @return {Remodata.Success(Map<String, JSON>)}
-   */
-  async getObjectsByName(objectsNames) {
-    const objectsMap = {};
-    await Promise.allSettled(
-      objectsNames.map(async (objectName) => {
-        const filename = `${QCG.CCDB_PLOT_URL}/${objectName}/${Date.now()}`;
-        try {
-          const file = await JSROOT.openFile(filename);
-          const obj = await file.readObject("ccdb_object");
-          objectsMap[objectName] = {qcObject: obj};
-        } catch (error) {
-          objectsMap[objectName] = {error: `Unable to load object ${objectName}`};
-        }
-      })
-    );
-    return RemoteData.Success(objectsMap);
   }
 }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Removes the use of async in promise
* Displays objects from a layout in parallel rather than waiting for all to load
   * In order to test parallel loading make a layout with the following objects:
      * `qc/CPV/MO/CPVPedestalTask/DigitIds`  small and quick to load
      * `qc/TPC/MO/PadCalibration/c_ROCs_Pedestal_2D` large object
