### PR TITLE
Fix winston logging from InfoLoggerSender

### DIFF
--- a/Framework/Backend/log/InfoLoggerSender.js
+++ b/Framework/Backend/log/InfoLoggerSender.js
@@ -31,9 +31,9 @@ class InfoLoggerSender {
     this.path = '/opt/o2-InfoLogger/bin/o2-infologger-log';
     fs.access(this.path, fs.constants.X_OK, (err) => {
       if (err) {
-        winston.debug('[ILSender] InfoLogger executable not found');
+        this.winston.debug('[ILSender] InfoLogger executable not found');
       } else {
-        winston.debug('[ILSender] Created instance of InfoLogger sender');
+        this.winston.debug('[ILSender] Created instance of InfoLogger sender');
         this.configured = true;
       }
     });

--- a/Framework/Backend/log/InfoLoggerSender.js
+++ b/Framework/Backend/log/InfoLoggerSender.js
@@ -31,9 +31,9 @@ class InfoLoggerSender {
     this.path = '/opt/o2-InfoLogger/bin/o2-infologger-log';
     fs.access(this.path, fs.constants.X_OK, (err) => {
       if (err) {
-        winston.instance.debug('[ILSender] InfoLogger executable not found');
+        winston.debug('[ILSender] InfoLogger executable not found');
       } else {
-        winston.instance.debug('[ILSender] Created instance of InfoLogger sender');
+        winston.debug('[ILSender] Created instance of InfoLogger sender');
         this.configured = true;
       }
     });
@@ -51,7 +51,7 @@ class InfoLoggerSender {
       log = this._removeNewLinesAndTabs(log);
       execFile(this.path, [
         `-oSeverity=${severity}`, `-oFacility=${facility}`, `-oSystem=GUI`, `-oLevel=${level}`, `${log}`
-      ], function(error, stdout, stderr) {
+      ], (error, stdout, stderr) => {
         if (error) {
           this.winston.debug(`[ILSender] Impossible to write a log to InfoLogger due to: ${error}`);
         }

--- a/Framework/Backend/log/Log.js
+++ b/Framework/Backend/log/Log.js
@@ -35,7 +35,7 @@ class Log {
       winston.instance.debug('Created default instance of console logger');
     }
     if (!infologger) {
-      infologger = new InfoLoggerSender(winston);
+      infologger = new InfoLoggerSender(winston.instance);
     }
   }
 

--- a/Framework/Backend/test/mocha-log.js
+++ b/Framework/Backend/test/mocha-log.js
@@ -42,7 +42,7 @@ describe('Logging: InfoLogger sender', () => {
   let sender;
   before(() => {
     const winston = new Winston();
-    sender = new InfoLoggerSender(winston, config.log.infologger.sender);
+    sender = new InfoLoggerSender(winston.instance, config.log.infologger.sender);
   })
   it('Send log over named socket', function() {
     if (skip) {


### PR DESCRIPTION
This unifies `winston` vs `winston.instance` and avoids node crashing when misused.