### PR TITLE
[OGUI-777] Proportionate column sizes

### DIFF
--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -282,17 +282,19 @@ const showEnvTasksTable = (environment, tasks) => {
       ),
       h('tbody', [
         tasks.map((task) => [h('tr', [
-          h('td', task.name),
-          h('td', h('.flex-row.items-center.justify-center.w-33', task.locked ? iconLockLocked() : iconLockUnlocked())),
-          h('td', task.status),
-          h('td', {
+          h('td.w-40', task.name),
+          h('td.w-10',
+            h('.flex-row.items-center.justify-center.w-33', task.locked ? iconLockLocked() : iconLockUnlocked())
+          ),
+          h('td.w-10', task.status),
+          h('td.w-10', {
             class: (task.state === 'RUNNING' ? 'success' :
               (task.state === 'CONFIGURED' ? 'warning' :
                 ((task.state === 'ERROR' || task.state === 'UNKNOWN') ? 'danger' : ''))),
             style: 'font-weight: bold;'
           }, task.state),
-          h('td', task.deploymentInfo.hostname),
-          h('td',
+          h('td.w-20', task.deploymentInfo.hostname),
+          h('td.w-10',
             h('button.btn-sm.btn-default', {
               title: 'More Details',
               onclick: () => environment.task.toggleTaskView(task.taskId),

--- a/Control/public/task/taskPage.js
+++ b/Control/public/task/taskPage.js
@@ -145,15 +145,15 @@ const taskTable = (items) =>
           h('tr', ['Name', 'PID', 'State', 'Locked'].map((header) => h('th', header)))
         ),
         h('tbody', items[hostname].list.map((task) => [h('tr', [
-          h('td', task.name),
-          h('td', task.pid),
-          h('td', {
+          h('td.w-50', task.name),
+          h('td.w-10', task.pid),
+          h('td.w-10', {
             class: (task.state === 'RUNNING' ? 'success'
               : (task.state === 'CONFIGURED' ? 'warning'
                 : ((task.state === 'ERROR' || task.state === 'UNKNOWN') ? 'danger' : ''))),
             style: 'font-weight: bold;'
           }, task.state),
-          h('td', task.locked ? iconLockLocked('fill-orange') : iconLockUnlocked('fill-green'))
+          h('td.w-10', task.locked ? iconLockLocked('fill-orange') : iconLockUnlocked('fill-green'))
         ])]))
       ])
     ])


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Column sizes will use percentage of the screen but will always keep the same percent no matter the content so that all tables per machine will be displayed-inline one under the other