### PR TITLE
[OGUI-1067] Add aliases to CRU Configuration page

### DIFF
--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -31,6 +31,7 @@ module.exports = {
     hostname: 'localhost',
     port: 8500,
     flpHardwarePath: 'o2/hardware/key/prefix',
+    detHardwarePath: 'o2/hardware/detectors',
     readoutPath: 'o2/components/readout/key/prefix',
     readoutCardPath: 'o2/components/readoutcard/key/prefix',
     qcPath: 'o2/components/qc/key/prefix',

--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -113,6 +113,7 @@ module.exports.setup = (http, ws) => {
   http.get('/consul/flps', validateService, (req, res) => consulConnector.getFLPs(req, res));
   http.get('/consul/crus', validateService, (req, res) => consulConnector.getCRUs(req, res));
   http.get('/consul/crus/config', validateService, (req, res) => consulConnector.getCRUsWithConfiguration(req, res));
+  http.get('/consul/crus/aliases', validateService, (req, res) => consulConnector.getCRUsAlias(req, res));
   http.post('/consul/crus/config/save', validateService, (req, res) => consulConnector.saveCRUsConfiguration(req, res));
 
   /**

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -48,12 +48,13 @@ function buildPublicConfig(config) {
 function getConsulConfig(config) {
   if (config?.consul) {
     const conf = config.consul;
-    conf.protocol = conf?.protocol ? conf.protocol : 'http';
-    conf.flpHardwarePath = conf?.flpHardwarePath ? conf.flpHardwarePath : 'o2/hardware/flps';
-    conf.readoutCardPath = conf?.readoutCardPath ? conf.readoutCardPath : 'o2/components/readoutcard';
-    conf.qcPath = conf?.qcPath ? conf.qcPath : 'o2/components/qc';
-    conf.readoutPath = conf?.readoutPath ? conf.readoutPath : 'o2/components/readout';
-    conf.kVPrefix = conf?.kVPrefix ? conf.kVPrefix : 'ui/alice-o2-cluster/kv';
+    conf.protocol = conf?.protocol || 'http';
+    conf.flpHardwarePath = conf?.flpHardwarePath || 'o2/hardware/flps';
+    conf.detHardwarePath = conf?.detHardwarePath ||'o2/hardware/detectors',
+    conf.readoutCardPath = conf?.readoutCardPath || 'o2/components/readoutcard';
+    conf.qcPath = conf?.qcPath || 'o2/components/qc';
+    conf.readoutPath = conf?.readoutPath || 'o2/components/readout';
+    conf.kVPrefix = conf?.kVPrefix || 'ui/alice-o2-cluster/kv';
 
     conf.kvStoreQC = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.qcPath}`;
     conf.kvStoreReadout = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.readoutPath}`;

--- a/Control/lib/utils.js
+++ b/Control/lib/utils.js
@@ -22,11 +22,7 @@ const http = require('http');
  * @param {number} status - status code 4xx 5xx, 500 will print to debug
  */
 function errorHandler(err, res, status = 500, facility = 'utils') {
-  log.facility = `${process.env.npm_config_log_label ?? 'cog'}/${facility}`;
-  if (err.stack) {
-    log.trace(err);
-  }
-  log.error(err.message || err);
+  errorLogger(err, facility);
   res.status(status);
   res.send({message: err.message || err});
 }
@@ -35,7 +31,8 @@ function errorHandler(err, res, status = 500, facility = 'utils') {
  * Global Error Logger for AliECS GUI
  * @param {Error} err 
  */
-function errorLogger(err) {
+function errorLogger(err, facility = 'utils') {
+  log.facility = `${process.env.npm_config_log_label ?? 'cog'}/${facility}`;
   if (err.stack) {
     log.trace(err);
   }

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -186,6 +186,7 @@ export default class Model extends Observable {
       case 'configuration':
         this.configuration.init();
         this.configuration.getCRUsConfig();
+        this.configuration.getCRUsAliases();
         break;
       case 'hardware':
         break;

--- a/Control/public/configuration/ConfigByCru.js
+++ b/Control/public/configuration/ConfigByCru.js
@@ -34,6 +34,7 @@ export default class Config extends Observable {
     this.detectorPanel = {}; // JSON in which the state of detector panels
     this.cruToggleByHost = {}; // JSON in which the state of displayed information is saved
     this.cruToggleByCruEndpoint = {}; // JSON in which it is saved the current state of the cru by endpoint panels
+    this.cruAlias = RemoteData.notAsked();
     this.selectedHosts = [];
 
     this.configurationRequest = RemoteData.notAsked();
@@ -41,6 +42,7 @@ export default class Config extends Observable {
     this.channelId = 0;
 
     this.isForceEnabled = false;
+    this.areAliasesOn = false;
   }
 
   /**
@@ -112,6 +114,40 @@ export default class Config extends Observable {
     }
     this.addToggleOptions(result);
     this.cruMapByHost = RemoteData.success(result);
+    this.notify();
+  }
+
+  /**
+   * Retrieve a JSON object of aliases for FLPs, card:endpoint and links which 
+   * are to be used for labeling
+   * @example
+   * {
+   *   "flp": {
+   *      "alias": "mini-flp", 
+   *   },
+   *   "cards:" {
+   *     "1106:0": {
+   *       "alias": "card-mini",
+   *       "links": {
+   *         "0": {
+   *           "alias": "name for zero"
+   *         }
+   *       }
+   *     }
+   *   }
+   * }
+   */
+  async getCRUsAliases() {
+    this.crusAliases = RemoteData.loading();
+    this.notify();
+
+    const {result, ok} = await this.model.loader.get(`/api/consul/crus/aliases`);
+    if (!ok) {
+      this.crusAliases = RemoteData.failure(result.message);
+      this.notify();
+      return;
+    }
+    this.crusAliases = RemoteData.success(result);
     this.notify();
   }
 

--- a/Control/public/configuration/components/linkCheckBox.js
+++ b/Control/public/configuration/components/linkCheckBox.js
@@ -23,15 +23,10 @@ import {h} from '/js/src/index.js';
  * @param {Object} model
  * @param {string} key - format link0
  * @param {JSON} config - reference to the configuration in CRUsMapByHost
+ * @param {string} label - name of link
  * @return {vnode}
  */
-const cruLinkCheckBox = (model, key, config) => {
-  let id;
-  try {
-    id = '#' + key.split('link')[1];
-  } catch (error) {
-    id = key;
-  }
+const cruLinkCheckBox = (model, key, config, label) => {
   return h('label.d-inline.f6.ph2', {
     style: 'white-space: nowrap',
     title: `Toggle selection of ${key}`
@@ -42,7 +37,7 @@ const cruLinkCheckBox = (model, key, config) => {
       config[key].enabled = config[key].enabled !== 'true' ? 'true' : 'false';
       model.configuration.notify();
     }
-  }), ' ' + id);
+  }), label);
 };
 
 export {cruLinkCheckBox};

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -76,8 +76,9 @@ const buildPage = (model, cruMapByHost) => {
       ]),
       tasksMessagePanel(model),
       h('.w-100.flex-row', [
-        h('.w-70', [
-          forceFlagCheckbox(model),
+        h('.w-70.flex-row', [
+          forceFlagCheckbox(model.configuration),
+          toggleAliases(model.configuration),
         ]),
         h('a.w-30', {
           style: 'display:flex; justify-content: flex-end',
@@ -96,18 +97,18 @@ const buildPage = (model, cruMapByHost) => {
 /**
  * Adds a checkbox and label which will send to AliECS a boolean
  * to add the force flag when running roc-config
- * @param {Object} model
+ * @param {ConfigByCru} configuration
  * @returns {vnode}
  */
-const forceFlagCheckbox = (model) => h(`.flex-row`, [
+const forceFlagCheckbox = (configuration) => h(`.flex-row.w-20.items-center`, [
   h('input', {
     type: 'checkbox',
     style: 'cursor: pointer',
     id: 'forceConfigId',
-    checked: model.configuration.isForceEnabled,
+    checked: configuration.isForceEnabled,
     onchange: () => {
-      model.configuration.isForceEnabled = !model.configuration.isForceEnabled;
-      model.configuration.notify();
+      configuration.isForceEnabled = !configuration.isForceEnabled;
+      configuration.notify();
     },
   }),
   h('label.f6.ph2', {
@@ -116,6 +117,32 @@ const forceFlagCheckbox = (model) => h(`.flex-row`, [
     title: `Use '--force-config' when running o2-roc-config`
   }, `Run with '--force'`),
 ]);
+
+/**
+ * Adds a checkbox which will allow the user to see aliases for FLPs, card:endpoint or links
+If no alias is identified, the normal label will be used
+ * @param {ConfigByCru} configuration
+ * @returns {vnode}
+ */
+const toggleAliases = (configuration) => h('.flex-row.w-20.items-center', [
+  h('input', {
+    type: 'checkbox',
+    style: 'cursor: pointer',
+    id: 'showAliasesId',
+    checked: configuration.areAliasesOn,
+    onchange: () => {
+      configuration.areAliasesOn = !configuration.areAliasesOn;
+      configuration.notify();
+    },
+  }),
+  h('label.f6.ph2', {
+    for: 'showAliasesId',
+    style: `font-weight: bold; margin-bottom:0;cursor:pointer`,
+    title: `Show aliases for FLPs, card:endpoint or links`
+  }, `Show Aliases`),
+]
+
+)
 
 /**
  * Build a series of panels for each detector based on the current view of the user
@@ -132,7 +159,7 @@ const cruByDetectorPanel = (model, cruMapByHost) => {
         && hostsByDetector[detector].filter((host) => cruMapByHost[host]).length > 0;
       return h('.w-100.pv2', [
         h('.panel-title.flex-row.pv2', [
-          h('.w-20.flex-row.ph2', [
+          h('.w-20.flex-row.ph2.items-center', [
             hasCRUs && h('input', {
               type: 'checkbox',
               style: 'cursor: pointer',
@@ -173,10 +200,17 @@ const cruByDetectorPanel = (model, cruMapByHost) => {
  * @param {JSON} cruMapByHost 
  * @returns 
  */
-const cruByHostPanel = (model, host, cruData) =>
-  h('', [
+const cruByHostPanel = (model, host, cruData) => {
+  let hostLabel = host;
+  if (model.configuration.crusAliases.isSuccess() && model.configuration.areAliasesOn) {
+    const aliases = model.configuration.crusAliases.payload;
+    if (aliases[host] && aliases[host].alias) {
+      hostLabel = aliases[host].alias;
+    }
+  }
+  return h('', [
     h('.panel-title-lighter.pv2.flex-row', [
-      h('.w-20.flex-row.ph2', [
+      h('.w-20.flex-row.ph2.items-center', [
         h('input', {
           type: 'checkbox',
           id: `${host}Checkbox`,
@@ -195,7 +229,7 @@ const cruByHostPanel = (model, host, cruData) =>
         h('label.w-100', {
           for: `${host}Checkbox`,
           style: `font-weight: bold; margin-bottom:0;cursor:pointer;`
-        }, host)
+        }, hostLabel)
       ]),
       userLogicCheckBox(model, host, 'host', '.w-15'),
       toggleAllLinksCheckBox(model, host, 'host', '.w-15')
@@ -204,7 +238,8 @@ const cruByHostPanel = (model, host, cruData) =>
       Object.keys(cruData)
         .map((cruId) => cruPanelByEndpoint(model, cruId, cruData[cruId], host))
     ])
-  ]);
+  ])
+};
 
 /**
  * Panel for each CRU endpoint to allow the user to enable/disable endpoints
@@ -215,8 +250,15 @@ const cruByHostPanel = (model, host, cruData) =>
  * @return {vnode}
  */
 const cruPanelByEndpoint = (model, cruId, cru, host) => {
-  const cruLabel = `${cru.info.serial}:${cru.info.endpoint}`;
+  let cruLabel = `${cru.info.serial}:${cru.info.endpoint}`;
   let isCruInfoVisible = model.configuration.cruToggleByCruEndpoint[`${host}_${cruId}`];
+
+  if (model.configuration.crusAliases.isSuccess() && model.configuration.areAliasesOn) {
+    const aliases = model.configuration.crusAliases.payload;
+    if (aliases[host] && aliases[host].cards && aliases[host].cards[cruLabel] && aliases[host].cards[cruLabel].alias) {
+      cruLabel = aliases[host].cards[cruLabel].alias;
+    }
+  }
   return h('.flex-column', [
     h('.flex-row.pv1.panel', {style: 'font-weight: bold'}, [
       h('.w-5.actionable-icon.text-center', {
@@ -227,7 +269,7 @@ const cruPanelByEndpoint = (model, cruId, cru, host) => {
         }
       }, isCruInfoVisible ? iconChevronBottom() : iconChevronRight()),
       h('.w-15', cruLabel),
-      linksPanel(model, cru),
+      linksPanel(model, cru, host),
     ]),
     isCruInfoVisible && h('.flex-row.p1.panel.bg-white', [
       h('.w-5', []),
@@ -244,23 +286,44 @@ const cruPanelByEndpoint = (model, cruId, cru, host) => {
 };
 
 /**
- * A panel which iterate through all links in the configuration
- * and creates a checkbox for each
+ * A panel which iterate through all links in the configuration and creates a checkbox for each;
  * It also adds UserLogic and All Links toggles
  * @param {Object} model
  * @param {JSON} cru
+ * @param {String} host - host to which the links belong to
  * @return {vnode}
  */
-const linksPanel = (model, cru) => {
+const linksPanel = (model, cru, host) => {
+  let cruLabel = `${cru.info.serial}:${cru.info.endpoint}`;
+  let linksAlias = {};
+  if (model.configuration.crusAliases.isSuccess()) {
+    const aliases = model.configuration.crusAliases.payload;
+    if (aliases[host] && aliases[host].cards && aliases[host].cards[cruLabel] && aliases[host].cards[cruLabel].links) {
+      linksAlias = aliases[host].cards[cruLabel].links;
+    }
+  }
   const linksKeyList = Object.keys(cru.config).filter((configField) => configField.match('link[0-9]{1,2}')); // select only fields from links0 to links11
   if (cru.config && cru.config.cru) {
     return [
       userLogicCheckBoxForEndpoint(model, cru, '.w-15'),
       linksKeyList.length !== 0 && toggleAllLinksCRUCheckBox(model, cru, linksKeyList, '.w-15'),
-      h('.w-50.flex-row.flex-wrap', {
-        style: 'justify-content: flex-end'
-      }, [
-        linksKeyList.map((link) => cruLinkCheckBox(model, link, cru.config)),
+      h('.w-50.flex-row.flex-wrap', [
+        linksKeyList.map((link) => {
+          let id;
+          let index = '';
+          try {
+            id = ' #' + link.split('link')[1];
+            index = link.split('link')[1];
+            if (linksAlias[index] && linksAlias[index].alias && model.configuration.areAliasesOn) {
+              id = ` ${linksAlias[index].alias}`;
+            }
+          } catch (error) {
+            console.log(error)
+            id = link;
+          }
+
+          return cruLinkCheckBox(model, link, cru.config, id)
+        }),
       ])
     ];
   }

--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -202,6 +202,7 @@ const cruByDetectorPanel = (model, cruMapByHost) => {
  */
 const cruByHostPanel = (model, host, cruData) => {
   let hostLabel = host;
+  let title = host;
   if (model.configuration.crusAliases.isSuccess() && model.configuration.areAliasesOn) {
     const aliases = model.configuration.crusAliases.payload;
     if (aliases[host] && aliases[host].alias) {
@@ -228,6 +229,7 @@ const cruByHostPanel = (model, host, cruData) => {
         ),
         h('label.w-100', {
           for: `${host}Checkbox`,
+          title,
           style: `font-weight: bold; margin-bottom:0;cursor:pointer;`
         }, hostLabel)
       ]),
@@ -251,6 +253,7 @@ const cruByHostPanel = (model, host, cruData) => {
  */
 const cruPanelByEndpoint = (model, cruId, cru, host) => {
   let cruLabel = `${cru.info.serial}:${cru.info.endpoint}`;
+  let title = cruLabel;
   let isCruInfoVisible = model.configuration.cruToggleByCruEndpoint[`${host}_${cruId}`];
 
   if (model.configuration.crusAliases.isSuccess() && model.configuration.areAliasesOn) {
@@ -268,7 +271,7 @@ const cruPanelByEndpoint = (model, cruId, cru, host) => {
           model.configuration.notify();
         }
       }, isCruInfoVisible ? iconChevronBottom() : iconChevronRight()),
-      h('.w-15', cruLabel),
+      h('.w-15', {title}, cruLabel),
       linksPanel(model, cru, host),
     ]),
     isCruInfoVisible && h('.flex-row.p1.panel.bg-white', [

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -143,6 +143,7 @@ describe('Control', function() {
         hostname: 'localhost',
         port: 8550,
         flpHardwarePath: 'test/o2/hardware/flps',
+        detHardwarePath: 'test/o2/hardware/detectors',
         readoutPath: 'test/o2/readout/components',
         readoutCardPath: 'test/o2/readoutcard/components',
         qcPath: 'test/o2/qc/components',

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -39,6 +39,7 @@ module.exports = {
     hostname: 'localhost',
     port: 8550,
     flpHardwarePath: 'test/o2/hardware/flps',
+    detHardwarePath: 'test/o2/hardware/detectors',
     readoutPath: 'test/o2/readout/components',
     readoutCardPath: 'test/o2/readoutcard/components',
     qcPath: 'test/o2/qc/components',


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Users will now be able to define aliases to their CRU hardware. List of possible elements to name:
* host
* cru(serial:endpoint)
* links

Feature will be enabled via the "Show aliases` checkbox. At all times, hovering the element will display the original name of the component.