### PR TITLE
[OGUI-851] Tab selection changes saved objects order

### DIFF
--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/qc",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/qc",
-      "version": "2.6.2",
+      "version": "2.7.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "jsroot"

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "O2 Quality Control Web User Interface",
   "author": "George Raduta",
   "contributors": [

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -247,7 +247,7 @@ export default class Layout extends Observable {
       throw new Error(`index ${index} does not exist`);
     }
 
-    this.tab = this.item.tabs[index];
+    this.tab = JSON.parse(JSON.stringify(this.item.tabs[index]));
     this.model.object.loadObjects(this.tab.objects.map((object) => object.name));
     const columns = this.item.tabs[index].columns;
     if (columns > 0) {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

When switching tabs in a layout, the order of the the objects is not always maintained. This is fixed by passing objects by value rather than referrence. 
Bumps minor version