### PR TITLE
[OGUI-867] Refactor and add label for AliECS loading

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/frameworkinfo/frameworkInfoPage.js
+++ b/Control/public/frameworkinfo/frameworkInfoPage.js
@@ -13,7 +13,7 @@
 */
 
 import {h} from '/js/src/index.js';
-import pageLoading from '../common/pageLoading.js';
+import {loadingStateInfoTable, successfulStateInfoTable, failureStateInfoTable} from './stateTables.js';
 
 /**
  * @file Page to FrameworkInfo(About) (content and header)
@@ -58,78 +58,17 @@ const tablesForDependenciesInfo = (frameworkInfo) => [
 ];
 
 /**
- * Create a row element which contains the status and name of the dependency
- * Will display icons based on status (loading, successful, error)
- * @param {String} label - name of the dependency
- * @param {RemoteData} content
- * @returns {vnode}
- */
-const buildStatusAndLabelRow = (label, content) =>
-  h('tr',
-    h('th.flex-row', [
-      content.match({
-        NotAsked: () => null,
-        Loading: () => pageLoading(1, 0),
-        Failure: (_) => [
-          h('.badge.bg-danger.white.f6', '✕'),
-          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()),
-        ],
-        Success: (item) => [
-          item.status && item.status.ok &&
-          h('label.badge.bg-success.white.f6', '✓'),
-          item.status && !item.status.ok &&
-          h('.badge.bg-danger.white.f6', '✕'),
-          h('.mh2', {style: 'text-decoration: underline'},
-            content.payload.name || label.toLocaleUpperCase()
-          ),
-        ]
-      }),
-    ])
-  );
-
-/**
- * Build the rows containing information about the direct dependency
- * @param {RemoteData} content 
- * @returns {vnode}
- */
-const buildContentRows = (content) =>
-  content.match({
-    NotAsked: () => null,
-    Loading: () => null,
-    Failure: (error) => h('tr.danger', [
-      h('th.w-25', 'error'),
-      h('td', error),
-    ]),
-    Success: (item) =>
-      Object.keys(item).map((name) =>
-        name === 'status' ?
-          !item['status'].ok &&
-          h('tr.danger', [
-            h('th.w-25', 'error'),
-            h('td', item['status'].message),
-          ])
-          :
-          h('tr', [
-            h('th.w-25', name),
-            h('td', JSON.stringify(item[name])),
-          ])
-      )
-  });
-
-/**
  * Show status and info of AliECS
  * @param {RemoteData} aliecs
  * @return {vnode}
  */
 const tableAliEcsInfo = (aliecs) =>
-  h('.shadow-level1',
-    h('table.table.table-sm', {style: 'white-space: pre-wrap;'}, [
-      h('tbody', [
-        buildStatusAndLabelRow('aliecs', aliecs),
-        buildContentRows(aliecs),
-      ])
-    ])
-  );
+  aliecs.match({
+    NotAsked: () => null,
+    Loading: () => loadingStateInfoTable('AliECS Core'),
+    Failure: (error) => failureStateInfoTable('AliECS Core', error),
+    Success: (item) => successfulStateInfoTable('AliECS Core', item)
+  });
 
 /**
  * Show status and info of AliECS Integrated Services
@@ -171,7 +110,8 @@ const tableIntegratedServicesInfo = (services) =>
           )
         ])
       ]
-    }));
+    })
+  );
 
 /**
  * Create a row element which contains the status and name of the dependency
@@ -209,79 +149,3 @@ const buildStatusAndLabelRowIntService = (label, service) => {
     );
   }
 };
-
-/**
- * Creates a table with a loading icon and upper case label
- * @param {String} label 
- * @returns {vnode}
- */
-const loadingStateInfoTable = (label) =>
-  h('.shadow-level1',
-    h('table.table.table-sm', {style: 'white-space: pre-wrap;'},
-      h('tbody', [
-        h('tr', h('th.flex-row', [
-          pageLoading(1, 0),
-          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()),
-        ]))
-      ])
-    )
-  );
-
-/**
- * Creates a table with a x icon and details about the issue
- * @param {String} label
- * @param {String} message
- * @param {JSON} content 
- * @returns {vnode}
- */
-const failureStateInfoTable = (label, error = undefined) =>
-  h('.shadow-level1',
-    h('table.table.table-sm', {style: 'white-space: pre-wrap;'},
-      h('tbody', [
-        h('tr', h('th.flex-row', [
-          h('.badge.bg-danger.white.f6', '✕'),
-          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()),
-        ])),
-        error && h('tr.danger', [
-          h('th.w-25', 'error'),
-          h('td', error),
-        ]),
-      ])
-    )
-  );
-
-/**
- * Creates a table with a succesful status and details about the service
- * @param {String} label 
- * @param {JSON} item 
- * @returns {vnode}
- */
-const successfulStateInfoTable = (label, dependency) => h('.shadow-level1',
-  h('table.table.table-sm', {style: 'white-space: pre-wrap;'},
-    h('tbody', [
-      h('tr',
-        h('th.flex-row', [
-          dependency.status && dependency.status.ok &&
-          h('label.badge.bg-success.white.f6', '✓'),
-          dependency.status && !dependency.status.ok &&
-          h('.badge.bg-danger.white.f6', '✕'),
-          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()
-          ),
-        ])
-      ),
-      Object.keys(dependency).map((name) =>
-        name === 'status' ?
-          !dependency['status'].ok &&
-          h('tr.danger', [
-            h('th.w-25', 'error'),
-            h('td', dependency['status'].message),
-          ])
-          :
-          h('tr', [
-            h('th.w-25', name),
-            h('td', JSON.stringify(dependency[name])),
-          ])
-      )
-    ])
-  )
-);

