### PR TITLE
[OGUI-1103] Update stats box on log length limit change

### DIFF
--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -106,22 +106,22 @@ export default class Log extends Observable {
    * Increments stats of the severity of the log passed
    * @param {Log} log
    */
-  addStats(log) {
+  addStats(log, increment = 1) {
     switch (log.severity) {
       case 'F':
-        this.stats.fatal++;
+        this.stats.fatal+=increment;
         break;
       case 'E':
-        this.stats.error++;
+        this.stats.error+=increment;
         break;
       case 'W':
-        this.stats.warning++;
+        this.stats.warning+=increment;
         break;
       case 'I':
-        this.stats.info++;
+        this.stats.info+=increment;
         break;
       case 'D':
-        this.stats.debug++;
+        this.stats.debug+=increment;
     }
   }
 
@@ -166,9 +166,17 @@ export default class Log extends Observable {
 
   /**
    * Set "limit" filter (1k, 10k, 100k)
+   * If the limit is being decreased:
+   * * Splices the current log list to the passed limit
+   * * Updates stat box at the bottom if the limit is being decreased
    * @param {number} limit
    */
   setLimit(limit) {
+    if (limit < this.limit) {
+      this.resetStats();
+      this.list.splice(0, this.list.length - limit);
+      this.list.forEach((log) => this.addStats(log));
+    }
     this.limit = limit;
     this.notify();
   }
@@ -473,6 +481,7 @@ export default class Log extends Observable {
     this.addStats(log);
     this.list.push(log);
     if (this.list.length > this.limit) {
+      this.addStats(this.list[0], -1);
       this.list.splice(0, this.list.length - this.limit);
     }
     this.notify();

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -109,19 +109,19 @@ export default class Log extends Observable {
   addStats(log, increment = 1) {
     switch (log.severity) {
       case 'F':
-        this.stats.fatal+=increment;
+        this.stats.fatal += increment;
         break;
       case 'E':
-        this.stats.error+=increment;
+        this.stats.error += increment;
         break;
       case 'W':
-        this.stats.warning+=increment;
+        this.stats.warning += increment;
         break;
       case 'I':
-        this.stats.info+=increment;
+        this.stats.info += increment;
         break;
       case 'D':
-        this.stats.debug+=increment;
+        this.stats.debug += increment;
     }
   }
 

--- a/InfoLogger/public/logFilter/commandFilters.js
+++ b/InfoLogger/public/logFilter/commandFilters.js
@@ -41,7 +41,7 @@ export default (model) => [
     ]),
     h('span.mh3'),
     h('.btn-group', [
-      buttonLogLimit(model, '1k', 1000),
+      buttonLogLimit(model, '1k', 100),
       buttonLogLimit(model, '10k', 10000),
       buttonLogLimit(model, '100k', 100000),
     ]),

--- a/InfoLogger/public/logFilter/commandFilters.js
+++ b/InfoLogger/public/logFilter/commandFilters.js
@@ -41,7 +41,7 @@ export default (model) => [
     ]),
     h('span.mh3'),
     h('.btn-group', [
-      buttonLogLimit(model, '1k', 100),
+      buttonLogLimit(model, '1k', 1000),
       buttonLogLimit(model, '10k', 10000),
       buttonLogLimit(model, '100k', 100000),
     ]),


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Fixes a bug in which after the limit of logs to be displayed would be reached, the stats box would continue countering;
* If the limit of logs is being decreased, the list of logs will be sliced and stats box updated accordingly