### PR TITLE
[OGUI-1122] Add '/' to both displayed and passed values of consul URIs

### DIFF
--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -57,8 +57,8 @@ function getConsulConfig(config) {
     conf.kVPrefix = conf?.kVPrefix || 'ui/alice-o2-cluster/kv';
 
     conf.ui = conf.ui || `${conf.hostname}:${conf.port}`;
-    conf.kvStoreQC = `${conf.ui}/${conf.kVPrefix}/${conf.qcPath}`;
-    conf.kvStoreReadout = `${conf.ui}/${conf.kVPrefix}/${conf.readoutPath}`;
+    conf.kvStoreQC = `${conf.ui}/${conf.kVPrefix}/${conf.qcPath}/`;
+    conf.kvStoreReadout = `${conf.ui}/${conf.kVPrefix}/${conf.readoutPath}/`;
     conf.qcPrefix = `${conf.hostname}:${conf.port}/${conf.qcPath}/`;
     conf.readoutPrefix = `${conf.hostname}:${conf.port}/${conf.readoutPath}/`;
     return conf;

--- a/Control/public/workflow/panels/variables/basicPanel.js
+++ b/Control/public/workflow/panels/variables/basicPanel.js
@@ -345,7 +345,7 @@ const readoutPanel = (workflow) => {
       h('.w-25'),
       h('a.w-75.f5.action', {
         style: 'font-style: italic; cursor: pointer',
-        href: `//${COG.CONSUL.kvStoreReadout}/${(
+        href: `//${COG.CONSUL.kvStoreReadout + (
           variables['readout_cfg_uri'] ?
             variables['readout_cfg_uri'] + '/edit' : '')}`,
         target: '_blank',
@@ -432,7 +432,7 @@ const qcUriPanel = (workflow) => {
       h('.w-25'),
       h('a.w-75.f5.action', {
         style: 'font-style: italic; cursor: pointer',
-        href: `//${COG.CONSUL.kvStoreQC}/${(
+        href: `//${COG.CONSUL.kvStoreQC + (
           variables['qc_config_uri'] ?
             variables['qc_config_uri'] + '/edit' : '')}`,
         target: '_blank',

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -148,8 +148,8 @@ describe('Control', function() {
         readoutCardPath: 'test/o2/readoutcard/components',
         qcPath: 'test/o2/qc/components',
         kVPrefix: 'test/ui/some-cluster/kv',
-        kvStoreQC: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/qc/components',
-        kvStoreReadout: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/readout/components',
+        kvStoreQC: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/qc/components/',
+        kvStoreReadout: 'localhost.cern.ch/test/ui/some-cluster/kv/test/o2/readout/components/',
         qcPrefix: "localhost:8550/test/o2/qc/components/",
         readoutPrefix: "localhost:8550/test/o2/readout/components/"
       },


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

In "Adv Config Panel", if users select the `consul-ini` option, the built URL will be displayed. This URL was missing a `/` which was added behind the scenes, making the user adding their own `/` and ending up with a wrong configuration.