### PR TITLE
[OGUI-937] Add safers for missing cru config

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/configuration/ConfigByCru.js
+++ b/Control/public/configuration/ConfigByCru.js
@@ -85,9 +85,9 @@ export default class Config extends Observable {
       const allULEnabled = this.areAllUserLogicsEnabled();
       Object.keys(this.cruMapByHost.payload).forEach((key) => {
         const cruByEndPoint = this.cruMapByHost.payload[key];
-        Object.keys(cruByEndPoint).forEach((cruKey) => {
-          cruByEndPoint[cruKey].config.cru.userLogicEnabled = allULEnabled ? 'false' : 'true';
-        });
+        Object.keys(cruByEndPoint)
+          .filter((cruKey) => (cruByEndPoint[cruKey].config && cruByEndPoint[cruKey].config.cru))
+          .forEach((cruKey) => cruByEndPoint[cruKey].config.cru.userLogicEnabled = allULEnabled ? 'false' : 'true');
       });
       this.selectAllHosts();
       this.notify();
@@ -104,11 +104,9 @@ export default class Config extends Observable {
       let allULEnabled = true;
       Object.keys(this.cruMapByHost.payload).forEach((key) => {
         const cruByEndPoint = this.cruMapByHost.payload[key];
-        Object.keys(cruByEndPoint).forEach((cruKey) => {
-          if (cruByEndPoint[cruKey].config.cru.userLogicEnabled === 'false') {
-            allULEnabled = false;
-          }
-        });
+        allULEnabled = !Object.keys(cruByEndPoint)
+          .filter((cruKey) => (cruByEndPoint[cruKey].config && cruByEndPoint[cruKey].config.cru))
+          .some((cruKey) => cruByEndPoint[cruKey].config.cru.userLogicEnabled === 'false')
       });
       return allULEnabled;
     }

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -178,17 +178,19 @@ const cruPanelByEndpoint = (model, cruId, cru, host) => {
  * @return {vnode}
  */
 const linksPanel = (model, cru) =>
-  h('.flex-row.w-75', [
-    h('.w-15', toggleUserLogic(model, cru)),
-    Object.keys(cru.config)
-      .filter((configField) => configField.match('link[0-9]{1,2}'))
-      .length !== 0 && h('.w-15', toggleAllCheckBox(model, cru)),
-    h('.w-70.flex-row.flex-wrap', [
+  (cru.config && cru.config.cru) ?
+    h('.flex-row.w-75', [
+      h('.w-15', toggleUserLogic(model, cru)),
       Object.keys(cru.config)
-        .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
-        .map((link, index) => checkBox(model, `link${index}`, `#${index}`, cru.config)),
+        .filter((configField) => configField.match('link[0-9]{1,2}'))
+        .length !== 0 && h('.w-15', toggleAllCheckBox(model, cru)),
+      h('.w-70.flex-row.flex-wrap', [
+        Object.keys(cru.config)
+          .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
+          .map((link, index) => checkBox(model, `link${index}`, `#${index}`, cru.config)),
+      ])
     ])
-  ]);
+    : h('.d-inline.f6.text-light', 'No configuration found for this serial:endpoint');
 
 /**
  * Add a checkbox for the user to enable/disable the user logic


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR fixes a bug in which if there is no matching data configuration for a specific `cru:serial:endpoint` the page would go in an infinite loading state due to undefined.
Now, a short message should be displayed `No configuration found for this serial:endpoint`

![image](https://user-images.githubusercontent.com/9214854/130941656-bf1e84ba-83bd-4e6f-b163-d59512762f46.png)

