### PR TITLE
[OGUI-805] TS should not be re-requested when it is provided

### DIFF
--- a/QualityControl/lib/services/ObjectService.js
+++ b/QualityControl/lib/services/ObjectService.js
@@ -80,8 +80,14 @@ export class ObjectService {
    * @throws
    */
   async getObject(objectName, timestamp = undefined, filter = '') {
-    const validFrom = await this._dbService.getObjectValidity(objectName, timestamp, filter);
-    const object = await this._dbService.getObjectDetails(objectName, validFrom, filter);
+    if (!timestamp) {
+      /*
+       * Timestamp provided by the user is taken from a dropdown list of valid-from timestamps.
+       * Thus there is no point in requesting it again
+       */
+      timestamp = await this._dbService.getObjectValidity(objectName, timestamp, filter);
+    }
+    const object = await this._dbService.getObjectDetails(objectName, timestamp, filter);
     const rootObj = await this._getJsRootFormat(this._DB_URL + object.location);
     const timestampList = await this._dbService.getObjectTimestampList(objectName, 1000, filter);
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Timestamp provided by the user is taken from a dropdown list of valid-from timestamps. Thus there is no point in requesting it again