### PR TITLE
[OGUI-1376] Add error converters for gRPC and express responses

### DIFF
--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -16,6 +16,7 @@
 const protoLoader = require('@grpc/proto-loader');
 const grpcLibrary = require('@grpc/grpc-js');
 const path = require('path');
+const {grpcErrorToNativeError} = require('./../errors/grpcErrorToNativeError.js');
 const {Status} = require(path.join(__dirname, './../../protobuf/status_pb.js'));
 const {EnvironmentInfo} = require(path.join(__dirname, './../../protobuf/environmentinfo_pb.js'));
 const log = new (require('@aliceo2/web-ui').Log)(`${process.env.npm_config_log_label ?? 'cog'}/grpcproxy`);
@@ -45,6 +46,7 @@ class GrpcProxy {
         (error) => this._logConnectionResponse(error, wasInError, address));
 
       // set all the available gRPC methods in object and build a separate array with names only
+      console.log(Object.keys(protoService.prototype))
       this.methods = Object.keys(protoService.prototype)
         .filter((item) => item.charAt(0) !== '$')
         .map((method) => this._getAndSetPromisfiedMethod(method));
@@ -80,7 +82,7 @@ class GrpcProxy {
             } catch (exception) {
               log.debug('Failed new env details error' + exception);
             }
-            reject(error);
+            reject(grpcErrorToNativeError(error));
             return;
           }
           resolve(response);

--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -46,7 +46,6 @@ class GrpcProxy {
         (error) => this._logConnectionResponse(error, wasInError, address));
 
       // set all the available gRPC methods in object and build a separate array with names only
-      console.log(Object.keys(protoService.prototype))
       this.methods = Object.keys(protoService.prototype)
         .filter((item) => item.charAt(0) !== '$')
         .map((method) => this._getAndSetPromisfiedMethod(method));

--- a/Control/lib/errors/InvalidInputError.js
+++ b/Control/lib/errors/InvalidInputError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an user provided input is not valid
+ */
+class InvalidInputError extends Error {}
+
+exports.InvalidInputError = InvalidInputError;

--- a/Control/lib/errors/NotFoundError.js
+++ b/Control/lib/errors/NotFoundError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an item is expected to exist but it does not
+ */
+class NotFoundError extends Error {}
+
+exports.NotFoundError = NotFoundError ;

--- a/Control/lib/errors/TimeoutError.js
+++ b/Control/lib/errors/TimeoutError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an action timed out
+ */
+class TimeoutError extends Error {}
+
+exports.TimeoutError = TimeoutError;

--- a/Control/lib/errors/grpcErrorToNativeError.js
+++ b/Control/lib/errors/grpcErrorToNativeError.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const {NotFoundError} = require('./NotFoundError.js');
+const {InvalidInputError} = require('./InvalidInputError.js');
+const {TimeoutError} = require('./TimeoutError.js');
+
+/**
+ * Convert a gRPC error to native error
+ * Code List source: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+ *
+ * @param {gRPCError} error - error object from gRPC Client library
+ * @returns {Error}
+ */
+const grpcErrorToNativeError = (error) => {
+  const { code, message } = error;
+
+  switch (code) {
+    case 3:
+      return new InvalidInputError(message);
+    case 4:
+      return new TimeoutError(message);
+    case 5:
+      return new NotFoundError(message);
+    default:
+      return new Error(message);
+  }
+};
+
+exports.grpcErrorToNativeError = grpcErrorToNativeError;

--- a/Control/lib/errors/updateExpressResponseFromNativeError.js
+++ b/Control/lib/errors/updateExpressResponseFromNativeError.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const {InvalidInputError} = require('./InvalidInputError.js');
+const {NotFoundError} = require('./NotFoundError.js');
+const {TimeoutError} = require('./TimeoutError.js');
+
+/**
+ * Update (in place) the given Express response considering a given error
+ * If the error is specific, the response status may be set to a specific error code
+ *
+ * @param {Response} response - express response to be used
+ * @param {Error} error - the error instance to handle
+ * @returns {void}
+ */
+const updateExpressResponseFromNativeError = (response, error) => {
+  let status = 502;
+  const {message, constructor} = error;
+  switch (constructor) {
+    case InvalidInputError:
+      status = 400;
+      break;
+    case NotFoundError:
+      status = 404;
+      break;
+    case TimeoutError:
+      status = 408;
+      break;
+    default:
+      status = 502;
+  }
+
+  response.status(status).json({message});
+};
+
+exports.updateExpressResponseFromNativeError = updateExpressResponseFromNativeError;


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds converter for gRPC to js native error based on gRPC list of codes
* adds `NotFoundError`, `TimeoutError`, `InvalidInputError` classes which are then to be used to build the express js response