### PR TITLE
[OGUI-1224] Specify type of operation on AutoEnv creation

### DIFF
--- a/Control/lib/control-core/ControlService.js
+++ b/Control/lib/control-core/ControlService.js
@@ -223,8 +223,10 @@ class ControlService {
     const username = req?.session?.username ?? '';
     const personid = req?.session?.personid ?? '';
     if (method.startsWith('New') || method.startsWith('CleanupTasks')) {
-      const type = req.body.type ? ` (${req.body.type})` : '';
-      log.info(`${username}(${personid}) => ${method} ${type}`, 6);
+      const operation = req.body.operation ? ` (${req.body.operation})` : '';
+      log.infoMessage(`${username}(${personid}) => ${method} ${operation}`, {
+        level: 1, facility: 'cog/controlservice'
+      });
     } else if (method.startsWith('Control') || method.startsWith('Destroy')) {
       const type = req.body.type ? ` (${req.body.type})` : '';
       const partition = req.body.id;


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Execution of configuration was logged automatically under `NewAutoEnvironment` but it was clashing with cleanup resources operation.
Now the log includes the operation and it follows below pattern:
- ` anonymous(0) => NewAutoEnvironment   (resources-cleanup)` - for `Clean Resources` button
- ` anonymous(0) => NewAutoEnvironment   (o2-roc-config)` for `CRU(s) configuration trigger`