### PR TITLE
[OGUI-852] Link to edit services from Status Page

### DIFF
--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -31,6 +31,7 @@ module.exports = {
     readoutCardPath: 'o2/components/readoutcard/key/prefix',
     qcPath: 'o2/components/qc/key/prefix',
     consulKVPrefix: 'o2/cluster/key/prefix',
+    coreServices: 'o2/components/aliecs/some/settings/path',
   },
   // infoLoggerGui: {
   //   hostname: 'localhost',

--- a/Control/public/frameworkinfo/FrameworkInfo.js
+++ b/Control/public/frameworkinfo/FrameworkInfo.js
@@ -35,6 +35,8 @@ export default class FrameworkInfo extends Observable {
 
     this.aliecs = RemoteData.notAsked();
     this.integratedServices = RemoteData.notAsked();
+
+    this.consulServicesLink = '';
   }
 
   /**
@@ -107,6 +109,7 @@ export default class FrameworkInfo extends Observable {
       this.statuses.consul = RemoteData.failure(result.message);
     } else {
       this.statuses.consul = RemoteData.success(result);
+      this.consulServicesLink = `${result.hostname}:${result.port}/`
     }
     this.notify();
   }

--- a/Control/public/frameworkinfo/FrameworkInfo.js
+++ b/Control/public/frameworkinfo/FrameworkInfo.js
@@ -12,6 +12,8 @@
  * or submit itself to any jurisdiction.
 */
 
+/* global COG */
+
 import {Observable, RemoteData} from '/js/src/index.js';
 
 /**
@@ -109,7 +111,11 @@ export default class FrameworkInfo extends Observable {
       this.statuses.consul = RemoteData.failure(result.message);
     } else {
       this.statuses.consul = RemoteData.success(result);
-      this.consulServicesLink = `${result.hostname}:${result.port}/`
+      const CONSUL = COG.CONSUL;
+      this.consulServicesLink = (CONSUL.consulKVPrefix && CONSUL.coreServices && result.hostname && result.port) ?
+        `${result.hostname}:${result.port}/${CONSUL.consulKVPrefix}/${CONSUL.coreServices}/edit`
+        : '';
+
     }
     this.notify();
   }

--- a/Control/public/frameworkinfo/frameworkInfoPage.js
+++ b/Control/public/frameworkinfo/frameworkInfoPage.js
@@ -163,7 +163,8 @@ const buildStatusAndLabelRowIntService = (model, label, service) => {
 
 /**
  * Build an actionable icon to open a new tab with consul edit panel
- * The panel shoudl be the one coresponding to integrated services declaration
+ * The panel should be the one coresponding to integrated services declaration
+ * and promt the user with a confirmation box
  * @param {Object} model 
  * @returns {vnode}
  */

--- a/Control/public/frameworkinfo/frameworkInfoPage.js
+++ b/Control/public/frameworkinfo/frameworkInfoPage.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
 */
 
-import {h, iconPencil} from '/js/src/index.js';
+import {h, info} from '/js/src/index.js';
 import {loadingStateInfoTable, successfulStateInfoTable, failureStateInfoTable} from './stateTables.js';
 
 /**
@@ -168,10 +168,12 @@ const buildStatusAndLabelRowIntService = (model, label, service) => {
  * @returns {vnode}
  */
 const consulEditServiceIcon = (model) =>
+  model.frameworkInfo.consulServicesLink !== '' &&
   h('.w-10.ph2', {style: 'display: flex; justify-content: flex-end;'},
     h('a.actionable-icon', {
       href: model.frameworkInfo.consulServicesLink,
       target: '_blank',
-      title: 'Open Consul to edit services'
-    }, iconPencil())
+      title: 'Open Consul to edit services',
+      onclick: () => confirm('Please be advised that only experts should modify this section!')
+    }, info())
   );

--- a/Control/public/frameworkinfo/frameworkInfoPage.js
+++ b/Control/public/frameworkinfo/frameworkInfoPage.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
 */
 
