### PR TITLE
[OGUI-1170] Update logs limit number in user filters

### DIFF
--- a/InfoLogger/package-lock.json
+++ b/InfoLogger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/infologger",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "bundleDependencies": [
         "@aliceo2/web-ui"
       ],

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Infologger GUI to query and stream log events",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -42,7 +42,7 @@ export default class Log extends Observable {
     this.isTimeDropdownEnabled = false;
     this.timeFormat = TIME_MS;
 
-    this.limit = 10000;
+    this.limit = 100000;
     this.applicationLimit = 100000; // browser can be slow is `list` array is bigger
 
     this.queryResult = RemoteData.notAsked();

--- a/InfoLogger/public/logFilter/commandFilters.js
+++ b/InfoLogger/public/logFilter/commandFilters.js
@@ -41,7 +41,7 @@ export default (model) => [
     ]),
     h('span.mh3'),
     h('.btn-group', [
-      buttonLogLimit(model, '30k', 30000),
+      buttonLogLimit(model, '50k', 50000),
       buttonLogLimit(model, '100k', 100000),
       buttonLogLimit(model, '1M', 1000000),
     ]),

--- a/InfoLogger/public/logFilter/commandFilters.js
+++ b/InfoLogger/public/logFilter/commandFilters.js
@@ -41,8 +41,7 @@ export default (model) => [
     ]),
     h('span.mh3'),
     h('.btn-group', [
-      buttonLogLimit(model, '1k', 1000),
-      buttonLogLimit(model, '10k', 10000),
+      buttonLogLimit(model, '30k', 30000),
       buttonLogLimit(model, '100k', 100000),
       buttonLogLimit(model, '1M', 1000000),
     ]),


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

* Updates allowed logs to be filtered by the user `1k, 10k, 100k, 1M` -> `50k, 100k, 1M`
* Bumps patch version