### PR TITLE
[OGUI-1066] Use node 16 for control compatibility

### DIFF
--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - run: (cd Control; npm ci)
       - run: (cd Control; npm i --save ../Framework)
       - name: Check @aliceo2/web-ui was successfully linked locally


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Use node `16.x` for framework - aliecs gui compatibility tests