### PR TITLE
[OGUI-560] Make git checkout with LF even on windows

### DIFF
--- a/Framework/.gitattributes
+++ b/Framework/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

GIT is by default checking out files on windows with CRLF but makes sure to convert them to LF once the users commit
One can use LF even on checkout by updating the `.gitattributes` to use LF