### PR TITLE
[OGUI-1012] Improvements for FLP & Detectors selection panels

### DIFF
--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -79,8 +79,7 @@ export default class Workflow extends Observable {
       this.reloadDataForm();
     }
     this.getAndSetSavedConfigurations();
-    this.flpSelection.getAndSetDetectors();
-    this.flpSelection.missingHosts = [];
+    this.flpSelection.init();
     this.selectedConfigurationId = '-';
     this.resetErrorMessage();
   }

--- a/Control/public/workflow/WorkflowForm.js
+++ b/Control/public/workflow/WorkflowForm.js
@@ -71,11 +71,13 @@ export default class WorkflowForm extends Observable {
   }
 
   /**
-   * Add a host to the list of selected ones
+   * Add a host to the list of selected ones if it is not included already
    * @param {String} host
    */
   addHost(host) {
-    this.hosts.push(host);
+    if (!this.hosts.includes(host)) {
+      this.hosts.push(host);
+    }
     this.notify();
   }
 

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -237,8 +237,22 @@ export default class FlpSelection extends Observable {
   }
 
   /**
-   * HTTP Requests
+   * Given a detector name, build a string containing the name and number of selected hosts
+   * and available hosts for that detector
+   * @param {String} detector
+   * @returns {String}
    */
+  getDetectorWithIndexes(detector) {
+    const hostsByDetectorRemote = this.workflow.model.detectors.hostsByDetectorRemote;
+    if (hostsByDetectorRemote.isSuccess() && hostsByDetectorRemote.payload[detector]) {
+      const hosts = hostsByDetectorRemote.payload[detector];
+      const selectedHosts = this.workflow.form.hosts;
+      const totalSelected = selectedHosts.filter((host) => hosts.includes(host)).length;
+
+      return detector + ' (' + totalSelected + '/' + hosts.length + ')'
+    }
+    return detector;
+  }
 
   /**
    * Given a detector name, if hosts were successfully loaded on page load,
@@ -247,7 +261,7 @@ export default class FlpSelection extends Observable {
    * as selected for the user
    * @param {String} detector
    */
-  async setHostsForDetector(detector, shouldSelect = false) {
+  setHostsForDetector(detector, shouldSelect = false) {
     const hostsByDetectorRemote = this.workflow.model.detectors.hostsByDetectorRemote;
     if (!hostsByDetectorRemote.isSuccess()) {
       this.list = RemoteData.failure(hostsByDetectorRemote.message);

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -61,7 +61,6 @@ export default class FlpSelection extends Observable {
     ) {
       // if single view preselect detectors and hosts for users
       this.toggleDetectorSelection(this.workflow.model.detectors.selected);
-      this.toggleAllFLPSelection();
     }
   }
 
@@ -130,7 +129,7 @@ export default class FlpSelection extends Observable {
         this.removeHostsByDetector(name);
       } else if (!this.isDetectorActive(name)) {
         this.selectedDetectors.push(name);
-        this.setHostsForDetector(name);
+        this.setHostsForDetector(name, true);
       }
     }
     this.notify();
@@ -244,9 +243,11 @@ export default class FlpSelection extends Observable {
   /**
    * Given a detector name, if hosts were successfully loaded on page load,
    * update the list of hosts by adding the ones for the given detector
+   * If specified via shouldSelect, it will also add the hosts to the form so that they appeared
+   * as selected for the user
    * @param {String} detector
    */
-  async setHostsForDetector(detector) {
+  async setHostsForDetector(detector, shouldSelect = false) {
     const hostsByDetectorRemote = this.workflow.model.detectors.hostsByDetectorRemote;
     if (!hostsByDetectorRemote.isSuccess()) {
       this.list = RemoteData.failure(hostsByDetectorRemote.message);
@@ -255,6 +256,9 @@ export default class FlpSelection extends Observable {
       let temp = [];
       Object.keys(this.hostsByDetectors).forEach((detector) => temp = temp.concat(this.hostsByDetectors[detector]));
       this.list = RemoteData.success(temp);
+      if (shouldSelect) {
+        this.hostsByDetectors[detector].forEach((hostname) => this.workflow.form.addHost(hostname));
+      }
     }
     this.notify();
   }

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -68,5 +68,5 @@ const detectorItem = (name, workflow) => {
     className,
     title,
     onclick: () => workflow.flpSelection.toggleDetectorSelection(name)
-  }, name)
+  }, workflow.flpSelection.getDetectorWithIndexes(name))
 };

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -91,9 +91,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
     assert.ok(flps.length > 0);
   });
 
-  it('should successfully select a host', async () => {
-    await page.evaluate(() => document.querySelector(
-      'body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div:nth-child(2) > div > div > div:nth-child(3) > div > div:nth-child(2) > div > a').click());
+  it('should successfully preselect hosts for TST detector', async () => {
     const flps = await page.evaluate(() => window.model.workflow.form.hosts);
     assert.ok(flps.length > 0);
   });

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -410,11 +410,9 @@ describe('`pageNewEnvironment` test-suite', async () => {
     assert.deepStrictEqual(flps, ['ali-flp-22', 'ali-flp-23']);
   });
 
-  it('should successfully select a host', async () => {
-    await page.evaluate(() => document.querySelector(
-      'body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div:nth-child(2) > div > div > div:nth-child(3) > div > div:nth-child(2) > div > a').click());
+  it('should successfully preselect hosts for selected detector', async () => {
     const flps = await page.evaluate(() => window.model.workflow.form.hosts);
-    assert.deepStrictEqual(flps, ['ali-flp-22']);
+    assert.deepStrictEqual(flps, ['ali-flp-22', 'ali-flp-23']);
   });
 
   it('should successfully save configuration', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

*  detectors and flps will automatically be selected in detector view but not for global view
*  when clicking on a detector, all hosts will automatically be selected
* the detector selection widget will show how many FLPs are selected, e.g. "TPC (80)", or even better "TPC (80/145)" (meaning 80 out of 145 selected)
* adds check not to duplicate hosts selection (without using a set for browser compatibility)