### PR TITLE
[OGUI-954] Adds detector view and panel to allow selection by the user

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -94,6 +94,10 @@ export default class Model extends Observable {
    * * wait for use to make their selection
    */
   async init() {
+    if (!this.router.params.page) {
+      // if page is loaded as host:port only a default route has to bepassed
+      this.router.go('?page=environments');
+    }
     await this.detectors.init();
     if (this.detectors.selected) {
       this.handleLocationChange();

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -194,6 +194,19 @@ export default class Model extends Observable {
   }
 
   /**
+   * Reset detector view by:
+   * * removing current selection
+   * * retrieving a list of detectors
+   * * opening modal and allowing the user to make a new selection
+   */
+  async resetDetectorView() {
+    this.detectors.saveSelection('');
+    this.notify();
+    await this.detectors.init();
+    this.notify();
+  }
+
+  /**
    * Display a browser notification(Notification - Web API)
    * @param {String} message
    */

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -91,11 +91,11 @@ export default class Model extends Observable {
   /**
    * If no detector view is selected:
    * * load a list of detectors
-   * * wait for use to make their selection
+   * * wait for user to make their selection
    */
   async init() {
     if (!this.router.params.page) {
-      // if page is loaded as host:port only a default route has to bepassed
+      // if page is loaded as host:port only, a default route has to be passed
       this.router.go('?page=environments');
     }
     await this.detectors.init();

--- a/Control/public/app.css
+++ b/Control/public/app.css
@@ -49,3 +49,6 @@
 #workflow-variable-info-label:hover + #workflow-variable-info { visibility: visible; transition-delay: .3s}
 .dropdown-menu-right { z-index: 300; box-shadow: 0 8px 17px 2px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12), 0 5px 5px -3px rgba(0,0,0,0.2); visibility: hidden; position: absolute; top: calc(100% + 0.1rem); right: 0.1rem; z-index: 1000; font-size: 1rem; background-color: #fff; border: 1px solid rgba(0,0,0,.15); border-radius: .25rem; }
 .dropdown-menu-left { z-index: 300; box-shadow: 0 8px 17px 2px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12), 0 5px 5px -3px rgba(0,0,0,0.2); visibility: hidden; position: absolute; top: calc(100% + 0.1rem); left: 0.1rem; z-index: 1000; font-size: 1rem; background-color: #fff; border: 1px solid rgba(0,0,0,.15); border-radius: .25rem; }
+
+.o2-modal{z-index:1001; display:block; padding-top:10em; position:fixed; left:0; top:0; width:100%; height:100%; overflow:auto; background-color:rgb(0,0,0); background-color:rgba(0,0,0,0.4); }
+.o2-modal-content{margin:auto; background-color:#fff; position:relative; padding:0; outline:0; width:700px;  border-radius: 5px 20px 5px; }

--- a/Control/public/common/detectorHeader.js
+++ b/Control/public/common/detectorHeader.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {h, iconPencil} from '/js/src/index.js';
+
+/**
+ * Component which will display selected detectors to filter data based on
+ * To be used in most of the pages to display the selection
+ * @param {Object} model
+ * @return {vnode}
+ */
+const detectorHeader = (model) => {
+  const selected = model.detectors.selected;
+  if (selected) {
+    return h('.w-100.bg-gray-light.pv2', [
+      h('h4.f5.flex-row', {style: 'justify-content: center;'},
+        h('.ph2', `Detector View: ${selected}`),
+        h('a.f6.actionable-icon', {
+          onclick: () => model.resetDetectorView('')
+        }, [iconPencil()])
+      )
+    ])
+  }
+};
+
+export {detectorHeader};

--- a/Control/public/common/detectorModal.js
+++ b/Control/public/common/detectorModal.js
@@ -28,7 +28,7 @@ const detectorsModal = (model) =>
         h('h4', 'Select your detector view'),
         h('label', {style: 'font-style: italic;'}, 'Displayed data will be filtered based on your selection')
       ]),
-      h('.w-100.flex-row', {style: 'flex-wrap: wrap'}, [
+      h('.w-100.flex-row', {style: 'flex-wrap: wrap; justify-content:center'}, [
         model.detectors.listRemote.match({
           NotAsked: () => null,
           Loading: () => h('.w-100.text-center', loading(2)),
@@ -41,6 +41,7 @@ const detectorsModal = (model) =>
       h('.w-100.pv3.f3.flex-row', {style: 'justify-content:center;'},
         h('.w-50.flex-column.dropdown#flp_selection_info_icon', [
           h(`button.btn.btn-default.w-100`, {
+            id: `GLOBALViewButton`,
             onclick: () => model.setDetectorView('GLOBAL'),
           }, 'GLOBAL'),
           h('.p2.dropdown-menu-right#flp_selection_info.text-center', {style: 'width: 350px'},
@@ -59,6 +60,7 @@ const detectorsModal = (model) =>
 const detectorsList = (model, list) =>
   list.map((detector) => h('.w-25.pv3.text-center.f3',
     h('button.btn.btn-default.w-70', {
+      id: `${detector}ViewButton`,
       onclick: () => model.setDetectorView(detector)
     }, detector)
   ));

--- a/Control/public/common/detectorModal.js
+++ b/Control/public/common/detectorModal.js
@@ -21,39 +21,34 @@ import loading from './loading.js';
  * @param {Object} model
  * @return {vnode}
  */
-const detectorsModal = (model) => {
-  const selected = model.detectors.selected;
-  if (!selected) {
-    const detectors = model.detectors.listRemote;
-    return h('.o2-modal',
-      h('.o2-modal-content', [
-        h('.p2.text-center', [
-          h('h4', 'Select your detector view'),
-          h('label', {style: 'font-style: italic;'}, 'Displayed data will be filtered based on your selection')
-        ]),
-        h('.w-100.flex-row', {style: 'flex-wrap: wrap'}, [
-          detectors.match({
-            NotAsked: () => null,
-            Loading: () => h('.w-100.text-center', loading(2)),
-            Success: (data) => detectorsList(model, data),
-            Failure: (_) => h('.w-100.text-center.danger', [
-              iconCircleX(), ' Unable to load list of detectors. Use GLOBAL View'
-            ])
-          })
-        ]),
-        h('.w-100.pv3.f3.flex-row', {style: 'justify-content:center;'},
-          h('.w-50.flex-column.dropdown#flp_selection_info_icon', [
-            h(`button.btn.btn-default.w-100`, {
-              onclick: () => model.setDetectorView('GLOBAL'),
-            }, 'GLOBAL'),
-            h('.p2.dropdown-menu-right#flp_selection_info.text-center', {style: 'width: 350px'},
-              'Use GLOBAL view to make use of data from all detectors')
+const detectorsModal = (model) =>
+  !model.detectors.selected && h('.o2-modal',
+    h('.o2-modal-content', [
+      h('.p2.text-center', [
+        h('h4', 'Select your detector view'),
+        h('label', {style: 'font-style: italic;'}, 'Displayed data will be filtered based on your selection')
+      ]),
+      h('.w-100.flex-row', {style: 'flex-wrap: wrap'}, [
+        model.detectors.listRemote.match({
+          NotAsked: () => null,
+          Loading: () => h('.w-100.text-center', loading(2)),
+          Success: (data) => detectorsList(model, data),
+          Failure: (_) => h('.w-100.text-center.danger', [
+            iconCircleX(), ' Unable to load list of detectors. Use GLOBAL View'
           ])
-        )
-      ])
-    );
-  }
-};
+        })
+      ]),
+      h('.w-100.pv3.f3.flex-row', {style: 'justify-content:center;'},
+        h('.w-50.flex-column.dropdown#flp_selection_info_icon', [
+          h(`button.btn.btn-default.w-100`, {
+            onclick: () => model.setDetectorView('GLOBAL'),
+          }, 'GLOBAL'),
+          h('.p2.dropdown-menu-right#flp_selection_info.text-center', {style: 'width: 350px'},
+            'Use GLOBAL view to make use of data from all detectors')
+        ])
+      )
+    ])
+  );
 
 /**
  * Build a wrapped list of detector buttons

--- a/Control/public/common/detectorModal.js
+++ b/Control/public/common/detectorModal.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {h, iconCircleX} from '/js/src/index.js';
+import loading from './loading.js';
+
+/**
+ * Component which will display a modal allowing the users to select their detector view
+ * No matter the page location, modal will be displayed if user did not make a selection
+ * @param {Object} model
+ * @return {vnode}
+ */
+const detectorsModal = (model) => {
+  const selected = model.detectors.selected;
+  if (!selected) {
+    const detectors = model.detectors.listRemote;
+    return h('.o2-modal',
+      h('.o2-modal-content', [
+        h('.p2.text-center', [
+          h('h4', 'Select your detector view'),
+          h('label', {style: 'font-style: italic;'}, 'Displayed data will be filtered based on your selection')
+        ]),
+        h('.w-100.flex-row', {style: 'flex-wrap: wrap'}, [
+          detectors.match({
+            NotAsked: () => null,
+            Loading: () => h('.w-100.text-center', loading(2)),
+            Success: (data) => detectorsList(model, data),
+            Failure: (_) => h('.w-100.text-center.danger', [
+              iconCircleX(), ' Unable to load list of detectors. Use GLOBAL View'
+            ])
+          })
+        ]),
+        h('.w-100.pv3.f3.flex-row', {style: 'justify-content:center;'},
+          h('.w-50.flex-column.dropdown#flp_selection_info_icon', [
+            h(`button.btn.btn-default.w-100`, {
+              onclick: () => model.setDetectorView('GLOBAL'),
+            }, 'GLOBAL'),
+            h('.p2.dropdown-menu-right#flp_selection_info.text-center', {style: 'width: 350px'},
+              'Use GLOBAL view to make use of data from all detectors')
+          ])
+        )
+      ])
+    );
+  }
+};
+
+/**
+ * Build a wrapped list of detector buttons
+ * @param {Object} model
+ * @param {List<String>} list
+ * @returns {vnode}
+ */
+const detectorsList = (model, list) =>
+  list.map((detector) => h('.w-25.pv3.text-center.f3',
+    h('button.btn.btn-default.w-70', {
+      onclick: () => model.setDetectorView(detector)
+    }, detector)
+  ));
+
+export {detectorsModal};

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -49,7 +49,7 @@ export const header = (model) => [
 export const content = (model) => h('.scroll-y.absolute-fill', [
   model.environment.item.match({
     NotAsked: () => null,
-    Loading: () => pageLoading(),
+    Loading: () => h('.w-100.text-center', pageLoading()),
     Success: (data) => showContent(model.environment, data.environment),
     Failure: (error) => errorPage(error),
   })

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -16,6 +16,7 @@ import {h, iconPlus} from '/js/src/index.js';
 import pageLoading from '../common/pageLoading.js';
 import errorPage from '../common/errorPage.js';
 import {parseObject} from './../common/utils.js';
+import {detectorHeader} from '../common/detectorHeader.js';
 
 /**
  * @file Page to show a list of environments (content and header)
@@ -42,6 +43,7 @@ export const header = (model) => [
  * @return {vnode}
  */
 export const content = (model) => h('.scroll-y.absolute-fill.text-center', [
+  detectorHeader(model),
   model.environment.list.match({
     NotAsked: () => null,
     Loading: () => pageLoading(),

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -97,14 +97,28 @@ const environmentsTable = (model, list) => {
           style: 'font-weight: bold; text-align: center;'
         }, item.state
         ),
-        h('td', {style: 'text-align: center;'},
-          h('button.btn.btn-primary', {
-            title: 'Open the environment page with more details',
-            onclick: () => model.router.go(`?page=environment&id=${item.id}`),
-          }, 'Details')
-        )
+        h('td', {style: 'text-align: center;'}, actionsCell(model, item))
       ]),
       ),
     ]),
   ]);
 };
+
+/**
+ * Return a button if detector of the environment is among
+ * the ones belonging the environment
+ * @param {Object} model
+ * @param {JSON} item
+ * @return {vnode}
+ */
+const actionsCell = (model, item) => {
+  const isDetectorIncluded = item.includedDetectors.includes(model.detectors.selected);
+  if (isDetectorIncluded || model.detectors.selected === 'GLOBAL') {
+    return h('button.btn.btn-primary', {
+      title: 'Open the environment page with more details',
+      onclick: () => model.router.go(`?page=environment&id=${item.id}`),
+    }, 'Details')
+  } else {
+    return h('', '')
+  }
+}

--- a/Control/public/services/DetectorService.js
+++ b/Control/public/services/DetectorService.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+import {Observable, RemoteData, BrowserStorage} from '/js/src/index.js';
+import {STORAGE} from './../workflow/constants.js';
+
+/**
+ * Model representing API Calls regarding Detectors
+ */
+export default class DetectorService extends Observable {
+  /**
+   * Initialize service with model object
+   * @param {Observable} model
+   */
+  constructor(model) {
+    super();
+    this.model = model;
+    this.storage = new BrowserStorage(`COG-${this.model.router.location.hostname}`);
+
+    this.listRemote = RemoteData.notAsked();
+    this._selected = '';
+  }
+
+  /**
+   * Load the selected detector from LocalStorage;
+   * Initialize to empty string if the user did not select any
+   */
+  async init() {
+    const stored = this.storage.getLocalItem(STORAGE.DETECTOR);
+    if (stored && stored.SELECTED) {
+      this._selected = stored.SELECTED;
+    } else {
+      this._selected = '';
+      this.listRemote = await this.getDetectorsAsRemoteData(this.listRemote);
+    }
+    this.notify();
+  }
+
+  /**
+   * Update selection for detector view in LocalStorage
+   * Format: {SELECTED: <string>}
+   * @param {Array<String>} detector
+   */
+  saveSelection(detector) {
+    this._selected = detector;
+    this.storage.setLocalItem(STORAGE.DETECTOR, {SELECTED: detector});
+  }
+
+  /**
+   * HTTP Calls
+   */
+
+  /**
+   * Fetch detectors and return it as a remoteData object
+   * @param {RemoteData} item
+   */
+  async getDetectorsAsRemoteData(item) {
+    item = RemoteData.loading();
+    this.notify();
+
+    const {result, ok} = await this.model.loader.post(`/api/ListDetectors`);
+    if (!ok) {
+      item = RemoteData.failure(result.message);
+    } else {
+      item = RemoteData.success(result.detectors);
+    }
+    this.notify();
+    return item;
+  }
+
+  /**
+   * Fetch detectors and return it as a remoteData object
+   * @param {RemoteData} item
+   */
+  async getActiveDetectorsAsRemoteData(item) {
+    item = RemoteData.loading();
+    this.notify();
+
+    const {result, ok} = await this.model.loader.post(`/api/GetActiveDetectors`);
+    if (!ok) {
+      item = RemoteData.failure(result.message);
+    } else {
+      item = RemoteData.success(result.detectors);
+    }
+    this.notify();
+    return item;
+  }
+
+  /**
+   * Getters & Setters
+   */
+
+  /**
+   * Return selected detectors
+   * @return {String}
+   */
+  get selected() {
+    return this._selected;
+  }
+
+  /**
+   * Set the selected detectors
+   * @param {String}
+   */
+  set selected(detector) {
+    this._selected = detector;
+  }
+}

--- a/Control/public/services/DetectorService.js
+++ b/Control/public/services/DetectorService.js
@@ -55,6 +55,7 @@ export default class DetectorService extends Observable {
   saveSelection(detector) {
     this._selected = detector;
     this.storage.setLocalItem(STORAGE.DETECTOR, {SELECTED: detector});
+    this.notify();
   }
 
   /**

--- a/Control/public/view.js
+++ b/Control/public/view.js
@@ -44,6 +44,7 @@ import {
   content as taskContent,
   header as taskHeader
 } from './task/taskPage.js';
+import {detectorsModal} from './common/detectorModal.js';
 
 /**
  * Main view layout
@@ -52,6 +53,7 @@ import {
  */
 export default (model) => [
   notification(model.notification),
+  detectorsModal(model),
   h('.flex-column absolute-fill', [
     header(model),
     h('.flex-grow flex-row', [

--- a/Control/public/workflow/constants.js
+++ b/Control/public/workflow/constants.js
@@ -43,4 +43,8 @@ const VAR_TYPE = {
   JSON: 'JSON',
 }
 
-export {PREFIX, WIDGET_VAR, VAR_TYPE};
+const STORAGE = {
+  DETECTOR: 'DETECTOR'
+}
+
+export {PREFIX, WIDGET_VAR, VAR_TYPE, STORAGE};

--- a/Control/public/workflow/workflowsPage.js
+++ b/Control/public/workflow/workflowsPage.js
@@ -19,6 +19,7 @@ import mainPanel from './panels/variables/mainPanel.js';
 import advancedVarsPanel from './panels/variables/advancedPanel.js';
 import flpSelectionPanel from './panels/flps/flpSelectionPanel.js';
 import detectorsPanel from './panels/flps/detectorsPanel.js';
+import {detectorHeader} from './../common/detectorHeader.js';
 import errorComponent from './../common/errorComponent.js';
 import pageLoading from '../common/pageLoading.js';
 import errorPage from '../common/errorPage.js';
@@ -40,14 +41,17 @@ export const header = (model) => h('h4.w-100 text-center', 'New Environment');
  * @param {Object} model
  * @return {vnode}
  */
-export const content = (model) => h('.scroll-y.absolute-fill.text-center.p2', [
-  model.workflow.repoList.match({
-    NotAsked: () => null,
-    Loading: () => pageLoading(),
-    Success: (repoList) => (repoList.repos.length === 0)
-      ? h('h3.m4', ['No repositories found.']) : showNewEnvironmentForm(model, repoList.repos),
-    Failure: (error) => errorPage(error),
-  })
+export const content = (model) => h('.scroll-y.absolute-fill.text-center', [
+  detectorHeader(model),
+  h('.p2',
+    model.workflow.repoList.match({
+      NotAsked: () => null,
+      Loading: () => pageLoading(),
+      Success: (repoList) => (repoList.repos.length === 0)
+        ? h('h3.m4', ['No repositories found.']) : showNewEnvironmentForm(model, repoList.repos),
+      Failure: (error) => errorPage(error),
+    })
+  )
 ]);
 
 /**

--- a/Control/public/workflow/workflowsPage.js
+++ b/Control/public/workflow/workflowsPage.js
@@ -19,7 +19,6 @@ import mainPanel from './panels/variables/mainPanel.js';
 import advancedVarsPanel from './panels/variables/advancedPanel.js';
 import flpSelectionPanel from './panels/flps/flpSelectionPanel.js';
 import detectorsPanel from './panels/flps/detectorsPanel.js';
-import {detectorHeader} from './../common/detectorHeader.js';
 import errorComponent from './../common/errorComponent.js';
 import pageLoading from '../common/pageLoading.js';
 import errorPage from '../common/errorPage.js';

--- a/Control/public/workflow/workflowsPage.js
+++ b/Control/public/workflow/workflowsPage.js
@@ -41,17 +41,17 @@ export const header = (model) => h('h4.w-100 text-center', 'New Environment');
  * @param {Object} model
  * @return {vnode}
  */
-export const content = (model) => h('.scroll-y.absolute-fill.text-center', [
-  detectorHeader(model),
-  h('.p2',
-    model.workflow.repoList.match({
-      NotAsked: () => null,
-      Loading: () => pageLoading(),
-      Success: (repoList) => (repoList.repos.length === 0)
-        ? h('h3.m4', ['No repositories found.']) : showNewEnvironmentForm(model, repoList.repos),
-      Failure: (error) => errorPage(error),
-    })
-  )
+export const content = (model) => h('.scroll-y.absolute-fill.text-center.p2', [
+  // detectorHeader(model),
+  // h('.p2',
+  model.workflow.repoList.match({
+    NotAsked: () => null,
+    Loading: () => pageLoading(),
+    Success: (repoList) => (repoList.repos.length === 0)
+      ? h('h3.m4', ['No repositories found.']) : showNewEnvironmentForm(model, repoList.repos),
+    Failure: (error) => errorPage(error),
+  })
+  // )
 ]);
 
 /**

--- a/Control/test/integration/core-tests.js
+++ b/Control/test/integration/core-tests.js
@@ -49,6 +49,23 @@ describe('Control', function() {
     }
   });
 
+  it('should select detector view GLOBAL and redirect to environments page', async() => {
+    const [label] = await page.$x(`//div/button[@id="GLOBALViewButton"]`);
+    if (label) {
+      await label.click();
+      await page.waitForTimeout(200);
+      const location = await page.evaluate(() => window.location);
+      assert.strictEqual(location.search, '?page=environments','nu vreeeeea');
+    } else {
+      assert.ok(false, `Unable to click GLOBAL View`);
+    }
+  });
+
+  it('should successfully set selected detector', async() => {
+    const selected = await page.evaluate(() => window.model.detectors.selected);
+    assert.strictEqual(selected, 'GLOBAL');
+  });
+
   it('should have redirected to default page "/?page=environments"', async () => {
     const location = await page.evaluate(() => window.location);
     assert.strictEqual(location.search, '?page=environments', 'Could not load home page of AliECS GUI');

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -59,7 +59,7 @@ describe('Control', function() {
     this.ok = true;
 
     // Start browser to test UI
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: false});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: true});
     page = await browser.newPage();
 
     // Listen to browser

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -57,5 +57,9 @@ module.exports = {
   grafana: {
     hostname: 'localhost',
     port: 2020
+  },
+  utils: {
+    refreshTask: 5000, // how often should task list page should refresh its content
+    refreshEnvs: 10000, // how often should env list page should refresh its content
   }
 };


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which adds detector view to AlIECS GUI:
* If no detector view is saved in local storage of the browser, than the GUI will:
   * not load any AliECS information needed for the current page;
   * will load the detectors list
   *  it will display a modal to allow the user to select a detector view
   * once a detector is selected it will save it in LocalStorage browser for future use
* If a detector view is saved, the page will load normally
* The environments page table will only allow to view more details of environments of that detector or of all if GLOBAL is selected
* The user can change their selection by clicking on the detector header currently present on pages `environments` and and `newEnvironment`