### PR TITLE
[OGUI-1205] Inspector View should split long messages

### DIFF
--- a/InfoLogger/package-lock.json
+++ b/InfoLogger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/infologger",
-      "version": "1.11.2",
+      "version": "1.11.3",
       "bundleDependencies": [
         "@aliceo2/web-ui"
       ],

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/infologger",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Infologger GUI to query and stream log events",
   "author": "Vladimir Kosmala",
   "contributors": [

--- a/InfoLogger/public/log/inspector.js
+++ b/InfoLogger/public/log/inspector.js
@@ -28,10 +28,7 @@ export default (model) => model.log.item ? h('', [
         h('td.cell.text-ellipsis.cell-xl',
           h('.f7.w-100.flex-column.items-end',
             h('.w-10.actionable-icon', {
-              onclick: () => {
-                model.inspectorEnabled = false;
-                model.notify();
-              }
+              onclick: () => model.toggleInspector()
             }, iconX())
           )
         )
@@ -57,5 +54,5 @@ export default (model) => model.log.item ? h('', [
       h('tr', h('td', 'ErrSource'), h('td', model.log.item.errsource)),
     ])
   ),
-  h('.p2.f7', h('', model.log.item.message))
+  h('.p2.f7', {style: 'word-break: break-word'}, model.log.item.message)
 ]) : h('', {className: 'f6 text-center p3'}, 'Click on a log to show its properties');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

For really long log messages, the inspector view does not properly break-word