### PR TITLE
[OGUI-1238] Allow mjs config files

### DIFF
--- a/QualityControl/lib/config/configProvider.js
+++ b/QualityControl/lib/config/configProvider.js
@@ -45,7 +45,7 @@ try {
 function _getConfigurationFilePath() {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
-  if (process.argv.length >= 3 && /\.js$/.test(process.argv[2])) {
+  if (process.argv.length >= 3 && /\.m{0,1}js$/.test(process.argv[2])) {
     return process.argv[2];
   } else {
     return join(__dirname, DEFAULT_CONF_LOCATION);

--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/qc",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "jsroot",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "O2 Quality Control Web User Interface",
   "author": "George Raduta",
   "contributors": [


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

ES6 syntax will not allow reading `.js` configuration files as modules outside of the project directory.
Thus, it needs to have the extension `.mjs` and regex to allow it