### PR TITLE
[IOGUI-981] Allow for missing links in configuration

### DIFF
--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -66,7 +66,7 @@ module.exports.setup = (http, ws) => {
     ctrlService.isConnectionReady.bind(ctrlService),
     ctrlService.isLockSetUp.bind(ctrlService),
     ctrlService.logAction.bind(ctrlService),
-  ]
+  ];
   ctrlProxy.methods.forEach(
     (method) => http.post(`/${method}`, coreMiddleware, (req, res) => ctrlService.executeCommand(req, res))
   );

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -56,7 +56,7 @@ function getConsulConfig(config) {
     conf.kvStoreQC = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.qcPath}`;
     conf.kvStoreReadout = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.readoutPath}`;
     conf.qcPrefix = `${conf.hostname}:${conf.port}/${conf.qcPath}/`;
-    conf.readoutPrefix = `${conf.hostname}:${conf.port}/${conf.readoutPath}/`
+    conf.readoutPrefix = `${conf.hostname}:${conf.port}/${conf.readoutPath}/`;
     return conf;
   }
   return {};

--- a/Control/lib/control-core/ApricotService.js
+++ b/Control/lib/control-core/ApricotService.js
@@ -100,7 +100,7 @@ class ApricotService {
     }
 
     if (missingFields.length !== 0) {
-      throw new Error(`Configuration cannot be saved without the following fields: ${missingFields.toString()}`)
+      throw new Error(`Configuration cannot be saved without the following fields: ${missingFields.toString()}`);
     } else {
       const user = {
         username: req?.session?.username ?? 'anonymous',

--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -97,7 +97,7 @@ class GrpcProxy {
       isValid = false;
     }
     if (!path) {
-      log.error('Missing path for gRPC API declaration')
+      log.error('Missing path for gRPC API declaration');
       isValid = false;
     }
     if (!config.label) {

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -196,7 +196,7 @@ const linksPanel = (model, cru) => {
  * Based on this selection the links panel will be hidden
  * @param {Object} model
  * @param {JSON} cru
- * @returns {vndoe}
+ * @returns {vnode}
  */
 const toggleUserLogic = (model, cru) =>
   h('label.d-inline.f6', {
@@ -270,7 +270,7 @@ const tasksMessagePanel = (model) =>
   h('.w-100.p2', {
     style: 'border: 1px solid #ddd;'
   }, [
-    h('.danger.w-90', 'The following errors occured during execution:'),
+    h('.danger.w-90', 'The following errors ocurred during execution:'),
     model.configuration.failedTasks.map((task) =>
       (task.id && task.host) ? h('.danger.flex-row', [
         '- task id:',

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -240,7 +240,7 @@ const toggleAllCheckBox = (model, cru, linksList) =>
  * @return {vnode}
  */
 const checkBox = (model, key, config) => {
-  let id = '-';
+  let id;
   try {
     id = '#' + key.split('link')[1];
   } catch (error) {

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -177,20 +177,19 @@ const cruPanelByEndpoint = (model, cruId, cru, host) => {
  * @param {JSON} cru
  * @return {vnode}
  */
-const linksPanel = (model, cru) =>
-  (cru.config && cru.config.cru) ?
-    h('.flex-row.w-75', [
+const linksPanel = (model, cru) => {
+  const linksKeyList = Object.keys(cru.config).filter((configField) => configField.match('link[0-9]{1,2}')); // select only fields from links0 to links11
+  if (cru.config && cru.config.cru) {
+    return h('.flex-row.w-75', [
       h('.w-15', toggleUserLogic(model, cru)),
-      Object.keys(cru.config)
-        .filter((configField) => configField.match('link[0-9]{1,2}'))
-        .length !== 0 && h('.w-15', toggleAllCheckBox(model, cru)),
+      linksKeyList.length !== 0 && h('.w-15', toggleAllCheckBox(model, cru, linksKeyList)),
       h('.w-70.flex-row.flex-wrap', [
-        Object.keys(cru.config)
-          .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
-          .map((link, index) => checkBox(model, `link${index}`, `#${index}`, cru.config)),
+        linksKeyList.map((link) => checkBox(model, link, cru.config)),
       ])
     ])
-    : h('.d-inline.f6.text-light', 'No configuration found for this serial:endpoint');
+  }
+  return h('.d-inline.f6.text-light', 'No configuration found for this serial:endpoint');
+};
 
 /**
  * Add a checkbox for the user to enable/disable the user logic
@@ -219,23 +218,16 @@ const toggleUserLogic = (model, cru) =>
  * @param {JSON} cru - reference to the currently displayed cru
  * @return {vnode}
  */
-const toggleAllCheckBox = (model, cru) =>
+const toggleAllCheckBox = (model, cru, linksList) =>
   h('label.d-inline.f6.ph2', {
     style: 'white-space: nowrap',
     title: `Toggle selection of all links`
   }, h('input', {
     type: 'checkbox',
-    checked: Object.keys(cru.config)
-      .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
-      .filter((key) => cru.config[key].enabled === 'true').length === 12,
+    checked: linksList.filter((key) => cru.config[key].enabled === 'true').length === linksList.length,
     onchange: () => {
-      const areAllChecked =
-        Object.keys(cru.config)
-          .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
-          .filter((key) => cru.config[key].enabled === 'true').length === 12;
-      Object.keys(cru.config)
-        .filter((configField) => configField.match('link[0-9]{1,2}')) // select only fields from links0 to links11
-        .forEach((key) => cru.config[key].enabled = !areAllChecked ? 'true' : 'false');
+      const areAllChecked = linksList.filter((key) => cru.config[key].enabled === 'true').length === linksList.length;
+      linksList.forEach((key) => cru.config[key].enabled = !areAllChecked ? 'true' : 'false');
       model.configuration.notify();
     }
   }), ' All Links');
@@ -243,12 +235,18 @@ const toggleAllCheckBox = (model, cru) =>
 /**
  * Generate a checkbox based on title and field to change
  * @param {Object} model
- * @param {string} title
+ * @param {string} key - format link0
  * @param {JSON} config - reference to the configuration in CRUsMapByHost
  * @return {vnode}
  */
-const checkBox = (model, key, title, config) =>
-  h('label.d-inline.f6.ph2', {
+const checkBox = (model, key, config) => {
+  let id = '-';
+  try {
+    id = '#' + key.split('link')[1];
+  } catch (error) {
+    id = key;
+  }
+  return h('label.d-inline.f6.ph2', {
     style: 'white-space: nowrap',
     title: `Toggle selection of ${key}`
   }, h('input', {
@@ -258,7 +256,8 @@ const checkBox = (model, key, title, config) =>
       config[key].enabled = config[key].enabled !== 'true' ? 'true' : 'false';
       model.configuration.notify();
     }
-  }), ' ' + title);
+  }), ' ' + id);
+};
 
 /**
  * Builds a panel under the command buttons to display failed tasks information

--- a/Control/public/task/Task.js
+++ b/Control/public/task/Task.js
@@ -44,7 +44,7 @@ export default class Task extends Observable {
 
     await this.model.detectors.getAndSetDetectorsAsRemoteData();
     if (this.model.detectors.listRemote.isSuccess()) {
-      const detectorMap = {}
+      const detectorMap = {};
       await Promise.all(
         this.model.detectors.listRemote.payload.map(async (detector) => {
           let hosts = RemoteData.notAsked();

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -56,7 +56,7 @@ export default class Workflow extends Observable {
 
     this.templatesVarsMap = {};
     this.selectedVarsMap = {};
-    this.groupedPanels = {}
+    this.groupedPanels = {};
     this.panelsUtils = {};
 
     this.READOUT_PREFIX = PREFIX.READOUT;
@@ -65,7 +65,7 @@ export default class Workflow extends Observable {
     this.dom = {
       keyInput: '',
       keyValueArea: ''
-    }
+    };
 
     this.advErrorPanel = [];
     this.kvPairsString = ''; // variable stored for Adv Config Panel

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -30,7 +30,7 @@ export default class FlpSelection extends Observable {
     this.list = RemoteData.notAsked();
     this.firstFlpSelection = -1;
 
-    this.hostsByDetectors = {}
+    this.hostsByDetectors = {};
 
     this.detectors = RemoteData.notAsked();
     this.activeDetectors = RemoteData.notAsked();
@@ -62,7 +62,7 @@ export default class FlpSelection extends Observable {
     // Initialize selection
     this.selectedDetectors = [];
     this.list = RemoteData.notAsked();
-    this.hostsByDetectors = {}
+    this.hostsByDetectors = {};
     this.workflow.form.setHosts([]);
     this.unavailableDetectors = [];
     this.missingHosts = [];


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Users might want to remove links from Consul Configuration from various reasons (e.g. no fibre cable)
Because of this, the GUI should not assume `link0` to `link11` will always exist