### PR TITLE
[OGUI-888] Build consul configuration only once and use it across platform

### DIFF
--- a/Control/README.md
+++ b/Control/README.md
@@ -61,7 +61,7 @@ Use of a Consul instance is optional
 * `readoutPath` - Prefix for KV Store for readout's configuration
 * `readoutCardPath` - Prefix for KV Store for readout-card's configuration
 * `qcPath` - Prefix for KV Store for quality-control's configuration
-* `consulKVPrefix` - Name of the Consul cluster used by AliceO2
+* `kVPrefix` - Name of the Consul cluster used by AliceO2
   
 ### Kafka
 Use of a Kafka instance is optional. It is being used for prompting [Browser Notifications](#integration-with-notification-service) 

--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -30,8 +30,12 @@ module.exports = {
     readoutPath: 'o2/components/readout/key/prefix',
     readoutCardPath: 'o2/components/readoutcard/key/prefix',
     qcPath: 'o2/components/qc/key/prefix',
-    consulKVPrefix: 'o2/cluster/key/prefix',
+    kVPrefix: 'o2/cluster/key/prefix',
     coreServices: 'o2/components/aliecs/some/settings/path',
+  },
+  infoLoggerGui: {
+    hostname: 'localhost',
+    port: 8081
   },
   utils: {
     refreshTask: 5000 // how often should task list page should refresh its content

--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -73,10 +73,10 @@ module.exports.setup = (http, ws) => {
     .then((data) => res.status(200).json(data)));
 
   // Consul
-  http.get('/getCRUs', (req, res) => consulConnector.getCRUs(req, res));
-  http.get('/getFLPs', (req, res) => consulConnector.getFLPs(req, res));
-  http.get('/getCRUsConfig', (req, res) => consulConnector.getCRUsWithConfiguration(req, res));
-  http.post('/saveCRUsConfig', (req, res) => consulConnector.saveCRUsConfiguration(req, res));
+  http.get('/consul/flps', (req, res) => consulConnector.getFLPs(req, res));
+  http.get('/consul/crus', (req, res) => consulConnector.getCRUs(req, res));
+  http.get('/consul/crus/config', (req, res) => consulConnector.getCRUsWithConfiguration(req, res));
+  http.post('/consul/crus/config/save', (req, res) => consulConnector.saveCRUsConfiguration(req, res));
 
   const kafka = new KafkaConnector(config.kafka, ws);
   if (kafka.isKafkaConfigured()) {

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -29,7 +29,7 @@ function buildPublicConfig(config) {
   const publicConfig = {
     ILG_URL: _getInfoLoggerURL(config),
     GRAFANA: _getGrafanaConfig(config),
-    CONSUL: _getConsulConfig(config),
+    CONSUL: getConsulConfig(config),
     REFRESH_TASK: config?.utils?.refreshTask || 5000,
     DETECTORS: config?.detectorMap || {}
   };
@@ -43,9 +43,21 @@ function buildPublicConfig(config) {
  * @param {JSON} config - server configuration
  * @returns {JSON}
  */
-function _getConsulConfig(config) {
+function getConsulConfig(config) {
   if (config?.consul) {
-    return config.consul
+    const conf = config.consul;
+
+    conf.flpHardwarePath = conf?.flpHardwarePath ? conf.flpHardwarePath : 'o2/hardware/flps';
+    conf.readoutCardPath = conf?.readoutCardPath ? conf.readoutCardPath : 'o2/components/readoutcard';
+    conf.qcPath = conf?.qcPath ? conf.qcPath : 'o2/components/qc';
+    conf.readoutPath = conf?.readoutPath ? conf.readoutPath : 'o2/components/readout';
+    conf.kVPrefix = conf?.kVPrefix ? conf.kVPrefix : 'ui/alice-o2-cluster/kv';
+
+    conf.kvStoreQC = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.qcPath}`;
+    conf.kvStoreReadout = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.readoutPath}`;
+    conf.qcPrefix = `${conf.hostname}:${conf.port}/${conf.qcPath}/`;
+    conf.readoutPrefix = `${conf.hostname}:${conf.port}/${conf.readoutPath}/`
+    return conf;
   }
   return {};
 }
@@ -92,4 +104,4 @@ function _getInfoLoggerURL(config) {
   }
 }
 
-module.exports = {buildPublicConfig, _getGrafanaConfig, _getInfoLoggerURL};
+module.exports = {buildPublicConfig, _getGrafanaConfig, _getInfoLoggerURL, getConsulConfig};

--- a/Control/public/configuration/ConfigByCru.js
+++ b/Control/public/configuration/ConfigByCru.js
@@ -125,7 +125,7 @@ export default class Config extends Observable {
     this.cruMapByHost = RemoteData.loading();
     this.notify();
 
-    const {result, ok} = await this.model.loader.get(`/api/getCRUsConfig`);
+    const {result, ok} = await this.model.loader.get(`/api/consul/crus/config`);
     if (!ok) {
       this.cruMapByHost = RemoteData.failure(result.message);
       this.notify();
@@ -149,7 +149,7 @@ export default class Config extends Observable {
       this.notify();
       const copy = {};
       this.selectedHosts.forEach((host) => copy[host] = JSON.parse(JSON.stringify(this.cruMapByHost.payload[host])));
-      const {result, ok} = await this.model.loader.post(`/api/saveCRUsConfig`, copy);
+      const {result, ok} = await this.model.loader.post(`/api/consul/crus/config/save`, copy);
       if (!ok) {
         result.ended = true;
         result.success = false;
@@ -238,6 +238,6 @@ export default class Config extends Observable {
    */
   getConsulConfigURL() {
     const consul = COG.CONSUL;
-    return `//${consul.hostname}:${consul.port}/${consul.consulKVPrefix}/${consul.readoutCardPath}`
+    return `//${consul.hostname}:${consul.port}/${consul.kVPrefix}/${consul.readoutCardPath}`
   }
 }

--- a/Control/public/configuration/Configuration.js
+++ b/Control/public/configuration/Configuration.js
@@ -352,7 +352,7 @@ export default class Configuration extends Observable {
     this.readoutCardList = RemoteData.loading();
     this.notify();
 
-    const {result, ok} = await this.model.loader.get(`/api/getCRUs`);
+    const {result, ok} = await this.model.loader.get(`/api/consul/crus`);
     if (!ok) {
       this.readoutCardList = RemoteData.failure(result.message);
       this.notify();

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -260,7 +260,7 @@ const infoLoggerPerFlpButton = (environment, model, host) =>
     title: 'Open InfoLogger for this hostname',
     href: environment.currentRunNumber ?
       `//${COG.ILG_URL}?q={"run":{"match":"${environment.currentRunNumber}"},"hostname":{"match":"${host}"}}`
-      : `//${COG.ILG_URL}?q={"hostname":{"match":"flptest1"}}`,
+      : `//${COG.ILG_URL}?q={"hostname":{"match":"${host}"}}`,
     target: '_blank'
   }, h('button.btn-sm.primary', iconList())
   );

--- a/Control/public/frameworkinfo/FrameworkInfo.js
+++ b/Control/public/frameworkinfo/FrameworkInfo.js
@@ -112,8 +112,8 @@ export default class FrameworkInfo extends Observable {
     } else {
       this.statuses.consul = RemoteData.success(result);
       const CONSUL = COG.CONSUL;
-      this.consulServicesLink = (CONSUL.consulKVPrefix && CONSUL.coreServices && result.hostname && result.port) ?
-        `${result.hostname}:${result.port}/${CONSUL.consulKVPrefix}/${CONSUL.coreServices}/edit`
+      this.consulServicesLink = (CONSUL.kVPrefix && CONSUL.coreServices && result.hostname && result.port) ?
+        `${result.hostname}:${result.port}/${CONSUL.kVPrefix}/${CONSUL.coreServices}/edit`
         : '';
 
     }

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -525,7 +525,7 @@ export default class Workflow extends Observable {
       };
     } else if (vars['readout_cfg_uri'] && vars['readout_cfg_uri_pre']) {
       if (vars['readout_cfg_uri_pre'] === this.READOUT_PREFIX.CONSUL) {
-        vars['readout_cfg_uri'] = this.flpSelection.consulReadoutPrefix + vars['readout_cfg_uri'];
+        vars['readout_cfg_uri'] = COG.CONSUL.readoutPrefix + vars['readout_cfg_uri'];
       }
       vars['readout_cfg_uri'] = vars['readout_cfg_uri_pre'] + vars['readout_cfg_uri'];
       delete vars['readout_cfg_uri_pre'];
@@ -565,7 +565,7 @@ export default class Workflow extends Observable {
       };
     } else if (vars['qc_config_uri'] && vars['qc_config_uri_pre']) {
       if (vars['qc_config_uri_pre'] === this.QC_PREFIX.CONSUL) {
-        vars['qc_config_uri'] = this.flpSelection.consulQcPrefix + vars['qc_config_uri'];
+        vars['qc_config_uri'] = COG.CONSUL.qcPrefix + vars['qc_config_uri'];
       }
       vars['qc_config_uri'] = vars['qc_config_uri_pre'] + vars['qc_config_uri'];
       delete vars['qc_config_uri_pre'];

--- a/Control/public/workflow/panels/variables/basicPanel.js
+++ b/Control/public/workflow/panels/variables/basicPanel.js
@@ -12,6 +12,8 @@
  * or submit itself to any jurisdiction.
 */
 
+/* global COG */
+
 import {h} from '/js/src/index.js';
 
 /**
@@ -310,14 +312,14 @@ const readoutPanel = (workflow) => {
             h('option', {
               id: 'consulOption',
               value: consulPre,
-              disabled: workflow.flpSelection.consulReadoutPrefix ? false : true,
+              disabled: COG.CONSUL.readoutPrefix ? false : true,
               selected: variables['readout_cfg_uri_pre'] === consulPre
             }, consulPre)
           ])
         ),
         h('.flex-row', {style: 'width:85%;'}, [
           variables['readout_cfg_uri_pre'] === consulPre && h('input.form-control.w-60', {
-            value: workflow.flpSelection.consulReadoutPrefix,
+            value: COG.CONSUL.readoutPrefix,
             disabled: true
           }),
           variables['readout_cfg_uri_pre'] && h('input.form-control', {
@@ -344,11 +346,11 @@ const readoutPanel = (workflow) => {
       h('.w-25'),
       h('a.w-75.f5.action', {
         style: 'font-style: italic; cursor: pointer',
-        href: `//${workflow.flpSelection.consulKvStoreReadout}/${(
+        href: `//${COG.CONSUL.kvStoreReadout}/${(
           variables['readout_cfg_uri'] ?
             variables['readout_cfg_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + workflow.flpSelection.consulReadoutPrefix + (
+      }, consulPre + COG.CONSUL.readoutPrefix + (
         variables['readout_cfg_uri'] ?
           variables['readout_cfg_uri'] : '')
       )
@@ -397,14 +399,14 @@ const qcUriPanel = (workflow) => {
             h('option', {
               id: 'consulOption',
               value: consulPre,
-              disabled: workflow.flpSelection.consulQcPrefix ? false : true,
+              disabled: COG.CONSUL.qcPrefix ? false : true,
               selected: variables['qc_config_uri_pre'] === consulPre
             }, consulPre)
           ])
         ),
         h('.flex-row', {style: 'width:85%;'}, [
           variables['qc_config_uri_pre'] === consulPre && h('input.form-control.w-60', {
-            value: workflow.flpSelection.consulQcPrefix,
+            value: COG.CONSUL.qcPrefix,
             disabled: true
           }),
           variables['qc_config_uri_pre'] && h('input.form-control', {
@@ -435,7 +437,7 @@ const qcUriPanel = (workflow) => {
           variables['qc_config_uri'] ?
             variables['qc_config_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + workflow.flpSelection.consulQcPrefix + (
+      }, consulPre + COG.CONSUL.qcPrefix + (
         variables['qc_config_uri'] ?
           variables['qc_config_uri'] : '')
       )

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -231,7 +231,11 @@ describe('Control', function() {
         readoutPath: 'test/o2/readout/components',
         readoutCardPath: 'test/o2/readoutcard/components',
         qcPath: 'test/o2/qc/components',
-        consulKVPrefix: 'test/ui/some-cluster/kv',
+        kVPrefix: 'test/ui/some-cluster/kv',
+        kvStoreQC: 'localhost:8550/test/ui/some-cluster/kv/test/o2/qc/components',
+        kvStoreReadout: 'localhost:8550/test/ui/some-cluster/kv/test/o2/readout/components',
+        qcPrefix: "localhost:8550/test/o2/qc/components/",
+        readoutPrefix: "localhost:8550/test/o2/readout/components/"
       },
       DETECTORS: {},
       REFRESH_TASK: 5000,

--- a/Control/test/public/page-configuration-mocha.js
+++ b/Control/test/public/page-configuration-mocha.js
@@ -130,7 +130,7 @@ describe('`pageConfiguration` test-suite', async () => {
  * @param {Request} request
  */
 function keyNotFound(request) {
-  if (request.url().includes('/api/getCRUs')) {
+  if (request.url().includes('/api/consul/crus')) {
     request.respond({status: 404, contentType: 'application/json', body: JSON.stringify({message: 'Could not find any Readout Cards by key test/o2/hardware/flps'})});
   } else {
     request.continue();
@@ -142,7 +142,7 @@ function keyNotFound(request) {
  * @param {Request} request
  */
 function readoutCardsEmpty(request) {
-  if (request.url().includes('/api/getCRUs')) {
+  if (request.url().includes('/api/consul/crus')) {
     request.respond({status: 200, contentType: 'application/json', body: JSON.stringify({})});
   } else {
     request.continue();
@@ -154,7 +154,7 @@ function readoutCardsEmpty(request) {
  * @param {Request} request
  */
 function readoutCardList(request) {
-  if (request.url().includes('/api/getCRUs')) {
+  if (request.url().includes('/api/consul/crus')) {
     request.respond({status: 200, contentType: 'application/json', body: JSON.stringify(readoutCards)});
   } else {
     request.continue();

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -398,7 +398,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
    * @param {Request} request
    */
   function getFLPList(request) {
-    if (request.url().includes('/api/getFLPs')) {
+    if (request.url().includes('/api/consul/flps')) {
       request.respond({
         status: 200, contentType: 'application/json', body: JSON.stringify({
           flps: ['alio2-cr1-flp134', 'alio2-cr1-flp136', 'alio2-cr1-flp137'],

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -39,7 +39,7 @@ module.exports = {
     readoutPath: 'test/o2/readout/components',
     readoutCardPath: 'test/o2/readoutcard/components',
     qcPath: 'test/o2/qc/components',
-    consulKVPrefix: 'test/ui/some-cluster/kv',
+    kVPrefix: 'test/ui/some-cluster/kv',
   },
   infoLoggerGui: {
     hostname: 'localhost',


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Updates include:
* Using naming convention for API Consul paths
* Fixing a bug in which a wrong default was used as host for infologger redirect [OGUI-944]
* Refactoring in which consul configuration is build only once and passed to the services and client 