### PR TITLE
[OGUI-1367] Configuration pairs should be saved & updated sorted alphabetically

### DIFF
--- a/Control/lib/dtos/CoreEnvConfig.js
+++ b/Control/lib/dtos/CoreEnvConfig.js
@@ -66,7 +66,7 @@ class CoreEnvConfig {
       };
       envConfig._created = data.created ?? Date.now();
       envConfig._edited = data.edited ?? Date.now();
-      envConfig._variables = data.variables ?? {};
+      envConfig._variables = CoreEnvConfig._getObjectSortedByKeys(data.variables);
       envConfig._detectors = data.detectors ?? [];
       envConfig._workflow = data.workflow;
       envConfig._revision = data.revision;
@@ -128,6 +128,17 @@ class CoreEnvConfig {
    */
   static _getNameAsId(name) {
     return `${name.trim().replace(/ /g, '_')}`.replace(/\//g, '_');
+  }
+
+  /**
+   * Given an object, sort it alphabetically by its keys and return a new object
+   * @param {object} pairs - (K;V) pairs that are to be sorted
+   * @returns {object} - (K;V) pairs sorted by key alphabetically
+   */
+  static _getObjectSortedByKeys(pairs = {}) {
+    const orderedPairs = {};
+    Object.keys(pairs).sort().forEach((key) => orderedPairs[key] = pairs[key]);
+    return orderedPairs;
   }
 
   /**

--- a/Control/test/lib/control-core/mocha-apricot-service.js
+++ b/Control/test/lib/control-core/mocha-apricot-service.js
@@ -237,7 +237,7 @@ describe('ApricotService test suite', () => {
       };
     });
 
-    it('should successfully save configuration', async () => {
+    it('should successfully save configuration with alphabetically sorted pairs', async () => {
       const body = {
         name: 'My TST Configuration',
         variables: {
@@ -251,6 +251,16 @@ describe('ApricotService test suite', () => {
         repository: 'git/repo.git',
       };
       const session = {username: 'user', personid: 11};
+      const expectedSortedVars = {
+        user: { username: 'user', personid: 11 },
+        variables: { hosts: [ 'flp01' ], some_enabled: 'true', some_other: 'false' },
+        detectors: [ 'TST' ],
+        workflow: 'readout',
+        revision: 'master',
+        repository: 'git/repo.git',
+        name: 'My TST Configuration',
+        id: 'My_TST_Configuration'
+      };
       req = {body, session};
 
       const apricotProxy = {
@@ -264,6 +274,11 @@ describe('ApricotService test suite', () => {
       assert.ok(res.status.calledWith(201));
       assert.ok(res.json.calledOnce);
       assert.ok(res.json.calledWith({message: 'Configuration successfully saved as My_TST_Configuration'}));
+
+      const stubArgs = JSON.parse(apricotProxy.SetRuntimeEntry.getCall(0).args[0].value);
+      delete stubArgs.created;
+      delete stubArgs.edited;
+      assert.deepStrictEqual(stubArgs, expectedSortedVars, 'Saved configuration is not sorted alphabetically')
     });
 
     it('should reply with error due to bad configuration object', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

As a user, I would like to see the pairs sorted alphabetically in our KV Storage so that I can easily differentiate the changes when comparing files