### PR TITLE
[OGUI-973] Hide topology on EPN false

### DIFF
--- a/Control/public/common/utils.js
+++ b/Control/public/common/utils.js
@@ -25,7 +25,7 @@ const parseObject = (item, key) => {
     case 'epn_enabled':
       return item[key] && item[key] === 'true' ? 'ON' : 'OFF'
     case 'odc_topology':
-      if (item[key] && item['epn_enabled']) {
+      if (item[key] && item['epn_enabled'] && item['epn_enabled'] === 'true') {
         const pathList = item[key].split('/');
         if (pathList.length > 0) {
           return pathList[pathList.length - 1];


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

If EPN is not enabled, topology should not be displayed in the active environments table even if it is specified