### PR TITLE
[OGUI-877] Load templates by revision and repository

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -46,12 +46,8 @@ export default class Workflow extends Observable {
       rawValue: 'master'
     };
 
-    this.consulReadoutPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
-    this.consulKvStoreReadout = '';
     this.READOUT_PREFIX = PREFIX.READOUT;
 
-    this.consulQcPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
-    this.consulKvStoreQC = '';
     this.QC_PREFIX = PREFIX.QC;
   }
 
@@ -437,7 +433,7 @@ export default class Workflow extends Observable {
       };
     } else if (vars['readout_cfg_uri'] && vars['readout_cfg_uri_pre']) {
       if (vars['readout_cfg_uri_pre'] === this.READOUT_PREFIX.CONSUL) {
-        vars['readout_cfg_uri'] = this.consulReadoutPrefix + vars['readout_cfg_uri'];
+        vars['readout_cfg_uri'] = this.flpSelection.consulReadoutPrefix + vars['readout_cfg_uri'];
       }
       vars['readout_cfg_uri'] = vars['readout_cfg_uri_pre'] + vars['readout_cfg_uri'];
       delete vars['readout_cfg_uri_pre'];
@@ -477,7 +473,7 @@ export default class Workflow extends Observable {
       };
     } else if (vars['qc_config_uri'] && vars['qc_config_uri_pre']) {
       if (vars['qc_config_uri_pre'] === this.QC_PREFIX.CONSUL) {
-        vars['qc_config_uri'] = this.consulQcPrefix + vars['qc_config_uri'];
+        vars['qc_config_uri'] = this.flpSelection.consulQcPrefix + vars['qc_config_uri'];
       }
       vars['qc_config_uri'] = vars['qc_config_uri_pre'] + vars['qc_config_uri'];
       delete vars['qc_config_uri_pre'];

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -14,6 +14,8 @@
 
 import {Observable, RemoteData} from '/js/src/index.js';
 import {PREFIX} from './constants.js';
+import FlpSelection from './panels/flps/FlpSelection.js';
+import WorkflowForm from './WorkflowForm.js';
 
 /**
  * Model representing Workflow
@@ -26,10 +28,17 @@ export default class Workflow extends Observable {
   constructor(model) {
     super();
     this.model = model;
+    this.flpSelection = new FlpSelection(this);
+    this.flpSelection.bubbleTo(this);
+
+    this.form = new WorkflowForm();
+    this.form.bubbleTo(this);
 
     this.repoList = RemoteData.notAsked();
+    this.revisions = [];
+    this.templates = RemoteData.notAsked();
+
     this.refreshedRepositories = RemoteData.notAsked();
-    this.templatesMap = RemoteData.notAsked();
 
     this.revision = {
       isSelectionOpen: false,
@@ -37,16 +46,6 @@ export default class Workflow extends Observable {
       rawValue: 'master'
     };
 
-    this.form = {
-      repository: '',
-      revision: 'master',
-      template: '',
-      variables: {},
-      basicVariables: {},
-      hosts: []
-    };
-
-    this.flpList = RemoteData.notAsked();
     this.consulReadoutPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
     this.consulKvStoreReadout = '';
     this.READOUT_PREFIX = PREFIX.READOUT;
@@ -54,20 +53,16 @@ export default class Workflow extends Observable {
     this.consulQcPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
     this.consulKvStoreQC = '';
     this.QC_PREFIX = PREFIX.QC;
-
-    this.firstFlpSelection = -1;
   }
 
   /**
    * Initialize page and request data
    */
-  initWorkflowPage() {
-    if (!this.form.repository && !this.form.template) {
-      this.getRepositoriesList();
-      this.getAllTemplatesAsMap();
+  async initWorkflowPage() {
+    if (!this.form.isInputSelected()) {
+      this.reloadDataForm();
     }
-    this.getFLPList();
-
+    this.flpSelection.setFLPListByRequest();
     this.resetErrorMessage();
   }
 
@@ -77,18 +72,12 @@ export default class Workflow extends Observable {
    */
   setRepository(repository) {
     this.form.repository = repository;
-    this.resetErrorMessage();
-    this.setTemplate('');
     this.resetRevision(repository);
-    this.notify();
-  }
+    this.setTemplatesData();
+    this.form.setTemplate('');
 
-  /**
-   * Set template selected by the user from the list
-   * @param {string} template
-   */
-  setTemplate(template) {
-    this.form.template = template;
+    this.resetErrorMessage();
+
     this.notify();
   }
 
@@ -98,8 +87,10 @@ export default class Workflow extends Observable {
   resetErrorMessage() {
     this.model.environment.itemNew = RemoteData.notAsked();
   }
+
   /**
    * Reset revision to repository default or global default
+   * Update revisions list as well
    * @param {string} repository
    */
   resetRevision(repository) {
@@ -117,19 +108,13 @@ export default class Workflow extends Observable {
       rawValue: defaultRevision
     };
     this.form.revision = defaultRevision;
+    this.revisions = this.repoList.payload.repos.filter((obj) => obj.name === repository)[0].revisions;
     this.notify();
   }
 
   /**
-   * Method to return current selected revision
-   * @return {string}
-   */
-  getRevision() {
-    return this.form.revision;
-  }
-
-  /**
-   * Updates the selected repository with the new user selection
+   * Updates the selected revision with the new user selection
+   * It will also make a request to core to request the public templates available for that (repository,revision)
    * @param {string} inputField - input that should be updated
    * @param {string} selectedRevision - Repository that user clicked on from the dropdown list
    */
@@ -137,17 +122,8 @@ export default class Workflow extends Observable {
     this.revision.isSelectionOpen = !this.revision.isSelectionOpen;
     this.form.template = '';
     this.form.revision = selectedRevision;
+    this.setTemplatesData();
     this.updateInputSearch(inputField, selectedRevision);
-  }
-
-  /**
-   * Returns true/false if revision selected by the user exists
-   * @return {boolean}
-   */
-  isRevisionCorrect() {
-    return this.templatesMap.isSuccess()
-      && this.templatesMap.payload[this.form.repository]
-      && this.templatesMap.payload[this.form.repository][this.form.revision];
   }
 
   /**
@@ -190,22 +166,9 @@ export default class Workflow extends Observable {
   }
 
   /**
-   * Method to check that all mandatory fields were filled
-   * @return {boolean}
-   */
-  isInputSelected() {
-    return this.form.repository.trim() !== ''
-      && this.form.revision.trim() !== ''
-      && this.form.template.trim() !== '';
-  }
-
-  /**
    * Method to check user's input and create a new environment
    */
   async createNewEnvironment() {
-    const templates = this.templatesMap.payload;
-    const repository = this.form.repository;
-
     const {ok, message, variables} = this.checkAndMergeVariables(this.form.variables, this.form.basicVariables);
     if (!ok) {
       // Check the user did not introduce items with the same key in Basic Configuration and Advanced Configuration
@@ -216,29 +179,15 @@ export default class Workflow extends Observable {
         RemoteData.failure('Selecting FLPs and adding an environment variable with key `hosts` is not possible');
     } else {
       variables['hosts'] = this.form.hosts.length > 0 ? JSON.stringify(this.form.hosts) : this.form.variables.hosts;
-      if (!templates[repository]) {
-        this.model.environment.itemNew = RemoteData.failure('Selected repository does not exist');
+      if (!this.form.isInputSelected()) {
+        this.model.environment.itemNew =
+          RemoteData.failure('Please select repository, revision and workflow in order to create an environment');
       } else {
-        const revision = this.form.revision;
-        if (!templates[repository][revision]) {
-          this.model.environment.itemNew = RemoteData.failure('Selected revision does not exist for this repository');
-        } else {
-          const template = this.form.template;
-          if (template !== '') {
-            let path = '';
-            if (revision === '(no-revision-by-default)') {
-              path = this.parseRepository(repository) + `/workflows/${template}`;
-            } else {
-              path = this.parseRepository(repository) + `/workflows/${template}@${revision}`;
-            }
+        let path = '';
+        path = this.parseRepository(this.form.repository) + `/workflows/${this.form.template}@${this.form.revision}`;
 
-            // Combine Readout URI if it was used
-            this.model.environment.newEnvironment({workflowTemplate: path, vars: variables});
-          } else {
-            this.model.environment.itemNew =
-              RemoteData.failure('Selected template does not exist for this repository & revision');
-          }
-        }
+        // Combine Readout URI if it was used
+        this.model.environment.newEnvironment({workflowTemplate: path, vars: variables});
       }
     }
     this.notify();
@@ -254,7 +203,7 @@ export default class Workflow extends Observable {
       allBranches: false,
       allTags: false
     };
-    this.getAllTemplatesAsMap(options);
+    this.setTemplatesData(options);
   }
 
   /**
@@ -334,73 +283,31 @@ export default class Workflow extends Observable {
   }
 
   /**
-   * Toggle the selection of an FLP from the form host
-   * The user can also use SHIFT key to select between 2 FLP machines, thus
-   * selecting all machines between the 2 selected
-   * @param {string} name
-   * @param {Event} e
+   * Method to make the necesarry requests to reload the data on the new environment page
+   * * Make a request to retrieve a list of repositories with their corresponding revisions
+   * * If above request is ok, make a request to get the public templates for the new updated (repository,revision)
    */
-  toggleFLPSelection(name, e) {
-    if (e.shiftKey && this.flpList.isSuccess()) {
-      if (this.firstFlpSelection === -1) {
-        this.firstFlpSelection = this.flpList.payload.indexOf(name);
-      } else {
-        let secondFlpSelection = this.flpList.payload.indexOf(name);
-        if (this.firstFlpSelection > secondFlpSelection) {
-          [this.firstFlpSelection, secondFlpSelection] = [secondFlpSelection, this.firstFlpSelection];
-        }
-        for (let flpIndex = this.firstFlpSelection; flpIndex <= secondFlpSelection; ++flpIndex) {
-          const flpName = this.flpList.payload[flpIndex];
-          const hostFormIndex = this.form.hosts.indexOf(flpName);
-          if (hostFormIndex < 0) {
-            this.form.hosts.push(flpName);
-          }
-        }
-        this.firstFlpSelection = -1;
-      }
-    } else {
-      this.firstFlpSelection = -1;
-      const index = this.form.hosts.indexOf(name);
-      if (index < 0) {
-        this.form.hosts.push(name);
-      } else {
-        this.form.hosts.splice(index, 1);
-      }
+  async reloadDataForm() {
+    await this.requestRepositoryList();
+    if (this.repoList.isSuccess()) {
+      this.setTemplatesData();
     }
-    this.notify();
   }
-
-  /**
-   * If all FLPs are selected than deselect them
-   * Else select all FLPs
-   */
-  toggleAllFLPSelection() {
-    this.form.hosts = this.areAllFLPsSelected() ? [] : JSON.parse(JSON.stringify(this.flpList.payload));
-    this.notify();
-  }
-
-  /**
-   * Check if all FLPs are selected
-   * @return {boolean}
-   */
-  areAllFLPsSelected() {
-    return this.flpList.isSuccess() && this.form.hosts.length === this.flpList.payload.length;
-  }
-
   /**
    * HTTP Requests
    */
 
   /**
-   * Request to refresh repositories list from AliECS Core
+   * Make a request to refresh repositories list from AliECS Core
+   * If request is successful, make a new request with the updated repositories
+   * Afterwards, request the public templates for the new updated (repository,revision)
    */
   async refreshRepositories() {
     this.refreshedRepositories = await this.remoteDataPostRequest(
       this.refreshedRepositories, `/api/RefreshRepos`, {index: -1}
     );
     if (this.refreshedRepositories.isSuccess()) {
-      this.getRepositoriesList();
-      this.getAllTemplatesAsMap();
+      this.reloadDataForm();
     } else {
       this.model.notification.show(this.refreshedRepositories.payload, 'danger', 5000);
     }
@@ -408,9 +315,11 @@ export default class Workflow extends Observable {
 
   /**
    * Load repositories into `repoList` as RemoteData
+   * Set the selected repository the default one or the first one if default is missing
+   * Set the revisions for the selected repository
    */
-  async getRepositoriesList() {
-    this.repoList = await this.remoteDataPostRequest(this.repoList, `/api/ListRepos`, {});
+  async requestRepositoryList() {
+    this.repoList = await this.remoteDataPostRequest(this.repoList, `/api/ListRepos`, {getRevisions: true});
     if (this.repoList.isSuccess()) {
       // Set first repository the default one or first from the list if default does not exist
       const repository = this.repoList.payload.repos.find((repository) => repository.default);
@@ -419,40 +328,34 @@ export default class Workflow extends Observable {
       } else if (this.repoList.payload.repos.length > 0) {
         this.form.repository = this.repoList.payload.repos[0].name;
       }
+      this.notify();
       this.resetRevision(repository.name);
     }
   }
 
   /**
-  * Load all templates from all repositories & all revisions into `map` as RemoteData
+  * Load public templates for the selected repository and revision into RemoteData
   * @param {JSON} options
   */
-  async getAllTemplatesAsMap(options) {
+  async setTemplatesData(options) {
+    this.templates = RemoteData.loading();
+    this.notify();
+
     if (!options) {
       options = {
-        repoPattern: '*',
-        revisionPattern: '*',
+        repoPattern: this.form.repository,
+        revisionPattern: this.form.revision,
         allBranches: false,
         allTags: false
       };
     }
-    const tempMap = this.templatesMap.payload;
-    this.templatesMap = RemoteData.loading();
-    this.notify();
-
     const {result, ok} = await this.model.loader.post(`/api/GetWorkflowTemplates`, options);
     if (!ok) {
-      this.templatesMap = RemoteData.failure(result.message);
-      this.notify();
-      return;
-    }
-
-    let map = this.getMapFromList(result);
-    if (tempMap) {
-      map = this.mergeMaps(map, tempMap);
-      this.templatesMap = RemoteData.success(map);
+      this.templates = RemoteData.failure(result.message);
     } else {
-      this.templatesMap = RemoteData.success(map);
+      const templateList = [];
+      result.workflowTemplates.map((templateObject) => templateList.push(templateObject.template))
+      this.templates = RemoteData.success(templateList);
     }
     this.notify();
   }
@@ -477,41 +380,6 @@ export default class Workflow extends Observable {
       this.notify();
       return remoteDataItem;
     }
-  }
-
-  /**
-   * Method to retrieve a list of FLPs
-   */
-  async getFLPList() {
-    this.flpList = RemoteData.loading();
-    this.notify();
-
-    const {result, ok} = await this.model.loader.get(`/api/getFLPs`);
-    if (!ok) {
-      this.flpList = RemoteData.failure(result.message);
-      this.consulReadoutPrefix = '';
-      this.consulQcPrefix = '';
-      this.consulKvStoreQC = '';
-      this.consulKvStoreReadout = '';
-      this.notify();
-      return;
-    }
-    this.consulReadoutPrefix = result['consulReadoutPrefix'];
-    this.consulQcPrefix = result['consulQcPrefix'];
-    this.consulKvStoreReadout = result['consulKvStoreReadout'];
-    this.consulKvStoreQC = result['consulKvStoreQC'];
-    this.flpList = RemoteData.success(result.flps);
-    if (this.form.hosts.length === 0) {
-      // preselect all hosts if hosts were not selected already previously
-      this.form.hosts = Object.values(result.flps);
-    } else {
-      // FLP machines can be removed by the user since the last creation of an environment
-      // ensure the list of selected items is still up to date
-      const tempFormHosts = [];
-      this.form.hosts.filter((host) => this.flpList.payload.includes(host)).forEach((host) => tempFormHosts.push(host));
-      this.form.hosts = tempFormHosts.slice();
-    }
-    this.notify();
   }
 
   /**
@@ -615,50 +483,5 @@ export default class Workflow extends Observable {
       delete vars['qc_config_uri_pre'];
     }
     return {variables: vars, ok: true, message: ''};
-  }
-
-  /**
-   * Group list of repository in a JSON object by
-   * repository and revision as keys
-   * @param {Array<JSON>} list
-   * @return {JSON}
-   */
-  getMapFromList(list) {
-    const map = {};
-    Object.values(list.workflowTemplates).forEach((element) => {
-      if (!element.revision) {
-        element.revision = '(no-revision-by-default)';
-      }
-      if (map[element.repo]) {
-        if (map[element.repo][element.revision]) {
-          const templates = map[element.repo][element.revision];
-          templates.push(element.template);
-          map[element.repo][element.revision] = templates;
-        } else {
-          map[element.repo][element.revision] = [element.template];
-        }
-      } else {
-        map[element.repo] = {};
-        map[element.repo][element.revision] = [element.template];
-      }
-    });
-    return map;
-  }
-
-  /**
-   * Method to merge 2 maps
-   * @param {JSON} map
-   * @param {JSON} tempMap
-   * @return {JSON}
-   */
-  mergeMaps(map, tempMap) {
-    Object.keys(tempMap).forEach((tempKey) => {
-      Object.keys(map).filter((key) => key === tempKey).forEach((key) => {
-        Object.keys(tempMap[key]).forEach((revisionKey) => {
-          map[key][revisionKey] = tempMap[key][revisionKey];
-        });
-      });
-    });
-    return map;
   }
 }

--- a/Control/public/workflow/WorkflowForm.js
+++ b/Control/public/workflow/WorkflowForm.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {Observable} from '/js/src/index.js';
+
+/**
+ * Model representing Workflow
+ */
+export default class WorkflowForm extends Observable {
+  /**
+   * Initialize WorkflowForm component
+   */
+  constructor() {
+    super();
+
+    this.repository = '';
+    this.revision = '';
+    this.template = '';
+
+    this.variables = {};
+    this.basicVariables = {};
+
+    this.hosts = [];
+  }
+
+  /**
+   * Method to check that all mandatory fields were filled
+   * @return {boolean}
+   */
+  isInputSelected() {
+    return this.repository.trim() !== ''
+      && this.revision.trim() !== ''
+      && this.template.trim() !== '';
+  }
+
+  /**
+   * Set template selected by the user from the list
+   * @param {string} template
+   */
+  setTemplate(template) {
+    this.template = template;
+    this.notify();
+  }
+
+  /**
+   * Set the hosts selected by the user
+   * @param {Array<String>} hosts
+   */
+  setHosts(hosts) {
+    this.hosts = JSON.parse(JSON.stringify(hosts));
+    this.notify();
+  }
+
+  /**
+   * Retrieve a list of hosts selected by the user
+   * @return {Array<string>}
+   */
+  getHosts() {
+    return JSON.parse(JSON.stringify(this.hosts));
+  }
+
+  /**
+   * Add a host to the list of selected ones
+   * @param {String} host
+   */
+  addHost(host) {
+    this.hosts.push(host);
+    this.notify();
+  }
+
+  /**
+   * Remove a selected host by its index
+   * @param {Number} index
+   */
+  removeHostByIndex(index) {
+    this.hosts.splice(index, 1);
+    this.notify();
+  }
+}

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {Observable, RemoteData} from '/js/src/index.js';
+
+/**
+ * Model representing Workflow
+ */
+export default class FlpSelection extends Observable {
+  /**
+   * Initialize FLPs Selection Component
+   * @param {Object} workflow
+   */
+  constructor(workflow) {
+    super();
+    this.loader = workflow.model.loader;
+    this.workflow = workflow;
+
+    this.list = RemoteData.notAsked(); // list of FLPs gathered from Consul
+
+    this.firstFlpSelection = -1;
+  }
+
+  /**
+   * Toggle the selection of an FLP from the form host
+   * The user can also use SHIFT key to select between 2 FLP machines, thus
+   * selecting all machines between the 2 selected
+   * @param {string} name
+   * @param {Event} e
+   */
+  toggleFLPSelection(name, e) {
+    if (e.shiftKey && this.list.isSuccess()) {
+      if (this.firstFlpSelection === -1) {
+        this.firstFlpSelection = this.list.payload.indexOf(name);
+      } else {
+        let secondFlpSelection = this.list.payload.indexOf(name);
+        if (this.firstFlpSelection > secondFlpSelection) {
+          [this.firstFlpSelection, secondFlpSelection] = [secondFlpSelection, this.firstFlpSelection];
+        }
+        for (let flpIndex = this.firstFlpSelection; flpIndex <= secondFlpSelection; ++flpIndex) {
+          const flpName = this.list.payload[flpIndex];
+          const hostFormIndex = this.workflow.form.getHosts().indexOf(flpName);
+          if (hostFormIndex < 0) {
+            this.workflow.form.addHost(flpName);
+          }
+        }
+        this.firstFlpSelection = -1;
+      }
+    } else {
+      this.firstFlpSelection = -1;
+      const index = this.workflow.form.hosts.indexOf(name);
+      if (index < 0) {
+        this.workflow.form.addHost(name);
+      } else {  
+        this.workflow.form.removeHostByIndex(name);
+      }
+    }
+    this.notify();
+  }
+
+  /**
+   * If all FLPs are selected than deselect them
+   * Else select all FLPs
+   */
+  toggleAllFLPSelection() {
+    this.workflow.form.hosts = this.areAllFLPsSelected() ? [] : JSON.parse(JSON.stringify(this.list.payload));
+    this.notify();
+  }
+
+  /**
+   * Check if all FLPs are selected
+   * @return {boolean}
+   */
+  areAllFLPsSelected() {
+    return this.list.isSuccess() && this.workflow.form.hosts.length === this.list.payload.length;
+  }
+
+  /**
+   * HTTP Requests
+   */
+
+  /**
+   * Method to request a list of FLPs
+   */
+  async setFLPListByRequest() {
+    this.list = RemoteData.loading();
+    this.notify();
+
+    const {result, ok} = await this.loader.get(`/api/getFLPs`);
+    if (!ok) {
+      this.list = RemoteData.failure(result.message);
+      this.consulReadoutPrefix = '';
+      this.consulQcPrefix = '';
+      this.consulKvStoreQC = '';
+      this.consulKvStoreReadout = '';
+      this.notify();
+      return;
+    }
+    this.consulReadoutPrefix = result['consulReadoutPrefix'];
+    this.consulQcPrefix = result['consulQcPrefix'];
+    this.consulKvStoreReadout = result['consulKvStoreReadout'];
+    this.consulKvStoreQC = result['consulKvStoreQC'];
+    this.list = RemoteData.success(result.flps);
+    if (this.workflow.form.getHosts().length === 0) {
+      // preselect all hosts if hosts were not selected already previously
+      this.workflow.form.hosts = Object.values(result.flps);
+    } else {
+      // FLP machines can be removed by the user since the last creation of an environment
+      // ensure the list of selected items is still up to date
+      const tempFormHosts = [];
+      const hosts = this.workflow.form.getHosts();
+      hosts.filter((host) => this.list.payload.includes(host)).forEach((host) => tempFormHosts.push(host));
+      this.workflow.form.setHosts(tempFormHosts.slice());
+    }
+    this.notify();
+  }
+}

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -30,6 +30,12 @@ export default class FlpSelection extends Observable {
     this.list = RemoteData.notAsked(); // list of FLPs gathered from Consul
 
     this.firstFlpSelection = -1;
+
+    this.consulReadoutPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
+    this.consulKvStoreReadout = '';
+
+    this.consulQcPrefix = ''; // Used in Readout URI field of Basic Configuration Panel
+    this.consulKvStoreQC = '';
   }
 
   /**

--- a/Control/public/workflow/panels/flps/flpSelectionPanel.js
+++ b/Control/public/workflow/panels/flps/flpSelectionPanel.js
@@ -21,17 +21,17 @@ import pageLoading from './../../../common/pageLoading.js';
  * @return {vnode}
  */
 export default (workflow) =>
-  h('', [
+  h('.w-50.ph1', [
     h('.w-100.flex-row.panel-title.p2', [
       h('.flex-column.justify-center.f6',
         h('button.btn', {
-          class: workflow.areAllFLPsSelected() ? 'selected-btn' : 'none-selected-btn',
-          onclick: () => workflow.toggleAllFLPSelection()
+          class: workflow.flpSelection.areAllFLPsSelected() ? 'selected-btn' : 'none-selected-btn',
+          onclick: () => workflow.flpSelection.toggleAllFLPSelection()
         }, 'Toggle')
       ),
       h('h5.bg-gray-light', {style: 'width: 90%'},
-        workflow.flpList.kind === 'Success'
-          ? `FLP Selection (${workflow.form.hosts.length} out of ${workflow.flpList.payload.length} selected)`
+        workflow.flpSelection.list.kind === 'Success'
+          ? `FLP Selection (${workflow.form.hosts.length} out of ${workflow.flpSelection.list.payload.length} selected)`
           : 'FLP Selection'
       ),
       h('.flex-column.dropdown#flp_selection_info_icon', {style: 'display: flex'}, [
@@ -41,7 +41,7 @@ export default (workflow) =>
       ])
     ]),
     h('.w-100.p2.panel',
-      workflow.flpList.match({
+      workflow.flpSelection.list.match({
         NotAsked: () => null,
         Loading: () => pageLoading(2),
         Success: (list) => flpSelectionArea(list, workflow),
@@ -71,7 +71,7 @@ const flpSelectionArea = (list, workflow) =>
     list.map((name) =>
       h('a.menu-item', {
         className: workflow.form.hosts.indexOf(name) >= 0 ? 'selected' : null,
-        onclick: (e) => workflow.toggleFLPSelection(name, e)
+        onclick: (e) => workflow.flpSelection.toggleFLPSelection(name, e)
       }, name)
     ),
   ]);

--- a/Control/public/workflow/panels/revision/revisionPanel.js
+++ b/Control/public/workflow/panels/revision/revisionPanel.js
@@ -18,36 +18,24 @@ import errorComponent from './../../../common/errorComponent.js';
 /**
 * Method to create the revision input-dropdown panel
 * @param {RemoteData} workflow
-* @param {RemoteData<Map<String, JSON>>} templatesMap
-* @param {string} repository
 * @return {vnode}
 */
-export default (workflow, templatesMap, repository) =>
-  !templatesMap[repository] ?
-    errorComponent('No revisions found for this repository. Please contact an administrator') :
-    revisionInputDropdown(workflow, templatesMap, repository);
-
-
-/**
- * Method which creates a combo box (input + dropdown) of repositories
- * @param {Object} workflow
- * @param {RemoteData<Map<String, JSON>>} templatesMap
- * @param {string} repository
- * @return {vnode}
- */
-const revisionInputDropdown = (workflow, templatesMap, repository) => h('.mv2.text-left.w-100', [
-  h('h5', 'Revision:'),
-  h('', {style: 'display:flex; flex-direction: row;'}, [
-    h('.dropdown', {
-      style: 'flex-grow: 1;',
-      class: workflow.revision.isSelectionOpen ? 'dropdown-open' : ''
-    }, [
-      revisionInputField(workflow),
-      revisionDropdownArea(workflow, templatesMap, repository)
-    ]),
-    workflow.isInputCommitFormat() && buttonCommitFormat(workflow)
-  ]),
-]);
+export default (workflow) =>
+  h('.pv1.text-left.w-100', [
+    h('h5', 'Revision:'),
+    workflow.revisions.length === 0 ?
+      h('', errorComponent('No revisions found for the selected repository')) :
+      h('', {style: 'display:flex; flex-direction: row;'}, [
+        h('.dropdown', {
+          style: 'flex-grow: 1;',
+          class: workflow.revision.isSelectionOpen ? 'dropdown-open' : ''
+        }, [
+          revisionInputField(workflow),
+          revisionDropdownArea(workflow)
+        ]),
+        workflow.isInputCommitFormat() && buttonCommitFormat(workflow)
+      ]),
+  ]);
 
 /**
  * Create an input field for revision input:
@@ -56,43 +44,43 @@ const revisionInputDropdown = (workflow, templatesMap, repository) => h('.mv2.te
  * @param {Object} workflow
  * @return {vnode}
  */
-const revisionInputField = (workflow) => h('input.form-control', {
-  type: 'text',
-  style: 'z-index:100',
-  value: workflow.revision.rawValue,
-  oninput: (e) => workflow.updateInputSearch('revision', e.target.value),
-  onblur: () => workflow.closeRevisionInputDropdown(),
-  onkeyup: (e) => {
-    if (e.keyCode === 27) { // code for escape
-      workflow.closeRevisionInputDropdown();
+const revisionInputField = (workflow) =>
+  h('input.form-control', {
+    type: 'text',
+    style: 'z-index:100',
+    value: workflow.revision.rawValue,
+    oninput: (e) => workflow.updateInputSearch('revision', e.target.value),
+    onblur: () => workflow.closeRevisionInputDropdown(),
+    onkeyup: (e) => {
+      if (e.keyCode === 27) { // code for escape
+        workflow.closeRevisionInputDropdown();
+      }
+    },
+    onclick: (e) => {
+      workflow.setRevisionInputDropdownVisibility(true);
+      workflow.updateInputSearch('revision', '');
+      e.stopPropagation();
     }
-  },
-  onclick: (e) => {
-    workflow.setRevisionInputDropdownVisibility(true);
-    workflow.updateInputSearch('revision', '');
-    e.stopPropagation();
-  }
-});
+  });
 
 
 /**
  * Create dropdown area based on user input on revision field
  * @param {Object} workflow
- * @param {RemoteData<Map<String, JSON>>} templatesMap
  * @param {string} repository
  * @return {vnode}
  */
-const revisionDropdownArea = (workflow, templatesMap, repository) => h('.dropdown-menu.w-100.scroll-y',
-  {style: 'max-height: 25em;'},
-  Object.keys(templatesMap[repository])
-    .filter((name) => name.match(workflow.revision.regex))
-    .map((revision) =>
-      h('a.menu-item.w-wrapped', {
-        class: revision === workflow.form.revision ? 'selected' : '',
-        onmousedown: () => workflow.updateInputSelection('revision', revision),
-      }, revision)
-    )
-);
+const revisionDropdownArea = (workflow) =>
+  h('.dropdown-menu.w-100.scroll-y', {style: 'max-height: 25em;'},
+    workflow.revisions
+      .filter((name) => name.match(workflow.revision.regex))
+      .map((revision) =>
+        h('a.menu-item.w-wrapped', {
+          class: revision === workflow.form.revision ? 'selected' : '',
+          onmousedown: () => workflow.updateInputSelection('revision', revision),
+        }, revision)
+      )
+  );
 
 /**
 * Button to be displayed if revision input is a commit format

--- a/Control/public/workflow/panels/variables/advancedPanel.js
+++ b/Control/public/workflow/panels/variables/advancedPanel.js
@@ -21,7 +21,7 @@ import {h, iconTrash, iconPlus, info} from '/js/src/index.js';
  * @return {vnode}
  */
 export default (workflow) =>
-  h('', [
+  h('.w-100', [
     h('.bg-gray-light.p2.panel-title.w-100.flex-row', [
       h('h5.w-100', 'Advanced Configuration'),
       h('a.ph1.actionable-icon', {

--- a/Control/public/workflow/panels/variables/advancedPanel.js
+++ b/Control/public/workflow/panels/variables/advancedPanel.js
@@ -21,7 +21,7 @@ import {h, iconTrash, iconPlus, info} from '/js/src/index.js';
  * @return {vnode}
  */
 export default (workflow) =>
-  h('.w-100', [
+  h('.w-100.ph1', [
     h('.bg-gray-light.p2.panel-title.w-100.flex-row', [
       h('h5.w-100', 'Advanced Configuration'),
       h('a.ph1.actionable-icon', {

--- a/Control/public/workflow/panels/variables/basicPanel.js
+++ b/Control/public/workflow/panels/variables/basicPanel.js
@@ -72,7 +72,7 @@ const dcsPanel = (workflow) =>
  * @return {vnode}
  */
 const dataDistributionPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'Data Distribution:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {
@@ -109,7 +109,7 @@ const dataDistributionPanel = (workflow) =>
   * @return {vnode}
   */
 const dataDistributionSchedulerPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'Data Distribution Scheduler:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {
@@ -143,7 +143,7 @@ const dataDistributionSchedulerPanel = (workflow) =>
  * @return {vnode}
  */
 const epnPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'EPN:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {
@@ -177,7 +177,7 @@ const epnPanel = (workflow) =>
  * @return {vnode}
  */
 const qcddPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'QC:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {
@@ -213,7 +213,7 @@ const qcddPanel = (workflow) =>
  * @return {vnode}
  */
 const dplMwPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'Minimal DPL workflow:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {
@@ -283,14 +283,14 @@ const readoutPanel = (workflow) => {
             h('option', {
               id: 'consulOption',
               value: consulPre,
-              disabled: workflow.consulReadoutPrefix ? false : true,
+              disabled: workflow.flpSelection.consulReadoutPrefix ? false : true,
               selected: variables['readout_cfg_uri_pre'] === consulPre
             }, consulPre)
           ])
         ),
         h('.flex-row', {style: 'width:85%;'}, [
           variables['readout_cfg_uri_pre'] === consulPre && h('input.form-control.w-60', {
-            value: workflow.consulReadoutPrefix,
+            value: workflow.flpSelection.consulReadoutPrefix,
             disabled: true
           }),
           variables['readout_cfg_uri_pre'] && h('input.form-control', {
@@ -317,11 +317,11 @@ const readoutPanel = (workflow) => {
       h('.w-25'),
       h('a.w-75.f5.action', {
         style: 'font-style: italic; cursor: pointer',
-        href: `//${workflow.consulKvStoreReadout}/${(
+        href: `//${workflow.flpSelection.consulKvStoreReadout}/${(
           variables['readout_cfg_uri'] ?
             variables['readout_cfg_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + workflow.consulReadoutPrefix + (
+      }, consulPre + workflow.flpSelection.consulReadoutPrefix + (
         variables['readout_cfg_uri'] ?
           variables['readout_cfg_uri'] : '')
       )
@@ -370,14 +370,14 @@ const qcUriPanel = (workflow) => {
             h('option', {
               id: 'consulOption',
               value: consulPre,
-              disabled: workflow.consulQcPrefix ? false : true,
+              disabled: workflow.flpSelection.consulQcPrefix ? false : true,
               selected: variables['qc_config_uri_pre'] === consulPre
             }, consulPre)
           ])
         ),
         h('.flex-row', {style: 'width:85%;'}, [
           variables['qc_config_uri_pre'] === consulPre && h('input.form-control.w-60', {
-            value: workflow.consulQcPrefix,
+            value: workflow.flpSelection.consulQcPrefix,
             disabled: true
           }),
           variables['qc_config_uri_pre'] && h('input.form-control', {
@@ -404,11 +404,11 @@ const qcUriPanel = (workflow) => {
       h('.w-25'),
       h('a.w-75.f5.action', {
         style: 'font-style: italic; cursor: pointer',
-        href: `//${workflow.consulKvStoreQC}/${(
+        href: `//${workflow.flpSelection.consulKvStoreQC}/${(
           variables['qc_config_uri'] ?
             variables['qc_config_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + workflow.consulQcPrefix + (
+      }, consulPre + workflow.flpSelection.consulQcPrefix + (
         variables['qc_config_uri'] ?
           variables['qc_config_uri'] : '')
       )

--- a/Control/public/workflow/panels/variables/basicPanel.js
+++ b/Control/public/workflow/panels/variables/basicPanel.js
@@ -21,7 +21,7 @@ import {h} from '/js/src/index.js';
  * @return {vnode}
  */
 export default (workflow) =>
-  h('', [
+  h('.w-100', [
     h('h5.bg-gray-light.p2.panel-title.w-100.flex-row', h('.w-100', 'Basic Configuration')),
     h('.p2.panel', [
       dcsPanel(workflow),
@@ -41,7 +41,7 @@ export default (workflow) =>
  * @return {vnode}
  */
 const dcsPanel = (workflow) =>
-  h('.flex-row.text-left.w-50', [
+  h('.flex-row.text-left', [
     h('.w-50', 'DCS:'),
     h('.w-25.form-check', [
       h('input.form-check-input', {

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -37,12 +37,9 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should successfully request a list of template objects', async () => {
-    const templatesMap = await page.evaluate(() => {
-      return window.model.workflow.templatesMap;
-    });
-    const repository = 'github.com/AliceO2Group/ControlWorkflows';
-    assert.strictEqual(templatesMap.kind, 'Success', `Request for list of template objects failed due to: ${templatesMap.payload}`);
-    assert.ok(templatesMap.payload[repository]);
+    const templates = await page.evaluate(() => window.model.workflow.templates);
+    assert.strictEqual(templates.kind, 'Success', `Request for list of template objects failed due to: ${templates.payload}`);
+    assert.ok(templates.payload.length !== 0);
   });
 
   it(`should successfully select workflow '${workflowToTest}' from template list`, async () => {
@@ -56,13 +53,13 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should display variables (K;V) panel', async () => {
-    await page.waitForSelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div', {timeout: 2000});
-    const title = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div').innerText);
+    await page.waitForSelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div', {timeout: 2000});
+    const title = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div').innerText);
     assert.strictEqual('Advanced Configuration', title, 'Could not find the Advanced Configuration Panel');
   });
 
   it('should successfully request a list of FLP names', async () => {
-    const flpList = await page.evaluate(() => window.model.workflow.flpList);
+    const flpList = await page.evaluate(() => window.model.workflow.flpSelection.list);
 
     assert.strictEqual(flpList.kind, 'Success', 'Could not retrieve list of FLPs from Consul');
     assert.ok(flpList.payload.length > 0, 'No FLPs were found in Consul');
@@ -76,16 +73,16 @@ describe('`pageNewEnvironment` test-suite', async () => {
   it('should successfully add provided K:V pairs', async () => {
     for (const key in confVariables) {
       if (key && confVariables[key]) {
-        await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div > input');
+        await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div:nth-child(3)> div > div > input');
         page.keyboard.type(key);
         await page.waitForTimeout(200);
 
-        await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div:nth-child(2) > input');
+        await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div:nth-child(3)> div > div:nth-child(2) > input');
         page.keyboard.type(confVariables[key]);
         await page.waitForTimeout(200);
 
         await page.evaluate(() => {
-          document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div:nth-child(3)').click();
+          document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div:nth-child(3)> div >  div:nth-child(3)').click();
         });
         await page.waitForTimeout(200);
       }
@@ -95,7 +92,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should have successfully select first FLP by default from area list by', async () => {
-    const flps = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div:nth-child(2) > div> div:nth-child(2) > div > a').classList);
+    const flps = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div > div:nth-child(2) > div:nth-child(2) > div > a').classList);
     assert.deepStrictEqual(flps, {0: 'menu-item', 1: 'selected'}, 'FLPs were not successfully selected by default in the panel');
     const hosts = await page.evaluate(() => window.model.workflow.form.hosts);
     assert.ok(hosts.length > 0, 'No hosts were selected before creating an environment')

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -62,12 +62,11 @@ describe('Control', function() {
     workflowTemplates: {
       workflowTemplates: [
         {repo: 'git.cern.ch/some-user/some-repo/', template: 'prettyreadout-1', revision: 'master'},
-        {repo: 'git.cern.ch/some-user/some-repo/', template: 'prettyreadout-1', revision: 'dev'},
       ]
     },
     listRepos: {
       repos: [
-        {name: 'git.cern.ch/some-user/some-repo/', default: true, defaultRevision: 'dev'},
+        {name: 'git.cern.ch/some-user/some-repo/', default: true, defaultRevision: 'dev', revisions: ['master', 'dev']},
         {name: 'git.com/alice-user/alice-repo/'}]
     }
   };

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -287,11 +287,11 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should successfully add trimmed pair (K;V) to variables by pressing enter key', async () => {
-    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div > input');
+    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(3)> div > div > input');
     await page.keyboard.type('TestKey   ');
     await page.waitForTimeout(200);
 
-    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div:nth-child(2) > input');
+    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(3) > div > div:nth-child(2) > input');
     await page.keyboard.type(' TestValue  ');
     await page.waitForTimeout(200);
 
@@ -309,16 +309,16 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should successfully add second pair (K;V) to variables by pressing iconPlus', async () => {
-    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div > input');
+    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(3) > div > div > input');
     await page.keyboard.type('TestKey2');
     await page.waitForTimeout(200);
 
-    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(3) > div:nth-child(3)> div > div:nth-child(2) > input');
+    await page.focus('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(3) > div > div:nth-child(2) > input');
     await page.keyboard.type('TestValue2');
     await page.waitForTimeout(200);
 
     const variables = await page.evaluate(() => {
-      document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div:nth-child(3)> div >  div:nth-child(3)').click();
+      document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div >div:nth-child(2) > div:nth-child(2) > div:nth-child(3) > div >  div:nth-child(3)').click();
       return window.model.workflow.form.variables;
     });
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Makes use of the new API changes from AliECS. 
Changes are needed so that requesting all templates (which can lead to hundreds or thousands of them) and adding a waiting time of about 5-10 seconds when loading AliECS GUI is not needed anymore. 

GUI will now request a list of repositories with their corresponding revisions. 
Following the user selection of repository & revision, a request will be made to core to retrieve templates only for the specified criteria. 

Should not be merged until AliECS Core fixes a bug in their API in which adding a new repository will not share its revisions. 