### PR TITLE
[OGUI-1305] QCG should not send ts anymore as QC uses validity intervals

### DIFF
--- a/QualityControl/lib/services/CcdbService.js
+++ b/QualityControl/lib/services/CcdbService.js
@@ -136,7 +136,7 @@ export class CcdbService {
    * @returns {Promise.<object>} - returns object validity
    * @throws {Error}
    */
-  async getObjectValidity(path, timestamp = '', filter = '') {
+  async getObjectValidity(path, timestamp = undefined, filter = '') {
     const headers = {
       Accept: 'application/json',
       'X-Filter-Fields': this.VALID_FROM,
@@ -176,7 +176,7 @@ export class CcdbService {
    * @returns {Promise.<JSON>} e.g  {location: '/download/id', drawOptions: 'colz'}
    * @throws {Error}
    */
-  async getObjectDetails(name, timestamp, filter = '') {
+  async getObjectDetails(name, timestamp = undefined, filter = '') {
     if (!name || !timestamp) {
       throw new Error('Missing mandatory parameters: name & timestamp');
     }
@@ -203,7 +203,7 @@ export class CcdbService {
   /**
    * Get latest version of an object or a specified version through the timestamp;
    * @param {string} path - Complete name of object; e.g qc/MO/CPV/merger1
-   * @param {number} timestamp - version of object that should be queried
+   * @param {number} timestamp - version of object that should be queried; default value ''
    * @returns {Promise.<JSON>} - object details for a given timestamp
    * @throws {Error}
    */

--- a/QualityControl/lib/services/ObjectService.js
+++ b/QualityControl/lib/services/ObjectService.js
@@ -79,7 +79,7 @@ export class ObjectService {
    * @returns {Promise<QcObject>} - QC objects with information CCDB and root
    * @throws
    */
-  async getObject(objectName, timestamp = null, filter = '') {
+  async getObject(objectName, timestamp = undefined, filter = '') {
     const validFrom = await this._dbService.getObjectValidity(objectName, timestamp, filter);
     const object = await this._dbService.getObjectDetails(objectName, validFrom, filter);
     const rootObj = await this._getJsRootFormat(this._DB_URL + object.location);
@@ -100,7 +100,7 @@ export class ObjectService {
    * @returns {Promise<QcObject>} - QC objects with information CCDB and root
    * @throws
    */
-  async getObjectById(id, timestamp = null, filter = '') {
+  async getObjectById(id, timestamp = undefined, filter = '') {
     const { object, layoutName } = this._dataService.getObjectById(id);
     const { name, options = {}, ignoreDefaults = false } = object;
     const qcObject = await this.getObject(name, timestamp, filter);

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -279,7 +279,7 @@ export default class QCObject extends Observable {
    * @param {number} timestamp - timestamp in ms
    * @returns {undefined}
    */
-  async loadObjectByName(objectName, timestamp = -1) {
+  async loadObjectByName(objectName, timestamp = undefined) {
     this.objects[objectName] = RemoteData.loading();
     this.notify();
     const obj = await this.model.services.object.getObjectByName(objectName, timestamp, '', this);
@@ -295,7 +295,7 @@ export default class QCObject extends Observable {
         this.notify();
       }
       if (this.selected) {
-        this.selected.version = timestamp === -1
+        this.selected.version = !timestamp
           ? parseInt(this.objects[objectName].payload.timestamps[0], 10)
           : parseInt(timestamp, 10);
       }
@@ -325,7 +325,8 @@ export default class QCObject extends Observable {
     await Promise.allSettled(objectsName.map(async (objectName) => {
       this.objects[objectName] = RemoteData.Loading();
       this.notify();
-      this.objects[objectName] = await this.model.services.object.getObjectByName(objectName, -1, filterAsString, this);
+      this.objects[objectName] = await this
+        .model.services.object.getObjectByName(objectName, undefined, filterAsString, this);
       this.notify();
     }));
     this.objectsRemote = RemoteData.success();

--- a/QualityControl/public/pages/objectView/ObjectViewModel.js
+++ b/QualityControl/public/pages/objectView/ObjectViewModel.js
@@ -55,7 +55,7 @@ export default class ObjectViewModel extends Observable {
    * @param {object} filter - specific fields that should be applied
    * @returns {undefined}
    */
-  async updateObjectSelection({ objectName = undefined, objectId = undefined }, timestamp = -1, filter = {}) {
+  async updateObjectSelection({ objectName = undefined, objectId = undefined }, timestamp = undefined, filter = {}) {
     if (!objectName && !objectId && !this.selected.isSuccess()) {
       return;
     } else if (!objectName && !objectId) {
@@ -86,12 +86,12 @@ export default class ObjectViewModel extends Observable {
     this.selected = RemoteData.loading();
     this.notify();
 
-    const { objectName, layoutId, objectId } = urlParams;
+    const { objectName, layoutId, objectId, ts = undefined } = urlParams;
 
     if (objectName) {
-      this.updateObjectSelection({ objectName }, -1, {});
+      this.updateObjectSelection({ objectName }, ts, {});
     } else if (layoutId && objectId) {
-      this.updateObjectSelection({ objectId }, -1, {});
+      this.updateObjectSelection({ objectId }, ts, {});
     } else {
       this.selected = RemoteData.failure('Invalid URL parameters provided');
     }

--- a/QualityControl/public/services/QCObject.service.js
+++ b/QualityControl/public/services/QCObject.service.js
@@ -63,7 +63,7 @@ export default class QCObjectService {
    * @param {Class<Observable>} that - object to be used to notify
    * @returns {Promise<RemoteData>} {result, ok, status}
    */
-  async getObjectByName(objectName, timestamp = -1, filter = '', that = this) {
+  async getObjectByName(objectName, timestamp = undefined, filter = '', that = this) {
     this.objectsLoadedMap[objectName] = RemoteData.loading();
     that.notify();
 
@@ -104,7 +104,7 @@ export default class QCObjectService {
    * @param {Class<Observable>} that - object to be used to notify
    * @returns {Promise<RemoteData>} {result, ok, status}
    */
-  async getObjectById(objectId, timestamp = -1, filter = '', that = this) {
+  async getObjectById(objectId, timestamp = undefined, filter = '', that = this) {
     try {
       // `/api/object?path=${objectName}&timestamp=${timestamp}&filter=${filter}`
       const url = this._buildURL(`/api/object/${objectId}?`, timestamp, filter);
@@ -142,12 +142,11 @@ export default class QCObjectService {
    * @param {string} filter - filter as string
    * @returns {string} - url with appended parameters
    */
-  _buildURL(url, timestamp, filter) {
-    if (timestamp === -1 && filter === '') {
-      url += `&timestamp=${Date.now()}`;
-    } else if (filter !== '') {
+  _buildURL(url, timestamp = undefined, filter = '') {
+    if (filter) {
       url += `&filter=${filter}`;
-    } else {
+    }
+    if (timestamp) {
       url += `&timestamp=${timestamp}`;
     }
     return url;


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

As now tools are using `validity` correctly (from/until), QCG scenario in which `Date.now()` is sent to CCDB does not apply anymore as it will end up in the object not being found.
Thus, QCG should not send any timestamp anymore for the initial request of the object. Only path and potentially filters

PR which:
* passes `undefined` instead of `-1` through QCG for timestamp if none is selected by the user
