### PR TITLE
[OGUI-1131] Add env ID to env request table

### DIFF
--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -70,12 +70,18 @@ class GrpcProxy {
       return new Promise((resolve, reject) => {
         this.client[methodName](args, options, (error, response) => {
           if (error) {
-            if (methodName === 'NewEnvironment' && error.metadata?.internalRepr?.has('grpc-status-details-bin')) {
-              const buffer = error.metadata.internalRepr.get('grpc-status-details-bin').toString('base64').split('\n');
-              const index = buffer.findIndex(record => record.includes('EnvironmentInfo'));
-              if (index > 1) {
-                error.envId = buffer[index + 1].trim().substring(0, 11);
+            try {
+              if (methodName === 'NewEnvironment' && error.metadata?.internalRepr?.has('grpc-status-details-bin')) {
+                const buffer = error.metadata.internalRepr
+                  .get('grpc-status-details-bin')
+                  .toString('base64').split('\n');
+                const index = buffer.findIndex(record => record.includes('EnvironmentInfo'));
+                if (index > 1) {
+                  error.envId = buffer[index + 1].trim().substring(0, 11);
+                }
               }
+            } catch(error) {
+              log.debug('Failed new env details error' + error);
             }
             reject(error);
             return;

--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -70,6 +70,13 @@ class GrpcProxy {
       return new Promise((resolve, reject) => {
         this.client[methodName](args, options, (error, response) => {
           if (error) {
+            if (methodName === 'NewEnvironment' && error.metadata?.internalRepr?.has('grpc-status-details-bin')) {
+              const buffer = error.metadata.internalRepr.get('grpc-status-details-bin').toString('base64').split('\n');
+              const index = buffer.findIndex(record => record.includes('EnvironmentInfo'));
+              if (index > 1) {
+                error.envId = buffer[index + 1].trim().substring(0, 11);
+              }
+            }
             reject(error);
             return;
           }

--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -80,13 +80,12 @@ class GrpcProxy {
                   error.envId = buffer[index + 1].trim().substring(0, 11);
                 }
               }
-            } catch(error) {
-              log.debug('Failed new env details error' + error);
+            } catch(exception) {
+              log.debug('Failed new env details error' + exception);
             }
             reject(error);
             return;
           }
-
           resolve(response);
         });
       });

--- a/Control/lib/control-core/RequestHandler.js
+++ b/Control/lib/control-core/RequestHandler.js
@@ -64,6 +64,9 @@ class RequestHandler {
       errorLogger('Request failed, ID: ' + index);
       this.requestList[index].failed = true;
       this.requestList[index].message = error.details;
+      if (error.envId) {
+        this.requestList[index].envId = error.envId;
+      }
     }
     this.broadcast();
   }

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -90,14 +90,15 @@ const requestsTable = (model, requests) =>
     h('thead', [
       h('tr.primary.bg-white',
         {style: 'border-top: 2px solid var(--color-gray); border-bottom: 1px solid var(--color-gray)'},
-        h('th', {colspan: 7}, 'Environment creation requests')
+        h('th', {colspan: 8}, 'Environment creation requests')
       ),
-      h('tr', [['Detectors', 'Workflow', 'Created by', 'When', 'State', 'Message', 'Action'].map((header) =>
+      h('tr', [['ID', 'Detectors', 'Workflow', 'Created by', 'When', 'State', 'Message', 'Action'].map((header) =>
         h('th', {style: 'text-align: center;'}, header)
       )])
     ]),
     h('tbody', [
       requests.map(item => h('tr', {style: {background: item.failed ? 'rgba(214, 38, 49, 0.2)' : '' }}, [
+        h('td', {style: 'text-align: center;'}, item.envId || '-'),
         h('td', {style: 'text-align: center;'}, item.detectors),
         h('td', {style: 'text-align: center;'}, item.workflow.substring(
           item.workflow.lastIndexOf('/') + 1, item.workflow.indexOf('@')

--- a/Control/test/public/page-environments-mocha.js
+++ b/Control/test/public/page-environments-mocha.js
@@ -94,8 +94,8 @@ describe('`pageEnvironments` test-suite', () => {
 
     it('verify request fields', async () => {
       await waitForEnvRequest(page);
-      const detector = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(1)').innerText);
-      const state = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(5)').innerText);
+      const detector = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(2)').innerText);
+      const state = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(6)').innerText);
       assert.strictEqual(detector, 'MID');
       assert.strictEqual(state, 'FAILED');
     });
@@ -113,7 +113,7 @@ async function waitForEnvRequest(page, timeout = 90) {
     let i = 0;
     while (i++ < timeout) {
       const requestFailed = await page.evaluate(() => window.model?.environment?.requests?.payload?.requests[0]?.failed);
-      if (!requestFailed) {
+      if (requestFailed) {
         await page.waitForTimeout(1000);
         resolve();
       } else {

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -427,8 +427,8 @@ describe('`pageNewEnvironment` test-suite', async () => {
   });
 
   it('should display successfull environment request', async () => {
-    const detector = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(1)').innerText);
-    const state = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(5)').innerText);
+    const detector = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(2)').innerText);
+    const state = await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > table > tbody > tr > td:nth-child(6)').innerText);
     assert.strictEqual(detector, 'MID');
     assert.strictEqual(state, 'ONGOING');
   });


### PR DESCRIPTION
This is ugly workaround to get environment ID from error message details. This should be improved to use protobuf deserialisation (we need to change protobuf to do so).