### PR TITLE
[OGUI-752] Add onblur for menu account button

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -150,6 +150,15 @@ export default class Model extends Observable {
   }
 
   /**
+   * Set the visibilty of the account menu
+   * @param {boolean} value 
+   */
+  setAccountMenu(value = false) {
+    this.accountMenuEnabled = value ? true : false;
+    this.notify();
+  }
+
+  /**
    * Toggles the sidebar size
    * * minimal - icons only
    * * normal - icons + text

--- a/Control/public/common/appHeader.js
+++ b/Control/public/common/appHeader.js
@@ -39,7 +39,10 @@ export default (model) => h('.flex-grow text-left',
  * @return {vnode}
  */
 const loginButton = (model) => h('.dropdown', {class: model.accountMenuEnabled ? 'dropdown-open' : ''}, [
-  h('button.btn', {onclick: () => model.toggleAccountMenu()}, iconPerson()),
+  h('button.btn', {
+    onclick: () => model.toggleAccountMenu(),
+    onblur: () => model.setAccountMenu(false)
+  }, iconPerson()),
   h('.dropdown-menu', [
     h('p.m3.mv2.text-ellipsis', model.session.access === 2
       ? `Welcome ${model.session.name} *`


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

If the user clicks outside of the menu account button, the menu should automatically be hidden, rather than the user having to press once again on the button