### PR TITLE
[OGUI-1201] AliECS GUI should gracefully deal with badly formatted env configuration JSONs

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.50.0",
+      "version": "1.50.1",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -572,7 +572,8 @@ export default class Workflow extends Observable {
       } catch (error) {
         console.error(error);
         this.loadingConfiguration = RemoteData.notAsked();
-        this.model.notification.show('Unable to load configuration. Please contact an administrator', 'warning', 2000);
+        this.model.notification.show(`SyntaxError - Failed to load configuration '${key}'.`
+          + ' Please contact an administrator', 'warning', 6000);
       }
       this.notify();
     }

--- a/Control/public/workflow/panels/loadConfiguration/loadConfiguration.js
+++ b/Control/public/workflow/panels/loadConfiguration/loadConfiguration.js
@@ -170,15 +170,19 @@ const btnSaveEnvConfiguration = (model) => {
  */
 const btnUpdateEnvConfiguration = (model) => {
   const isEnvLoading = model.environment.itemNew.isLoading();
-  const isConfigurationSelected = 
+  const isConfigurationSelected =
     Boolean(model.workflow.selectedConfiguration) && model.workflow.loadingConfiguration.isNotAsked();
   const name = model.workflow.selectedConfiguration;
 
   let isUserAllowedToUpdate = model.isAllowed(ROLES.Admin, true);
 
   if (isConfigurationSelected) {
-    const owner = JSON.parse(model.workflow.loadedConfiguration.payload.payload).user.personid;
-    isUserAllowedToUpdate = isUserAllowedToUpdate || owner == model.session.personid;
+    try {
+      const owner = JSON.parse(model.workflow.loadedConfiguration.payload.payload).user.personid;
+      isUserAllowedToUpdate = isUserAllowedToUpdate || owner == model.session.personid;
+    } catch (error) {
+      console.error(error);
+    }
   }
   const infoMessage = (isConfigurationSelected && isUserAllowedToUpdate) ?
     `Update the selected configuration "${name}" with the currently displayed and selected configuration`


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

- Adds a try/catch for trying to parse a configuration. This should be done before retrieving it on front-end side in the future;
- Improves warning message for the user;
- Bumps AliECS GUI patch version