--- a/Control/public/frameworkinfo/stateTables.js
+++ b/Control/public/frameworkinfo/stateTables.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {h} from '/js/src/index.js';
+import pageLoading from '../common/pageLoading.js';
+
+/**
+ * Creates a 1-row table with a loading icon and upper case label
+ * @param {String} label 
+ * @returns {vnode}
+ */
+const loadingStateInfoTable = (label) =>
+  h('.shadow-level1',
+    h('table.table.table-sm', {style: 'white-space: pre-wrap; margin-bottom: 0'},
+      h('tbody', [
+        h('tr', h('th.flex-row', [
+          pageLoading(1, 0),
+          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()),
+        ]))
+      ])
+    )
+  );
+
+/**
+ * Creates a table with a x icon and details about the issue
+ * @param {String} label
+ * @param {String} message
+ * @param {JSON} content 
+ * @returns {vnode}
+*/
+const failureStateInfoTable = (label, error = undefined) =>
+  h('.shadow-level1',
+    h('table.table.table-sm', {style: 'white-space: pre-wrap; margin-bottom: 0'},
+      h('tbody', [
+        h('tr', h('th.flex-row', [
+          h('.badge.bg-danger.white.f6', '✕'),
+          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()),
+        ])),
+        error && h('tr.danger', [
+          h('th.w-25', 'error'),
+          h('td', error),
+        ]),
+      ])
+    )
+  );
+
+/**
+ * Creates a table with a succesful status and details about the service
+ * @param {String} label 
+ * @param {JSON} item 
+ * @returns {vnode}
+*/
+const successfulStateInfoTable = (label, dependency) => h('.shadow-level1',
+  h('table.table.table-sm', {style: 'white-space: pre-wrap;'},
+    h('tbody', [
+      h('tr',
+        h('th.flex-row', [
+          dependency.status && dependency.status.ok &&
+          h('label.badge.bg-success.white.f6', '✓'),
+          dependency.status && !dependency.status.ok &&
+          h('.badge.bg-danger.white.f6', '✕'),
+          h('.mh2', {style: 'text-decoration: underline'}, label.toLocaleUpperCase()
+          ),
+        ])
+      ),
+      Object.keys(dependency).map((name) =>
+        name === 'status' ?
+          !dependency['status'].ok &&
+          h('tr.danger', [
+            h('th.w-25', 'error'),
+            h('td', dependency['status'].message),
+          ])
+          :
+          h('tr', [
+            h('th.w-25', name),
+            h('td', JSON.stringify(dependency[name])),
+          ])
+      )
+    ])
+  )
+);
+
+export {loadingStateInfoTable, failureStateInfoTable, successfulStateInfoTable};


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* In cases in which `AliECS Core` request was timing out due to issues on the server side, the table with the status would simply display a loading icon without the label, thus the user not knowing what service is not up and running
* Refactors the status table of `AliECS` to use the general state tables

Issue before:
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/9214854/119794217-0291e680-bee0-11eb-875f-9b3826fd8e27.png">
