### PR TITLE
[OGUI-898] Clear should close inspector panel

### DIFF
--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -438,10 +438,12 @@ export default class Log extends Observable {
   }
 
   /**
-   * Empty the list of all logs, reset stats and clear query mode request if any.
+   * Empty the list of all logs, reset stats, clear query mode request if any
+   * and close the inspector panel
    */
   empty() {
     this.list = [];
+    this.model.inspectorEnabled = false;
     this.resetStats();
     this.queryResult = RemoteData.notAsked();
     this.notify();

--- a/InfoLogger/public/log/inspector.js
+++ b/InfoLogger/public/log/inspector.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
 */
 
-import {h} from '/js/src/index.js';
+import {h, iconX} from '/js/src/index.js';
 
 import {severityClass, severityLabel} from './severityUtils.js';
 
@@ -23,6 +23,19 @@ export default (model) => model.log.item ? h('', [
       h('col.cell-m'), // last column fills space
     ]),
     h('tbody', [
+      h('tr', [
+        h('td.cell-bordered', ''),
+        h('td.cell.text-ellipsis.cell-xl',
+          h('.f7.w-100.flex-column.items-end',
+            h('.w-10.actionable-icon', {
+              onclick: () => {
+                model.inspectorEnabled = false;
+                model.notify();
+              }
+            }, iconX())
+          )
+        )
+      ]),
       h('tr', [
         h('td', {className: severityClass(model.log.item.severity)}, 'Severity'),
         h('td', {className: severityClass(model.log.item.severity)}, severityLabel(model.log.item.severity))


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

If the user clicks Clear on the logs, the inspector panel should close.
An `x` icon should be present on the panel to easily allow the user to close the inspector panel.