-import {h} from '/js/src/index.js';
+import {h, iconPencil} from '/js/src/index.js';
 import pageLoading from '../common/pageLoading.js';
 
 /**
@@ -38,7 +38,7 @@ export const header = (model) => [
 export const content = (model) => h('.scroll-y.absolute-fill.flex-column.p2', [
   h('', tablesForDependenciesInfo(model.frameworkInfo)),
   tableAliEcsInfo(model.frameworkInfo.aliecs),
-  tableIntegratedServicesInfo(model.frameworkInfo.integratedServices),
+  tableIntegratedServicesInfo(model, model.frameworkInfo.integratedServices),
 ]);
 
 /**
@@ -133,10 +133,11 @@ const tableAliEcsInfo = (aliecs) =>
 
 /**
  * Show status and info of AliECS Integrated Services
+ * @param {Object} model
  * @param {RemoteData} services
  * @return {vnode}
  */
-const tableIntegratedServicesInfo = (services) =>
+const tableIntegratedServicesInfo = (model, services) =>
   h('.pv2',
     services.match({
       NotAsked: () => null,
@@ -158,7 +159,7 @@ const tableIntegratedServicesInfo = (services) =>
           h('.shadow-level1',
             h('table.table.table-sm', {style: 'white-space: pre-wrap;'},
               h('tbody', [
-                buildStatusAndLabelRowIntService(serviceKey, data[serviceKey]),
+                buildStatusAndLabelRowIntService(model, serviceKey, data[serviceKey]),
                 Object.keys(data[serviceKey]).filter((name) => name !== 'name')
                   .map((name) =>
                     h('tr', [
@@ -179,7 +180,7 @@ const tableIntegratedServicesInfo = (services) =>
  * @param
  * @returns {vnode}
  */
-const buildStatusAndLabelRowIntService = (label, service) => {
+const buildStatusAndLabelRowIntService = (model, label, service) => {
   const isServiceConfigured = Object.keys(service).length > 0;
   if (isServiceConfigured) {
     return h('tr',
@@ -194,17 +195,27 @@ const buildStatusAndLabelRowIntService = (label, service) => {
         h('.mh2', {style: 'text-decoration: underline'},
           service.name || label.toLocaleUpperCase()
         ),
-      ])
+
+      ]),
+      h('td',
+        h('.w-100.ph2', {style: 'display: flex; justify-content: flex-end;'},
+          consulEditServiceIcon(model)
+        ))
     );
   } else {
     // Empty value from AliECS Core means service was not enabled
     return h('tr',
       h('th.flex-row', [
-        h('.badge.bg-gray.white.f6', '?'),
-        h('.mh2', {style: 'text-decoration: underline'},
-          label.toLocaleUpperCase(),
-        ),
-        h('.mh5', '- Service was not enabled')
+        h('.w-90.flex-row', [
+          h('.badge.bg-gray.white.f6', '?'),
+          h('.mh2', {style: 'text-decoration: underline'},
+            label.toLocaleUpperCase(),
+          ),
+          h('.mh5', '- Service was not enabled'),
+        ]),
+        h('.w-10.ph2', {style: 'display: flex; justify-content: flex-end;'},
+          consulEditServiceIcon(model)
+        )
       ])
     );
   }
@@ -285,3 +296,18 @@ const successfulStateInfoTable = (label, dependency) => h('.shadow-level1',
     ])
   )
 );
+
+/**
+ * Build an actionable icon to open a new tab with consul edit panel
+ * The panel shoudl be the one coresponding to integrated services declaration
+ * @param {Object} model 
+ * @returns {vnode}
+ */
+const consulEditServiceIcon = (model) =>
+  h('.w-10.ph2', {style: 'display: flex; justify-content: flex-end;'},
+    h('a.actionable-icon', {
+      href: model.frameworkInfo.consulServicesLink,
+      target: '_blank',
+      title: 'Open Consul to edit services'
+    }, iconPencil())
+  );

--- a/Control/public/frameworkinfo/frameworkInfoPage.js
+++ b/Control/public/frameworkinfo/frameworkInfoPage.js
@@ -178,3 +178,4 @@ const consulEditServiceIcon = (model) =>
       onclick: () => confirm('Please be advised that only experts should modify this section!')
     }, info())
   );
+  


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Adds a new `info` icon in line with the integrated services status tables. 
* On click, the `info` icon will display a confirmation box informing the user that only experts should modify that section. In the future based on permissions the users will see or not see the icon
* After confirmation, a new browser tab will be opened with the edit section of consul core services settings 
* If consul is not responding or configuration was not provided for the settings path, than no icon will be displayed