### PR TITLE
[OGUI-1099] Display consul URL with its UI node

### DIFF
--- a/Control/README.md
+++ b/Control/README.md
@@ -21,6 +21,7 @@
     - [GUI](#gui)
       - [Enable/Disable CRU Links](#enabledisable-cru-links)
       - [Clean Resources/Tasks](#clean-resourcestasks)
+    - [Roles](#roles)
     - [Integration with ControlWorkflows](#integration-with-controlworkflows)
       - [List of fixed variables used by AliECS GUI for user logic](#list-of-fixed-variables-used-by-aliecs-gui-for-user-logic)
       - [Dynamically built Workflow Panels](#dynamically-built-workflow-panels)
@@ -71,6 +72,7 @@ Use of a Consul instance is optional
 
 * `hostname` - Consul head node hostname
 * `port` - Consul head node port
+* `ui` - Consul UI URL (will default to `hostname:port`)
 * `flpHardwarePath` - Prefix for KV Store for the content about the FLPs machines
 * `readoutPath` - Prefix for KV Store for readout's configuration
 * `readoutCardPath` - Prefix for KV Store for readout-card's configuration

--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -28,6 +28,7 @@ module.exports = {
     url: 'http://localhost:3000'
   },
   consul: {
+    ui: 'localhost:8500',
     hostname: 'localhost',
     port: 8500,
     flpHardwarePath: 'o2/hardware/key/prefix',

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -56,8 +56,9 @@ function getConsulConfig(config) {
     conf.readoutPath = conf?.readoutPath || 'o2/components/readout';
     conf.kVPrefix = conf?.kVPrefix || 'ui/alice-o2-cluster/kv';
 
-    conf.kvStoreQC = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.qcPath}`;
-    conf.kvStoreReadout = `${conf.hostname}:${conf.port}/${conf.kVPrefix}/${conf.readoutPath}`;
+    conf.ui = conf.ui || `${conf.hostname}:${conf.port}`;
+    conf.kvStoreQC = `${conf.ui}/${conf.kVPrefix}/${conf.qcPath}`;
+    conf.kvStoreReadout = `${conf.ui}/${conf.kVPrefix}/${conf.readoutPath}`;
     conf.qcPrefix = `${conf.hostname}:${conf.port}/${conf.qcPath}/`;
     conf.readoutPrefix = `${conf.hostname}:${conf.port}/${conf.readoutPath}/`;
     return conf;

--- a/Control/public/workflow/panels/variables/basicPanel.js
+++ b/Control/public/workflow/panels/variables/basicPanel.js
@@ -349,7 +349,7 @@ const readoutPanel = (workflow) => {
           variables['readout_cfg_uri'] ?
             variables['readout_cfg_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + COG.CONSUL.readoutPrefix + (
+      }, consulPre + COG.CONSUL.kvStoreReadout + (
         variables['readout_cfg_uri'] ?
           variables['readout_cfg_uri'] : '')
       )
@@ -436,7 +436,7 @@ const qcUriPanel = (workflow) => {
           variables['qc_config_uri'] ?
             variables['qc_config_uri'] + '/edit' : '')}`,
         target: '_blank',
-      }, consulPre + COG.CONSUL.qcPrefix + (
+      }, consulPre + COG.CONSUL.kvStoreQC + (
         variables['qc_config_uri'] ?
           variables['qc_config_uri'] : '')
       )

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -141,6 +141,7 @@ describe('Control', function() {
       CONSUL: {
         protocol: 'http',
         hostname: 'localhost',
+        ui: 'localhost.cern.ch',
         port: 8550,
         flpHardwarePath: 'test/o2/hardware/flps',
         detHardwarePath: 'test/o2/hardware/detectors',
@@ -148,8 +149,8 @@ describe('Control', function() {
         readoutCardPath: 'test/o2/readoutcard/components',
         qcPath: 'test/o2/qc/components',
         kVPrefix: 'test/ui/some-cluster/kv',
-        kvStoreQC: 'localhost:8550/test/ui/some-cluster/kv/test/o2/qc/components',
-        kvStoreReadout: 'localhost:8550/test/ui/some-cluster/kv/test/o2/readout/components',
+        kvStoreQC: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/qc/components',
+        kvStoreReadout: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/readout/components',
         qcPrefix: "localhost:8550/test/o2/qc/components/",
         readoutPrefix: "localhost:8550/test/o2/readout/components/"
       },

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -36,6 +36,7 @@ module.exports = {
     package: 'apricot'
   },
   consul: {
+    ui: 'localhost.cern.ch',
     hostname: 'localhost',
     port: 8550,
     flpHardwarePath: 'test/o2/hardware/flps',


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

For display and user page redirect, the UI node of Consul shall be used
For the variable passed to AliECS, the normal server node should be used