### PR TITLE
Update AliECS refresh calls

### DIFF
--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -33,7 +33,6 @@ function buildPublicConfig(config) {
     GRAFANA: _getGrafanaConfig(config),
     CONSUL: getConsulConfig(config),
     REFRESH_TASK: config?.utils?.refreshTask || 10000,
-    REFRESH_ENVS: config?.utils?.refreshEnvs || 30000,
   };
   let codeStr = `/* eslint-disable quote-props */\n`
     + `const publicConfig = ${JSON.stringify(publicConfig, null, 2)}; \nexport {publicConfig as COG};\n`;

--- a/Control/lib/control-core/EnvCache.js
+++ b/Control/lib/control-core/EnvCache.js
@@ -27,7 +27,7 @@ class EnvCache {
   constructor(ctrlService) {
     this.ctrlService = ctrlService;
     this.cache = {};
-    this.timeout = 1500;
+    this.timeout = 2000;
     this.cacheEvictionTimeout = 5*60*1000;
     this.cacheEvictionLast = new Date();
     this.refreshInterval = setInterval(() => this.refresh(), this.timeout);

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -167,7 +167,7 @@ export default class Model extends Observable {
    */
   handleWSClose() {
     clearInterval(this.task.refreshInterval);
-    clearInterval(this.environment.refreshInterval);
+    clearInterval(this.frameworkInfo.refreshInterval);
 
     // Release client-side
     this.lock.setPadlockState({lockedBy: null, lockedByName: null});
@@ -197,16 +197,15 @@ export default class Model extends Observable {
    */
   handleLocationChange() {
     clearInterval(this.task.refreshInterval);
-    clearInterval(this.environment.refreshInterval);
+    clearInterval(this.frameworkInfo.refreshInterval);
     switch (this.router.params.page) {
       case 'environments':
         this.environment.getEnvironments();
         this.environment.getEnvironmentRequests();
         this.frameworkInfo.getIntegratedServicesInfo();
-        this.environment.refreshInterval = setInterval(() => {
-          this.environment.getEnvironments();
+        this.frameworkInfo.refreshInterval = setInterval(() => {
           this.frameworkInfo.getIntegratedServicesInfo();
-        }, COG.REFRESH_ENVS);
+        }, COG.REFRESH_TASK);
         break;
       case 'environment':
         if (!this.router.params.id) {

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -154,7 +154,6 @@ describe('Control', function() {
         readoutPrefix: "localhost:8550/test/o2/readout/components/"
       },
       REFRESH_TASK: 5000,
-      REFRESH_ENVS: 30000,
     }
     assert.deepStrictEqual(cog, expectedConf, 'Public configuration was not loaded successfully');
   });


### PR DESCRIPTION
This removes env refresh completely, and decreases framework info refresh from 30s to 10s (same as task refresh) so ODC info can be updated more often.