### PR TITLE
[OGUI-1100] Enable create button if workflow is QC

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.44.0",
+      "version": "1.44.1",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/workflow/workflowsPage.js
+++ b/Control/public/workflow/workflowsPage.js
@@ -199,7 +199,7 @@ const btnCreateEnvironment = (model) => h('button.btn.btn-primary#create-env', {
   class: model.environment.itemNew.isLoading() ? 'loading' : '',
   disabled: model.environment.itemNew.isLoading() ||
     !model.workflow.form.isInputSelected() ||
-    model.workflow.flpSelection.selectedDetectors.length <= 0,
+    (model.workflow.flpSelection.selectedDetectors.length <= 0 && !model.workflow.isQcWorkflow),
   onclick: () => model.workflow.createNewEnvironment(),
   title: 'Create environment based on selected workflow'
 }, 'Create');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Check to `enable/disable` creation button should be in place for selected detectors only if selected workflow is not QC type