### PR TITLE
[OGUI-863] Make use of PadLock when saving CRUs config

### DIFF
--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -34,15 +34,15 @@ if (!config.grpc) {
 if (!config.grafana) {
   log.error('[Grafana] Configuration is missing');
 }
+const padLock = new Padlock();
 
 let consulService;
 if (config.consul) {
   consulService = new ConsulService(config.consul);
 }
-const consulConnector = new ConsulConnector(consulService, config.consul);
+const consulConnector = new ConsulConnector(consulService, config.consul, padLock);
 consulConnector.testConsulStatus();
 
-const padLock = new Padlock();
 const ctrlProxy = new ControlProxy(config.grpc);
 const ctrlService = new ControlService(padLock, ctrlProxy, consulConnector, config.grpc);
 const statusService = new StatusService(config, ctrlService, consulService);

--- a/Control/lib/connectors/ConsulConnector.js
+++ b/Control/lib/connectors/ConsulConnector.js
@@ -176,7 +176,7 @@ class ConsulConnector {
    * @param {Response} res
    */
   async saveCRUsConfiguration(req, res) {
-    if (!this.padLock?.lockedBy) {
+    if (this.padLock?.lockedBy === null || this.padLock?.lockedBy === undefined) {
       errorHandler('Control is not locked', res, 403);
       return false;
     } else if (req.session.personid != this.padLock.lockedBy) {

--- a/Control/lib/connectors/ConsulConnector.js
+++ b/Control/lib/connectors/ConsulConnector.js
@@ -24,7 +24,7 @@ class ConsulConnector {
    * @param {ConsulService} consulService
    * @param {JSON} config
    */
-  constructor(consulService, config) {
+  constructor(consulService, config, padLock = undefined) {
     this.consulService = consulService;
     this.config = config;
     this.flpHardwarePath = (config && config.flpHardwarePath) ? config.flpHardwarePath : 'o2/hardware/flps';
@@ -32,6 +32,8 @@ class ConsulConnector {
     this.qcPath = (config && config.qcPath) ? config.qcPath : 'o2/components/qc';
     this.readoutPath = (config && config.readoutPath) ? config.readoutPath : 'o2/components/readout';
     this.consulKVPrefix = (config && config.consulKVPrefix) ? config.consulKVPrefix : 'ui/alice-o2-cluster/kv';
+
+    this.padLock = padLock;
   }
 
   /**
@@ -174,14 +176,22 @@ class ConsulConnector {
    * @param {Response} res
    */
   async saveCRUsConfiguration(req, res) {
-    const crusByHost = req.body;
-    const keyValues = this._mapToKVPairs(crusByHost);
-    try {
-      await this.consulService.putListOfKeyValues(keyValues);
-      log.info('[Consul] Successfully saved configuration links');
-      res.status(200).json({info: {message: 'CRUs Configuration saved'}});
-    } catch (error) {
-      errorHandler(error, res, 502);
+    if (!this.padLock?.lockedBy) {
+      errorHandler('Control is not locked', res, 403);
+      return false;
+    } else if (req.session.personid != this.padLock.lockedBy) {
+      errorHandler(`Control is locked by ${this.padLock.lockedByName}`, res, 403);
+      return false;
+    } else {
+      const crusByHost = req.body;
+      const keyValues = this._mapToKVPairs(crusByHost);
+      try {
+        await this.consulService.putListOfKeyValues(keyValues);
+        log.info('[Consul] Successfully saved configuration links');
+        res.status(200).json({info: {message: 'CRUs Configuration saved'}});
+      } catch (error) {
+        errorHandler(error, res, 502);
+      }
     }
   }
 

--- a/Control/test/lib/mocha-consul-connector.js
+++ b/Control/test/lib/mocha-consul-connector.js
@@ -293,6 +293,15 @@ describe('ConsulConnector test suite', () => {
       assert.ok(res.status.calledWith(403));
       assert.ok(res.send.calledWith({message: `Control is not locked`}));
     });
+    it('should return 403 due to lock not being taken', async () => {
+      padLock.lockedBy = undefined;
+
+      const connector = new ConsulConnector(consulService, config, padLock);
+      await connector.saveCRUsConfiguration(null, res);
+
+      assert.ok(res.status.calledWith(403));
+      assert.ok(res.send.calledWith({message: `Control is not locked`}));
+    });
     it('should return 403 due to PadLock not being configured in ConsulConnector', async () => {
       const connector = new ConsulConnector(consulService, config);
       await connector.saveCRUsConfiguration(null, res);


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Adds the PadLock as a dependency to the ConsulConnector
* Checks that the lock is taken by the user before allowing the user to save the configuration
* Adds tests