### PR TITLE
[OGUI-1055] Add status route to ILG

### DIFF
--- a/InfoLogger/lib/StatusService.js
+++ b/InfoLogger/lib/StatusService.js
@@ -49,6 +49,23 @@ class StatusService {
   }
 
   /**
+   * Method which handles the request for returning infologger gui information and status of it
+   * @param {Request} req
+   * @param {Response} res
+   */
+  async getILGStatus(_, res) {
+    let result = {};
+    if (this.projPackage && this.projPackage.version) {
+      result.version = this.projPackage.version;
+    }
+    if (this.config.http) {
+      const ilg = {hostname: this.config.http.hostname, port: this.config.http.port, status: {ok: true}};
+      result = Object.assign(result, ilg);
+    }
+    res.status(200).json(result);
+  }
+
+  /**
    * Method which handles the request for returning 
    * framework information and status of its components
    * @param {Request} req

--- a/InfoLogger/lib/api.js
+++ b/InfoLogger/lib/api.js
@@ -30,11 +30,14 @@ const profileService = new ProfileService(jsonDb);
 const statusService = new StatusService(config, projPackage);
 
 module.exports.attachTo = (http, ws) => {
+  http.post('/query', query);
+
+  http.get('/status/gui', statusService.getILGStatus.bind(statusService), {public: true});
   http.get('/getFrameworkInfo', statusService.frameworkInfo.bind(statusService), {public: true});
+
   http.get('/getUserProfile', (req, res) => profileService.getUserProfile(req, res));
   http.get('/getProfile', (req, res) => profileService.getProfile(req, res));
   http.post('/saveUserProfile', (req, res) => profileService.saveUserProfile(req, res));
-  http.post('/query', query);
 
   if (config.mysql) {
     log.info(`[API] Detected InfoLogger database configuration`);

--- a/InfoLogger/package-lock.json
+++ b/InfoLogger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/infologger",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "bundleDependencies": [
         "@aliceo2/web-ui"
       ],

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Infologger GUI to query and stream log events",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/InfoLogger/test/lib/mocha-status-service.js
+++ b/InfoLogger/test/lib/mocha-status-service.js
@@ -119,4 +119,20 @@ describe('Status Service test suite', () => {
       assert.ok(res.json.calledWith(info));
     });
   });
+
+  describe('`getILGStatus()` tests', () => {
+    it('should successfully send response with JSON information about ILG', async () => {
+      const statusService = new StatusService(config, undefined);
+      const res = {
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub()
+      }
+      await statusService.getILGStatus(undefined, res);
+
+      const info = {hostname: 'localhost', port: 8080, status: {ok: true}};
+
+      assert.ok(res.status.calledWith(200));
+      assert.ok(res.json.calledWith(info));
+    });
+  });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Add a new route in QCG `/status/gui` to be used by `FLP Diagnose` service.
* New route should send back QCG configuration and the status of it.