### PR TITLE
[OGUI-1136] Hide configure action for environments

### DIFF
--- a/Control/public/environment/components/controlEnvironmentPanel.js
+++ b/Control/public/environment/components/controlEnvironmentPanel.js
@@ -26,7 +26,7 @@ export const controlEnvironmentPanel = (environment, item) => h('.mv2.pv3.ph2', 
       [
         controlButton('.btn-success', environment, item, 'START', 'START_ACTIVITY', 'CONFIGURED'), ' ',
         controlButton('.btn-danger', environment, item, 'STOP', 'STOP_ACTIVITY', 'RUNNING'), ' ',
-        // controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', 'DEPLOYED'), ' ',
+        controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', ''), ' ',
         controlButton('', environment, item, 'RESET', 'RESET', 'CONFIGURED'), ' '
       ]
     ),

--- a/Control/public/environment/components/controlEnvironmentPanel.js
+++ b/Control/public/environment/components/controlEnvironmentPanel.js
@@ -26,7 +26,7 @@ export const controlEnvironmentPanel = (environment, item) => h('.mv2.pv3.ph2', 
       [
         controlButton('.btn-success', environment, item, 'START', 'START_ACTIVITY', 'CONFIGURED'), ' ',
         controlButton('.btn-danger', environment, item, 'STOP', 'STOP_ACTIVITY', 'RUNNING'), ' ',
-        controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', 'DEPLOYED'), ' ',
+        // controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', 'DEPLOYED'), ' ',
         controlButton('', environment, item, 'RESET', 'RESET', 'CONFIGURED'), ' '
       ]
     ),

--- a/Control/public/environment/components/controlEnvironmentPanel.js
+++ b/Control/public/environment/components/controlEnvironmentPanel.js
@@ -26,7 +26,7 @@ export const controlEnvironmentPanel = (environment, item) => h('.mv2.pv3.ph2', 
       [
         controlButton('.btn-success', environment, item, 'START', 'START_ACTIVITY', 'CONFIGURED'), ' ',
         controlButton('.btn-danger', environment, item, 'STOP', 'STOP_ACTIVITY', 'RUNNING'), ' ',
-        controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', ''), ' ',
+        controlButton('.btn-warning', environment, item, 'CONFIGURE', 'CONFIGURE', ''), ' ', // button will not be displayed in any state due to OCTRL-628
         controlButton('', environment, item, 'RESET', 'RESET', 'CONFIGURED'), ' '
       ]
     ),

--- a/Control/test/public/page-environment-mocha.js
+++ b/Control/test/public/page-environment-mocha.js
@@ -155,7 +155,8 @@ describe('`pageEnvironment` test-suite', async () => {
       assert.deepStrictEqual(stopButtonStyle, {0: 'display'});
     });
 
-    it('should have one button hidden for CONFIGURE in state DEPLOYED', async () => {
+    it.skip('should have one button for CONFIGURE in state DEPLOYED', async () => {
+      // skipping due to OCTRL-628
       await page.waitForSelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div > div > button:nth-child(3)', {timeout: 5000});
       const configureButtonTitle = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div > div >button:nth-child(3)').title);
       assert.strictEqual(configureButtonTitle, `CONFIGURE`);


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

The `CONFIGURE` action is not allowed until OCTRL-628 is fixed, thus button will not be displayed