### PR TITLE
[OGUI-1178] Add ILG_EPN button on active envs and details pages

### DIFF
--- a/Control/README.md
+++ b/Control/README.md
@@ -14,6 +14,7 @@
     - [Consul](#consul)
     - [Notification service](#notification-service)
     - [InfoLogger GUI](#infologger-gui)
+    - [InfoLogger EPN GUI](#infologger-epn-gui)
     - [QualityControl GUI](#qualitycontrol-gui)
     - [Bookkeeping GUI](#bookkeeping-gui)
     - [Utils](#utils)
@@ -83,22 +84,24 @@ Use of a Consul instance is optional
 Use of a Notification service is optional. It is being used for prompting and receiving notifications from global Notification Service, see more in [Notification service](../Framework/docs/guide/notification.md.md) framework guide.
 
 ### InfoLogger GUI
-Use of InfoLogger GUI instance is optional. Configuration details about it are being used only for building URLs to help the user navigate the logs of its actions.
+Use of InfoLogger GUI instance is optional. Configuration details about it are being used only for displaying URLs to help the user navigate the logs of its actions.
 
-* `hostname` - InfoLogger GUI hostname
-* `port` - InfoLogger GUI port
+* `url` - Prebuilt URL which is in format `host:port`
+
+### InfoLogger EPN GUI
+Use of InfoLogger **EPN** GUI instance is optional. Configuration details about it are being used only for displaying URLs to help the user navigate the logs of EPN actions.
+
+* `url` - Prebuilt URL which is in format `host:port`
 
 ### QualityControl GUI
 Use of QualityControl GUI instance is optional. Configuration details about it are being used only for building URLs to help the user navigate the objects created within an environment.
 
-* `hostname` - QualityControl GUI hostname
-* `port` - QualityControl GUI port
+* `url` - Prebuilt URL which is in format `host:port`
 
 ### Bookkeeping GUI
 Use of Bookkeeping GUI instance is optional. Configuration details about it are being used only for building URLs to help the user navigate to the run details of their environments.
 
-* `hostname` - Bookkeeping GUI hostname
-* `port` - Bookkeeping GUI port
+* `url` - Prebuilt URL which is in format `host:port`
 
 ### Utils
 Use of utils field is optional. Here, a user can specify configuration fields for various uses of AliECS GUI:

--- a/Control/config-default.js
+++ b/Control/config-default.js
@@ -40,16 +40,16 @@ module.exports = {
     coreServices: 'o2/components/aliecs/some/settings/path',
   },
   infoLoggerGui: {
-    hostname: 'localhost',
-    port: 8081
+    url: 'localhost:8081',
+  },
+  infoLoggerEpnGui: {
+    url: 'localhost:8083',
   },
   qcGui: {
-    hostname: 'localhost',
-    port: 8081
+    url: 'qcg.cern.ch'
   },
   bookkeepingGui: {
-    hostname: 'localhost',
-    port: 8081
+    url: 'ali-bookkeeping.cern.ch'
   },
   utils: {
     refreshTask: 10000, // how often should task list page should refresh its content

--- a/Control/lib/config/publicConfigProvider.js
+++ b/Control/lib/config/publicConfigProvider.js
@@ -28,6 +28,7 @@ function buildPublicConfig(config) {
   }
   const publicConfig = {
     ILG_URL: _getInfoLoggerURL(config),
+    ILG_EPN_URL: _getInfoLoggerEpnUrl(config),
     QCG_URL: _getQcgURL(config),
     BKP_URL: _getBookkeepingURL(config),
     GRAFANA: _getGrafanaConfig(config),
@@ -97,6 +98,15 @@ function _getGrafanaConfig(config) {
  */
 function _getInfoLoggerURL(config) {
   const ilg = config?.infoLoggerGui;
+  return (ilg?.url) ? `${ilg.url}` : '';
+}
+
+/**
+ * Retrieves the EPN InfoLogger URL and sends it
+ * @param {JSON} config - server configuration
+ */
+function _getInfoLoggerEpnUrl(config) {
+  const ilg = config?.infoLoggerEpnGui;
   return (ilg?.url) ? `${ilg.url}` : '';
 }
 

--- a/Control/public/environment/components/buttons.js
+++ b/Control/public/environment/components/buttons.js
@@ -37,7 +37,7 @@ const infoLoggerButton = (item, label = 'ILG') =>
  * @param {String} label
  * @return {vnode}
  */
-const infoLoggerEPNButton = (item, label = 'ILG EPN') =>
+const infoLoggerEpnButton = (item, label = 'ILG EPN') =>
   h('a.ph2.btn.primary.w-100', {
     style: {display: !COG.ILG_EPN_URL ? 'none' : ''},
     title: `Open InfoLogger EPN GUI with environment: ${item.id} and run ${item.currentRunNumber} set`,
@@ -88,4 +88,4 @@ const mesosLogButton = (href) =>
   }, h('button.btn-sm.primary', iconCloudDownload())
   );
 
-export {infoLoggerButton, infoLoggerEPNButton, bookkeepingButton, qcgButton, mesosLogButton};
+export {infoLoggerButton, infoLoggerEpnButton, bookkeepingButton, qcgButton, mesosLogButton};

--- a/Control/public/environment/components/buttons.js
+++ b/Control/public/environment/components/buttons.js
@@ -21,13 +21,29 @@ import {h, iconCloudDownload} from '/js/src/index.js';
  * @param {String} label
  * @return {vnode}
  */
-const infoLoggerButton = (item, label = 'InfoLogger') =>
-  h('a.ph2.btn.primary.w-100', {
+const infoLoggerButton = (item, label = 'ILG') =>
+  h('a.ph2.btn.btn.primary.w-100', {
     style: {display: !COG.ILG_URL ? 'none' : ''},
     title: `Open InfoLogger GUI with environment: ${item.id} and run ${item.currentRunNumber} set`,
     href: item.currentRunNumber ?
       `${COG.ILG_URL}?q={"partition":{"match":"${item.id}"},"run":{"match":"${item.currentRunNumber}"}}`
       : `${COG.ILG_URL}?q={"partition":{"match":"${item.id}"}}`,
+    target: '_blank'
+  }, label);
+
+/**
+ * Open InfoLogger in a new browser tab with run number and environment set if available
+ * @param {Object} environment
+ * @param {String} label
+ * @return {vnode}
+ */
+const infoLoggerEPNButton = (item, label = 'ILG EPN') =>
+  h('a.ph2.btn.primary.w-100', {
+    style: {display: !COG.ILG_EPN_URL ? 'none' : ''},
+    title: `Open InfoLogger EPN GUI with environment: ${item.id} and run ${item.currentRunNumber} set`,
+    href: item.currentRunNumber ?
+      `${COG.ILG_EPN_URL}?q={"partition":{"match":"${item.id}"},"run":{"match":"${item.currentRunNumber}"}}`
+      : `${COG.ILG_EPN_URL}?q={"partition":{"match":"${item.id}"}}`,
     target: '_blank'
   }, label);
 
@@ -42,7 +58,7 @@ const bookkeepingButton = (label = 'Bookkeeping') =>
     title: `Open Bookkeeping GUI run statistics page`,
     href: `//${COG.BKP_URL}?page=run-overview`,
     target: '_blank'
-  },label);
+  }, label);
 
 /**
 * Open QualityControl in a new browser tab on run details page for current run
@@ -55,7 +71,7 @@ const qcgButton = (label = 'Quality Control') =>
     title: `Open Quality Control GUI`,
     href: `//${COG.QCG_URL}?page=objectTree`,
     target: '_blank'
-  },label);
+  }, label);
 
 
 /**
@@ -72,4 +88,4 @@ const mesosLogButton = (href) =>
   }, h('button.btn-sm.primary', iconCloudDownload())
   );
 
-export {infoLoggerButton, bookkeepingButton, qcgButton, mesosLogButton};
+export {infoLoggerButton, infoLoggerEPNButton, bookkeepingButton, qcgButton, mesosLogButton};

--- a/Control/public/environment/environmentPage.js
+++ b/Control/public/environment/environmentPage.js
@@ -23,7 +23,9 @@ import showTableItem from '../common/showTableItem.js';
 import {controlEnvironmentPanel} from './components/controlEnvironmentPanel.js';
 import {parseObject, getTasksByFlp} from './../common/utils.js';
 import {userVarsRow, defaultsRow, varsRow} from './components/expandableEnvRows.js';
-import {infoLoggerButton, bookkeepingButton, qcgButton, mesosLogButton} from './components/buttons.js';
+import {
+  infoLoggerButton, infoLoggerEpnButton, bookkeepingButton, qcgButton, mesosLogButton
+} from './components/buttons.js';
 import {ROLES} from './../workflow/constants.js';
 
 /**
@@ -111,9 +113,10 @@ const redirectGUIsPanel = (item) => {
   return h('.w-100.text.center.flex-row', {
     style: 'padding-top: var(--space-xl);margin-left: var(--space-s);'
   }, [
-    h('.w-33.flex-row.justify-center', h('.w-70', infoLoggerButton(item))),
-    h('.w-33.flex-row.justify-center', h('.w-70', bookkeepingButton())),
-    h('.w-33.flex-row.justify-center', h('.w-70', qcgButton())),
+    h('.w-25.flex-row.justify-center', h('.w-70', infoLoggerButton(item))),
+    h('.w-25.flex-row.justify-center', h('.w-70', infoLoggerEpnButton(item))),
+    h('.w-25.flex-row.justify-center', h('.w-70', bookkeepingButton())),
+    h('.w-25.flex-row.justify-center', h('.w-70', qcgButton())),
   ]);
 };
 

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -17,7 +17,7 @@ import pageLoading from '../common/pageLoading.js';
 import errorPage from '../common/errorPage.js';
 import {parseObject, parseOdcStatusPerEnv} from './../common/utils.js';
 import {detectorHeader} from '../common/detectorHeader.js';
-import {infoLoggerButton} from './components/buttons.js';
+import {infoLoggerButton, infoLoggerEPNButton} from './components/buttons.js';
 import {ROLES} from './../workflow/constants.js';
 
 /**
@@ -146,15 +146,22 @@ const environmentsTable = (model, list) => {
       list.map((item) => h('tr', {
         class: _isGlobalRun(item.userVars) ? 'global-run' : ''
       }, [
-        h('td', {style: 'text-align: center;'}, item.id),
-        h('td', {style: 'text-align: center;'}, item.currentRunNumber ? item.currentRunNumber : '-'),
+        h('td', {style: 'text-align: center;'},
+          h('a', {
+            href: `?page=environment&id=${item.id}`,
+            onclick: (e) => model.router.handleLinkEvent(e),
+          }, item.id
+          )),
+        h('td', {style: 'text-align: center;'},
+          item.currentRunNumber ? h('.badge.bg-success.white.f4', item.currentRunNumber) : '-'
+        ),
         h('td', {style: 'text-align: center;'}, parseObject(item.createdWhen, 'createdWhen')),
         h('td', {style: 'text-align: center;'}, [
           item.includedDetectors && item.includedDetectors.length > 0 ?
             item.includedDetectors.map((detector) => `${detector} `)
             : '-'
         ]),
-        h('td', {style: 'text-align: center;'}, item.numberOfFlps),
+        h('td', {style: 'text-align: center;'}, item.numberOfFlps ? item.numberOfFlps : '-'),
         h('td', {style: 'text-align: center;'}, parseObject(item.userVars, 'dcs_enabled')),
         h('td', {style: 'text-align: center;'}, parseObject(item.userVars, 'trg_enabled')),
         h('td', {style: 'text-align: center;'}, parseObject(item.userVars, 'epn_enabled')),
@@ -188,11 +195,8 @@ const actionsCell = (model, item) => {
     item.includedDetectors.length === 1 && item.includedDetectors[0] === model.detectors.selected;
   if ((isDetectorIncluded || !model.detectors.isSingleView()) && model.isAllowed(ROLES.Detector)) {
     return h('.btn-group', [
-      h('button.btn.btn-primary', {
-        title: 'Open the environment page with more details',
-        onclick: () => model.router.go(`?page=environment&id=${item.id}`),
-      }, 'Details'),
       infoLoggerButton(item, 'ILG'),
+      infoLoggerEPNButton(item, 'ILG_EPN')
       // bookkeepingButton('BKP'),
       // qcgButton('QCG'),
     ]);

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -17,7 +17,7 @@ import pageLoading from '../common/pageLoading.js';
 import errorPage from '../common/errorPage.js';
 import {parseObject, parseOdcStatusPerEnv} from './../common/utils.js';
 import {detectorHeader} from '../common/detectorHeader.js';
-import {infoLoggerButton, infoLoggerEPNButton} from './components/buttons.js';
+import {infoLoggerButton, infoLoggerEpnButton} from './components/buttons.js';
 import {ROLES} from './../workflow/constants.js';
 
 /**
@@ -196,7 +196,7 @@ const actionsCell = (model, item) => {
   if ((isDetectorIncluded || !model.detectors.isSingleView()) && model.isAllowed(ROLES.Detector)) {
     return h('.btn-group', [
       infoLoggerButton(item, 'ILG'),
-      infoLoggerEPNButton(item, 'ILG_EPN')
+      infoLoggerEpnButton(item, 'ILG_EPN')
       // bookkeepingButton('BKP'),
       // qcgButton('QCG'),
     ]);

--- a/Control/test/integration/control-environment.js
+++ b/Control/test/integration/control-environment.js
@@ -28,8 +28,8 @@ describe('`Control Environment` test-suite', async () => {
   });
 
   it(`should be on page of new environment (workflow '${workflowToTest}') just created`, async () => {
-    // Click details button of newly created env
-    await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > div.scroll-auto > table > tbody > tr > td:nth-child(12) > div > button').click());
+    // Click envID link of newly created env
+    await page.evaluate(() => document.querySelector('body > div.flex-column.absolute-fill > div.flex-grow.flex-row > div.flex-grow.relative > div > div.scroll-auto > table > tbody > tr > td:nth-child(1) > a').click());
     const location = await page.evaluate(() => window.location);
     revision = await page.evaluate(() => window.model.workflow.form.revision);
     assert.ok(location.search.includes('?page=environment&id='));

--- a/Control/test/mocha-index.js
+++ b/Control/test/mocha-index.js
@@ -127,6 +127,7 @@ describe('Control', function() {
     const cog = await page.evaluate(() => window.COG);
     const expectedConf = {
       ILG_URL: 'http://localhost:8081',
+      ILG_EPN_URL: 'http://localhost:8083',
       BKP_URL: 'http://localhost:2021',
       QCG_URL: 'http://localhost:2022',
       GRAFANA: {

--- a/Control/test/public/page-environments-mocha.js
+++ b/Control/test/public/page-environments-mocha.js
@@ -41,17 +41,6 @@ describe('`pageEnvironments` test-suite', () => {
       assert.ok(calls['getEnvironments']);
     });
 
-    it('should have a button in Action column for More Details', async () => {
-      await page.waitForSelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(12) > div > button', {timeout: 2000});
-      const detailsButton = await page.evaluate(() => {
-        const title = document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(12) > div >button').title;
-        const label = document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(12) > div > button').innerText;
-        return {title, label};
-      });
-      assert.strictEqual(detailsButton.title, 'Open the environment page with more details');
-      assert.strictEqual(detailsButton.label, 'Details');
-    });
-
     it('should have a button in Action column for InfoLogger', async () => {
       await page.waitForSelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(12) > div > a', {timeout: 2000});
       const detailsButton = await page.evaluate(() => {
@@ -61,8 +50,8 @@ describe('`pageEnvironments` test-suite', () => {
       assert.strictEqual(detailsButton.label, 'ILG');
     });
 
-    it('should successfully navigate to environment page on click Details', async () => {
-      await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(12) > div > button').click());
+    it('should successfully navigate to environment page when clicking on environment ID', async () => {
+      await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > table > tbody > tr > td:nth-child(1) > a').click());
       await page.waitForTimeout(200);
       assert.ok(calls['getEnvironment']);
       const location = await page.evaluate(() => window.location);

--- a/Control/test/test-config.js
+++ b/Control/test/test-config.js
@@ -49,6 +49,9 @@ module.exports = {
   infoLoggerGui: {
     url: 'http://localhost:8081',
   },
+  infoLoggerEpnGui: {
+    url: 'http://localhost:8083',
+  },
   grafana: {
     url: 'http://localhost:2020'
   },


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* On Active Environments Page, adds a button for each environment that would redirect to EPN InfoLogger (if EPN is enabled) with env id and run set
* On Environment Details Page, adds a button allowing the user to navigate to EPN Infologger with env id and run set
* Removes `Details` button with environment id hyperlink to navigate from Active to Details pages