### PR TITLE
[OGUI-885] Add message to failed requests

### DIFF
--- a/Control/lib/control-core/ControlService.js
+++ b/Control/lib/control-core/ControlService.js
@@ -89,6 +89,7 @@ class ControlService {
         errorLogger(error);
         res.status(502).json({
           ended: true, success: false, id: channelId,
+          message: 'Error while attempting to clean resources ...',
           info: {message: error.message || error || 'Error while attempting to clean resources ...'}
         });
       }
@@ -154,6 +155,7 @@ class ControlService {
           errorLogger(error);
           res.status(502).json({
             ended: true, success: false, id: channelId,
+            message: error.message || error || 'Error while attempting to run o2-roc-config ...',
             info: {message: error.message || error || 'Error while attempting to run o2-roc-config ...'}
           });
         }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

If the requests fails, WebUi `Loader` expects a `message` field to exist