### PR TITLE
[OGUI-1173] Choose content location of root file if many returned

### DIFF
--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -59,7 +59,7 @@ class ObjectController {
     const timestamp = req.query?.timestamp ?? Date.now();
     try {
       const {location, drawingOptions, displayHints} = await this.db.getRootObjectDetails(path, timestamp);
-      
+
       const url = this.DB_URL + location;
       const root = await this._getJsRootFormat(url);
       const objContent = {

--- a/QualityControl/lib/services/CcdbService.js
+++ b/QualityControl/lib/services/CcdbService.js
@@ -115,19 +115,20 @@ class CcdbService {
     const path = `/${name}/${timestamp}`;
     const {status, headers} = await httpHeadJson(this.hostname, this.port, path);
 
-    let location = '';
     if (status >= 200 && status <= 299) {
-      location = headers[this.CONTENT_LOCATION];
-    } else if (status >= 300 && status <= 399) {
-      location = headers[this.LOCATION];
+      const location = headers[this.CONTENT_LOCATION].split(', ')
+        .filter((location) => !location.startsWith('alien'))[0];
+      if (!location) {
+        throw new Error(`No location provided by CCDB for object with path: ${path}`)
+      }
+      return {
+        drawingOptions: headers[this.DRAWING_OPTIONS] || '',
+        displayHints: headers[this.DISPLAY_HINTS] || '',
+        location
+      };
     } else {
       throw new Error(`Unable to retrieve object: ${name}`);
     }
-    return {
-      drawingOptions: headers[this.DRAWING_OPTIONS] || '',
-      displayHints: headers[this.DISPLAY_HINTS] || '',
-      location
-    };
   }
 
   /**

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/qc",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/qc",
-      "version": "2.12.2",
+      "version": "2.12.3",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "jsroot",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "O2 Quality Control Web User Interface",
   "author": "George Raduta",
   "contributors": [

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -37,7 +37,7 @@ export default class QCObjectService {
   async listObjects(that = this.model) {
     this.list = RemoteData.loading();
     that.notify();
-    
+
     const {result, ok} = await this.model.loader.get('/api/listObjects', {}, true);
     this.list = ok ? RemoteData.success(result) : RemoteData.failure({message: result.message});
     that.notify();
@@ -98,16 +98,20 @@ export default class QCObjectService {
         await this.model.loader.get(`/api/object/info?path=${objectName}&timestamp=${timestamp}`);
       if (ok) {
         const root = await this.model.loader.get(`/api/object/root?path=${objectName}&timestamp=${timestamp}`);
-        const obj = {
-          info: result.info,
-          timestamps: result.timestamps,
-          qcObject: {
-            root: JSROOT.parse(root.result.root),
-            drawingOptions: root.result.drawingOptions,
-            displayHints: root.result.displayHints,
-          }
-        };
-        return RemoteData.success(obj);
+        if (root.ok) {
+          const obj = {
+            info: result.info,
+            timestamps: result.timestamps,
+            qcObject: {
+              root: JSROOT.parse(root.result.root),
+              drawingOptions: root.result.drawingOptions,
+              displayHints: root.result.displayHints,
+            }
+          };
+          return RemoteData.success(obj);
+        }
+        return RemoteData.failure(`404: Object "${objectName}" could not be found.`);
+
       } else if (status === 404) {
         return RemoteData.failure(`404: Object "${objectName}" could not be found.`);
       }

--- a/QualityControl/test/public/mocha-index.js
+++ b/QualityControl/test/public/mocha-index.js
@@ -32,7 +32,7 @@ describe('QCG', function() {
   let page;
   let subprocess; // web-server runs into a subprocess
   let subprocessOutput = '';
-  this.timeout(20000);
+  this.timeout(25000);
   this.slow(2000);
   const url = 'http://' + config.http.hostname + ':' + config.http.port + '/';
 

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -25,6 +25,7 @@ describe('objectTree page test suite', async () => {
 
   it('should load', async () => {
     await page.goto(url + '?page=objectTree', {waitUntil: 'networkidle0'});
+    await page.waitForTimeout(500)
     const location = await page.evaluate(() => window.location);
     assert.strictEqual(location.search, '?page=objectTree');
   });

--- a/QualityControl/test/public/pages/object-view.test.js
+++ b/QualityControl/test/public/pages/object-view.test.js
@@ -132,6 +132,7 @@ describe('objectTree page test suite', async () => {
   describe('objectView called from layoutShow', () => {
     it('should load page=objectView and display error message & icon due to missing objectID parameter', async () => {
       await page.goto(url + '?page=objectView', {waitUntil: 'networkidle0'});
+      await page.waitForTimeout(500);
       const result = await page.evaluate(() => {
         const errorMessage = document.querySelector('body > div > div:nth-child(2) > div > span').textContent;
         const iconClassList = document.querySelector('div div:nth-child(2) div svg').classList;
@@ -215,6 +216,7 @@ describe('objectTree page test suite', async () => {
       const objectId = '5aba4a059b755d517e76ef54';
       const layoutId = '5aba4a059b755d517e76ea10';
       await page.goto(url + `?page=objectView&objectId=${objectId}&layoutId=${layoutId}`, {waitUntil: 'networkidle0'});
+      await page.waitForTimeout(500);
       const result = await page.evaluate(() => {
         const title = document.querySelector('div div b').textContent;
         const rootPlotClassList = document.querySelector('body > div > div:nth-child(2) > div > div').classList;

--- a/QualityControl/test/public/pages/object-view.test.js
+++ b/QualityControl/test/public/pages/object-view.test.js
@@ -230,7 +230,7 @@ describe('objectTree page test suite', async () => {
       await page.waitForTimeout(7000);
       assert.strictEqual(result.title, 'DAQ01/EquipmentSize/CPV/CPV(AliRoot)');
       assert.deepStrictEqual(result.rootPlotClassList, {0: 'relative', 1: 'jsroot-container'});
-      assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV', createTime: 3, lastModified: 100});
+      assert.deepStrictEqual(result.objectSelected, {name: 'DAQ01/EquipmentSize/CPV/CPV'});
       // TODO Add version back
     });
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* If `content-location` header returns multiple locations, choose the first one which does not contain `alien`
* Fix a bug on UI where if object loading failed it would infinitely display loading status;
* Bump patch version