### PR TITLE
[OGUI-976] Detector view included on configuration page

### DIFF
--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -207,8 +207,10 @@ export default class Model extends Observable {
   async resetDetectorView() {
     this.detectors.saveSelection('');
     this.notify();
-    await this.detectors.init();
-    this.notify();
+    if (!this.detectors.listRemote.isSuccess() || !this.detectors.hostsByDetectorRemote.isSuccess()) {
+      await this.detectors.init();
+      this.notify();
+    }
   }
 
   /**

--- a/Control/public/app.css
+++ b/Control/public/app.css
@@ -34,6 +34,7 @@
 .menu-title-large { text-transform: uppercase; height: 2em; line-height: 2em; color: var(--color-gray-darker); padding-left: 0.2em; font-size: 0.9em; font-weight: 100; margin: 0.5em; user-select: none; }
 
 .panel-title { border: 1px solid #ddd; background: var(--color-gray-light); }
+.panel-title-lighter { border: 1px solid #ddd; background: var(--color-gray-lighter); }
 .panel { border: 1px solid var(--color-gray-light); }
 
 .border-bot { border-bottom: 1px solid var(--color-gray-light); }

--- a/Control/public/configuration/ConfigByCru.js
+++ b/Control/public/configuration/ConfigByCru.js
@@ -31,6 +31,7 @@ export default class Config extends Observable {
 
     this.cruMapByHost = RemoteData.notAsked();
 
+    this.detectorPanel = {}; // JSON in which the state of detector panels
     this.cruToggleByHost = {}; // JSON in which the state of displayed information is saved
     this.cruToggleByCruEndpoint = {};
     this.selectedHosts = [];
@@ -45,6 +46,9 @@ export default class Config extends Observable {
    */
   init() {
     this.failedTasks = [];
+    if (this.model.detectors.listRemote.isSuccess()) {
+      this.model.detectors.listRemote.payload.forEach((detector) => this.detectorPanel[detector] = {isOpen: false});
+    }
   }
 
   /**


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Includes detector view on the configuration page
* Filters data based on detector selected
* Groups all hosts by detectors
* Loads detectors data only on page refresh; Navigating from one page to another will not request a new list of detectors and hosts anymore; Current pages sharing this are `tasks` and `configuration`