### PR TITLE
[OGUI-1357] Double quotes will break URL formatting

### DIFF
--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -116,8 +116,8 @@ export default class LogFilter extends Observable {
         if (!criterias[field][operator]) {
           delete criterias[field][operator];
         } else if (operator === 'match' || operator === 'exclude') {
-          // encode potential breaking characters
-          criterias[field][operator] = encodeURI(criterias[field][operator]);
+          // encode potential breaking characters and escape double quotes as are used by browser by default
+          criterias[field][operator] = encodeURI(criterias[field][operator].replace(/["]+/g, '\\"'));
         }
 
         // remove empty fields
@@ -126,7 +126,6 @@ export default class LogFilter extends Observable {
         }
       }
     }
-
     return criterias;
   }
 

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -93,13 +93,27 @@ describe('Filter actions test-suite', async () => {
     assert.strictEqual(searchParams, expectedParams);
   });
 
-  it('should update URI with new encoded criteria', async () => {
+  it('should update URI with new encoded "match" criteria', async () => {
     /* eslint-disable max-len */
-    const decodedParams = '?q={"hostname":{"match":"%ald_qdip01%"},"severity":{"in":"I W E F"}}';
-    const expectedParams = '?q={%22hostname%22:{%22match%22:%22%25ald_qdip01%25%22},%22severity%22:{%22in%22:%22I%20W%20E%20F%22}}';
-    /* eslint-enable max-len */
+    const decodedParams = '?q={"hostname":{"match":"\\"%ald_qdip01%"},"severity":{"in":"I W E F"}}';
+    const expectedParams = '?q={%22hostname%22:{%22match%22:%22%5C%22%25ald_qdip01%25%22},%22severity%22:{%22in%22:%22I%20W%20E%20F%22}}';
     const searchParams = await page.evaluate(() => {
-      window.model.log.filter.setCriteria('hostname', 'match', '%ald_qdip01%');
+      window.model.log.filter.setCriteria('hostname', 'match', '"%ald_qdip01%');
+      window.model.updateRouteOnModelChange();
+      return window.location.search;
+    });
+
+    assert.deepStrictEqual(searchParams, expectedParams);
+    assert.deepStrictEqual(decodeURI(searchParams), decodedParams);
+  });
+
+  it('should update URI with new encoded "exclude" criteria', async () => {
+    /* eslint-disable max-len */
+    const decodedParams = '?q={"hostname":{"exclude":"\\"%ald_qdip01%"},"severity":{"in":"I W E F"}}';
+    const expectedParams = '?q={%22hostname%22:{%22exclude%22:%22%5C%22%25ald_qdip01%25%22},%22severity%22:{%22in%22:%22I%20W%20E%20F%22}}';
+    const searchParams = await page.evaluate(() => {
+      window.model.log.filter.resetCriteria();
+      window.model.log.filter.setCriteria('hostname', 'exclude', '"%ald_qdip01%');
       window.model.updateRouteOnModelChange();
       return window.location.search;
     });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Double quotes in a filter field was not escaped correctly and it was breaking shared URLs;
PR which:
* replaces `"` with `\"` which then the browser encodes and decodes correctly