### PR TITLE
[OMON-487] Embed Grafana plots from different origin

### DIFF
--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -25,8 +25,7 @@ module.exports = {
     package: 'apricot'
   },
   grafana: {
-    hostname: 'localhost',
-    port: 3000
+    url: 'http://localhost:3000'
   },
   kafka: {
     hostnames: 'localhost', // can be a string with multiple hostnames delimited by comma

--- a/Control/index.js
+++ b/Control/index.js
@@ -23,6 +23,7 @@ const api = require('./lib/api.js');
 
 buildPublicConfig(config);
 
+config.http.iframeCsp = (config?.grafana?.url) ? [ config.grafana.url ] : [];
 const http = new HttpServer(config.http, config.jwt, config.openId);
 const ws = new WebSocket(http);
 http.addStaticPath(path.join(__dirname, 'public'));

--- a/Control/lib/config/configProvider.js
+++ b/Control/lib/config/configProvider.js
@@ -42,4 +42,8 @@ const config = require(configFile);
 Log.configure(config);
 log.info(`Read config file "${configFile}"`);
 
+// Add Grafana URL to frame-src CSP
+config.http.iframeCsp = (config?.grafana?.url) ? [ config.grafana.url ] : [];
+log.debug("Setting frame-src CSP ", config.http.iframeCsp);
+
 module.exports = config;

--- a/Control/lib/config/configProvider.js
+++ b/Control/lib/config/configProvider.js
@@ -42,8 +42,4 @@ const config = require(configFile);
 Log.configure(config);
 log.info(`Read config file "${configFile}"`);
 
-// Add Grafana URL to frame-src CSP
-config.http.iframeCsp = (config?.grafana?.url) ? [ config.grafana.url ] : [];
-log.debug("Setting frame-src CSP ", config.http.iframeCsp);
-
 module.exports = config;

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -68,8 +68,8 @@ function getConsulConfig(config) {
  * @return {JSON}
  */
 function _getGrafanaConfig(config) {
-  if (config?.grafana && config?.http?.hostname && config?.grafana?.port) {
-    const hostPort = `http://${config.http.hostname}:${config.grafana.port}`;
+  if (config?.grafana && config?.grafana?.url) {
+    const hostPort = config.grafana.url;
     const plotReadoutRateNumber = 'd-solo/TZsAxKIWk/readout?orgId=1&panelId=6';
     const plotReadoutRate = 'd-solo/TZsAxKIWk/readout?orgId=1&panelId=8';
     const plotReadoutRateGraph = 'd-solo/TZsAxKIWk/readout?orgId=1&panelId=4';

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -68,7 +68,7 @@ function getConsulConfig(config) {
  * @return {JSON}
  */
 function _getGrafanaConfig(config) {
-  if (config?.grafana && config?.grafana?.url) {
+  if (config?.grafana?.url) {
     const hostPort = config.grafana.url;
     const plotReadoutRateNumber = 'd-solo/TZsAxKIWk/readout?orgId=1&panelId=6';
     const plotReadoutRate = 'd-solo/TZsAxKIWk/readout?orgId=1&panelId=8';

--- a/Control/lib/services/StatusService.js
+++ b/Control/lib/services/StatusService.js
@@ -12,6 +12,7 @@
  * or submit itself to any jurisdiction.
 */
 
+const url = require('url');
 const projPackage = require('../../package.json');
 const {httpGetJson} = require('./../utils.js');
 
@@ -101,11 +102,10 @@ class StatusService {
    */
   async getGrafanaStatus() {
     let grafana = {};
-    if (this.config?.http?.hostname && this.config?.grafana?.port) {
-      grafana = this.config.grafana;
-      grafana.hostname = this.config.http.hostname;
+    if (this.config?.grafana?.url) {
+      grafana = url.parse(this.config.grafana.url)
       try {
-        await httpGetJson(this.config.http.hostname, this.config.grafana.port, '/api/health');
+        await httpGetJson(grafana.hostname, grafana.port, '/api/health');
         grafana.status = {ok: true, configured: true};
       } catch (error) {
         grafana.status = {ok: false, configured: true, message: error.toString()};

--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aliceo2/web-ui": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-1.20.0.tgz",
-      "integrity": "sha512-+8+5AvsGlXHKecJoqqg6NJ9WupdX74R35faExEt1ZZTjK0ucOE+AKuE4kVLDtG4jfhHVQYiE5IXTM3K2O8jWhA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-1.20.1.tgz",
+      "integrity": "sha512-PGkxlWGAkywPiHR5RxW22UGX9eMpDWymVZMB60tpdtBpt9fNIeuZJgPShIMTKBG94/t/zMjdmRm7/5/R27MpJA==",
       "requires": {
         "express": "^4.17.1",
         "helmet": "^4.1.1",
@@ -1746,11 +1746,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2706,14 +2701,14 @@
       }
     },
     "logform": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
-      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.0.tgz",
+      "integrity": "sha512-graeoWUH2knKbGthMtuG1EfaSPMZFZBIrhuJHhkS5ZseFBrc7DupCzihOQAzsK/qIKPQaPJ/lFQFctILUY5ARQ==",
       "requires": {
         "colors": "^1.2.1",
-        "fast-safe-stringify": "^2.0.4",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
+        "safe-stable-stringify": "^1.1.0",
         "triple-beam": "^1.3.0"
       },
       "dependencies": {
@@ -3470,9 +3465,9 @@
       }
     },
     "openid-client": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.7.5.tgz",
-      "integrity": "sha512-9APA9gHikzzRCc9z3lmIsZ1LcRHho9uTXxt567QlVmAmS2qoVpChTOdla7US9RrbiZsIh50xXd9DpLzh68FtgQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.9.0.tgz",
+      "integrity": "sha512-ThBbvRUUZwxUKBVK2UpDNIZ3eJkvtqWI8s5Dm+naV+gJdL+yRhT+8ywqct1gy5uL+xVS5+A/nhFcpJIisH2x6Q==",
       "requires": {
         "aggregate-error": "^3.1.0",
         "got": "^11.8.0",
@@ -4030,6 +4025,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/Control/package.json
+++ b/Control/package.json
@@ -27,7 +27,7 @@
     "coverage-local": "nyc --reporter=lcov npm run mocha"
   },
   "dependencies": {
-    "@aliceo2/web-ui": "1.20.0",
+    "@aliceo2/web-ui": "1.20.1",
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
     "kafka-node": "^4.1.3"

--- a/Control/test/lib/mocha-public-config.js
+++ b/Control/test/lib/mocha-public-config.js
@@ -58,6 +58,6 @@ describe('Public Configuration Test Suite', () => {
         'http://local:2000/d-solo/HBa9akknk/dd?orgId=1&panelId=10&refresh=5s&theme=light'
       ]
     };
-    assert.deepStrictEqual(_getGrafanaConfig({http: {hostname: 'local'}, grafana: {port: 2000}}), expectedConf);
+    assert.deepStrictEqual(_getGrafanaConfig({grafana: {url: 'http://local:2000'}}), expectedConf);
   });
 });

--- a/Control/test/lib/mocha-status-service.js
+++ b/Control/test/lib/mocha-status-service.js
@@ -115,34 +115,34 @@ describe('StatusService test suite', () => {
   });
 
   describe('Test Grafana Status', async () => {
-    const config = {grafana: {port: 8082}, http: {hostname: 'localh'}};
-    const expectedInfo = {hostname: 'localh', port: 8082};
+    const config = {grafana: {url: 'http://localhost:8084'}};
+    const expectedInfo = {protocol: 'http:', hostname: 'localhost', port: 8084};
 
     it('should successfully retrieve status and info about Grafana that it is running', async () => {
       const status = new StatusService(config, {}, {});
       const grafanaStatus = await status.getGrafanaStatus();
-      nock(`http://${config.http.hostname}:${config.grafana.port}`)
+      nock(config.grafana.url)
         .get('/api/health')
         .reply(200, {});
-      expectedInfo.status = {ok: true, configured: true};
-      assert.deepStrictEqual(grafanaStatus, expectedInfo);
+      assert.deepStrictEqual(grafanaStatus.status, {ok: true, configured: true});
+      assert.equal(grafanaStatus.protocol, expectedInfo.protocol);
+      assert.equal(grafanaStatus.hostname,  expectedInfo.hostname);
+      assert.equal(grafanaStatus.port,  expectedInfo.port);
     });
 
     it('should successfully retrieve status and info about AliECS that it is not running', async () => {
       const status = new StatusService(config, {}, {});
       const grafanaStatus = await status.getGrafanaStatus();
-      nock(`http://${config.http.hostname}:${config.grafana.port}`)
+      nock(config.grafana.url)
         .get('/api/health')
         .replyWithError('Unable to connect');
-      expectedInfo.status = {ok: false, configured: true, message: 'Error: Unable to connect'};
-      assert.deepStrictEqual(grafanaStatus, expectedInfo);
+      assert.deepStrictEqual(grafanaStatus.status, {ok: false, configured: true, message: 'Error: Unable to connect'});
     });
 
     it('should successfully return that grafana was not configured if configuration is not provided', async () => {
       const status = new StatusService({}, {}, {});
       const grafanaStatus = await status.getGrafanaStatus();
-      const expected = {status: {ok: false, configured: false, message: 'This service was not configured'}};
-      assert.deepStrictEqual(grafanaStatus, expected);
+      assert.deepEqual(grafanaStatus.status, {ok: false, configured: false, message: 'This service was not configured'});
     });
   });
 

--- a/Control/test/lib/mocha-status-service.js
+++ b/Control/test/lib/mocha-status-service.js
@@ -116,7 +116,7 @@ describe('StatusService test suite', () => {
 
   describe('Test Grafana Status', async () => {
     const config = {grafana: {url: 'http://localhost:8084'}};
-    const expectedInfo = {protocol: 'http:', hostname: 'localhost', port: 8084};
+    const expectedInfo = {protocol: 'http:', hostname: 'localhost', port: '8084'};
 
     it('should successfully retrieve status and info about Grafana that it is running', async () => {
       const status = new StatusService(config, {}, {});
@@ -125,9 +125,9 @@ describe('StatusService test suite', () => {
         .get('/api/health')
         .reply(200, {});
       assert.deepStrictEqual(grafanaStatus.status, {ok: true, configured: true});
-      assert.equal(grafanaStatus.protocol, expectedInfo.protocol);
-      assert.equal(grafanaStatus.hostname,  expectedInfo.hostname);
-      assert.equal(grafanaStatus.port,  expectedInfo.port);
+      assert.strictEqual(grafanaStatus.protocol, expectedInfo.protocol);
+      assert.strictEqual(grafanaStatus.hostname,  expectedInfo.hostname);
+      assert.strictEqual(grafanaStatus.port,  expectedInfo.port);
     });
 
     it('should successfully retrieve status and info about AliECS that it is not running', async () => {
@@ -142,7 +142,7 @@ describe('StatusService test suite', () => {
     it('should successfully return that grafana was not configured if configuration is not provided', async () => {
       const status = new StatusService({}, {}, {});
       const grafanaStatus = await status.getGrafanaStatus();
-      assert.deepEqual(grafanaStatus.status, {ok: false, configured: false, message: 'This service was not configured'});
+      assert.deepStrictEqual(grafanaStatus.status, {ok: false, configured: false, message: 'This service was not configured'});
     });
   });
 

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -55,7 +55,6 @@ module.exports = {
     port:8081
   },
   grafana: {
-    hostname: 'localhost',
-    port: 2020
+    url: 'http://localhost:2020'
   }
 };


### PR DESCRIPTION
This enables embedding Grafana plots from different origin, in configuration `grafana.url` is required instead of `grafana.port`