### PR TITLE
[OGUI-1306] Use gRPC deadline option instead of Promise.race

### DIFF
--- a/Control/lib/control-core/ControlService.js
+++ b/Control/lib/control-core/ControlService.js
@@ -164,10 +164,11 @@ class ControlService {
    * Execute Command but do not respond to user
    * @param {string} method - AliECS method name
    * @param {object} body - request body
+   * @param {JSON} options - optional parameters that are to be set to the gRPC call (e.g deadline)
    * @return {Promise}
    */
-  executeCommandNoResponse(method, body) {
-    return this.ctrlProx[method](body);
+  executeCommandNoResponse(method, body = {}, options = {}) {
+    return this.ctrlProx[method](body, options);
   }
 
   /**

--- a/Control/lib/control-core/EnvCache.js
+++ b/Control/lib/control-core/EnvCache.js
@@ -27,7 +27,7 @@ class EnvCache {
   constructor(ctrlService) {
     this.ctrlService = ctrlService;
     this.cache = {};
-    this.timeout = 1500;
+    this.timeout = 5000;
     this.cacheEvictionTimeout = 5 * 60 * 1000;
     this.cacheEvictionLast = new Date();
     this.refreshInterval = setInterval(() => this.refresh(), this.timeout);

--- a/Control/lib/control-core/EnvCache.js
+++ b/Control/lib/control-core/EnvCache.js
@@ -28,7 +28,7 @@ class EnvCache {
     this.ctrlService = ctrlService;
     this.cache = {};
     this.timeout = 1500;
-    this.cacheEvictionTimeout = 5*60*1000;
+    this.cacheEvictionTimeout = 5 * 60 * 1000;
     this.cacheEvictionLast = new Date();
     this.refreshInterval = setInterval(() => this.refresh(), this.timeout);
   }
@@ -68,7 +68,7 @@ class EnvCache {
   _cacheInSync(obj) {
     try {
       assert.deepStrictEqual(this.cache, obj);
-    } catch(error) {
+    } catch (error) {
       return false;
     }
     return true;
@@ -79,17 +79,15 @@ class EnvCache {
    */
   async refresh() {
     try {
-      const envs = await Promise.race([
-        this.ctrlService.executeCommandNoResponse('GetEnvironments'),
-        new Promise((_, reject) => {setTimeout(() => reject(new Error('GetEnvironments timed out')), this.timeout)})
-      ]);
+      const deadline = Date.now() + this.timeout;
+      const envs = await this.ctrlService.executeCommandNoResponse('GetEnvironments', {}, {deadline});
       if (!this._cacheInSync(envs)) {
         this.cache = envs;
         this.webSocket?.broadcast(new WebSocketMessage().setCommand('environments').setPayload(this.cache));
         log.debug('Updated cache');
       }
       this.cacheEvictionLast = new Date();
-    } catch(error) {
+    } catch (error) {
       log.debug(error);
     }
     this.evictCache();

--- a/Control/test/public/page-environments-mocha.js
+++ b/Control/test/public/page-environments-mocha.js
@@ -36,7 +36,7 @@ describe('`pageEnvironments` test-suite', () => {
     it('should successfully load page and request data', async () => {
       await page.goto(url + '?page=environments', {waitUntil: 'networkidle0'});
 
-      await page.waitForTimeout(1000);
+      await page.waitForTimeout(3500);
       const location = await page.evaluate(() => window.location);
 
       assert.strictEqual(location.search, '?page=environments');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the `EnvCache` to use gRPC `deadline` call option instead of racing a timeout;
* increase the default timeout for the cache