### PR TITLE
[OGUI-1231] notification message should include run numbers

### DIFF
--- a/Framework/Backend/services/notification.js
+++ b/Framework/Backend/services/notification.js
@@ -69,10 +69,11 @@ class NotificationService {
    * @param {string} title Notification title
    * @param {string} author Notification author
    * @param {string} url URL poiting to notification details
+   * @param {(string|string[])} runNumbers Bookkeeping tag
    * @param {string} extra Details information
    * @returns {Promise}
    */
-  async send(tag, title, author, url, extra) {
+  async send(tag, title, author, url, runNumbers, extra) {
     if (!tag) {
       throw new Error('Tag is required to send notifications');
     }
@@ -85,11 +86,15 @@ class NotificationService {
     if (Array.isArray(tag)) {
       tag = tag.join(',');
     }
+    if (runNumbers && Array.isArray(runNumbers)) {
+      runNumbers = runNumbers.join(',');
+    }
     const message = {
       tag: tag,
       title: title,
       author: author,
       url: url || undefined,
+      runNumbers: runNumbers || undefined,
       extra: extra || undefined
     };
     const producer = this.kafka.producer();

--- a/Framework/package-lock.json
+++ b/Framework/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/web-ui",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/web-ui",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "license": "GPL-3.0",
       "dependencies": {
         "express": "^4.18.0",

--- a/Framework/package.json
+++ b/Framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/web-ui",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "ALICE O2 Web UX framework",
   "author": "Adam Wegrzynek",
   "contributors": [


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Small improvement to allow notification service to accept `runNumbers` as well.
Bumps patch version of the `web-ui`
