### PR TITLE
[OGUI-938] Remove disabling of links on userLogic

### DIFF
--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -222,11 +222,9 @@ const toggleUserLogic = (model, cru) =>
 const toggleAllCheckBox = (model, cru) =>
   h('label.d-inline.f6.ph2', {
     style: 'white-space: nowrap',
-    class: cru.config.cru.userLogicEnabled === 'true' ? 'disabled-content' : '',
     title: `Toggle selection of all links`
   }, h('input', {
     type: 'checkbox',
-    disabled: cru.config.cru.userLogicEnabled === 'true',
     checked: Object.keys(cru.config)
       .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
       .filter((key) => cru.config[key].enabled === 'true').length === 12,
@@ -252,11 +250,9 @@ const toggleAllCheckBox = (model, cru) =>
 const checkBox = (model, key, title, config) =>
   h('label.d-inline.f6.ph2', {
     style: 'white-space: nowrap',
-    class: config.cru.userLogicEnabled === 'true' ? 'disabled-content' : '',
     title: `Toggle selection of ${key}`
   }, h('input', {
     type: 'checkbox',
-    disabled: config.cru.userLogicEnabled === 'true',
     checked: config[key].enabled === 'true',
     onchange: () => {
       config[key].enabled = config[key].enabled !== 'true' ? 'true' : 'false';


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

As requested by the users, the state of `userLogicEnabled` should not have power to disable/enable the functionality of the `link0-11`