### PR TITLE
[OGUI-1383] Reject with deserialized error for NewEnv failure

### DIFF
--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -78,6 +78,7 @@ class GrpcProxy {
                   }
                 });
               }
+              reject(error);
             } catch (exception) {
               log.debug('Failed new env details error' + exception);
             }

--- a/Control/lib/control-core/GrpcProxy.js
+++ b/Control/lib/control-core/GrpcProxy.js
@@ -81,6 +81,7 @@ class GrpcProxy {
               reject(error);
             } catch (exception) {
               log.debug('Failed new env details error' + exception);
+              reject(exception);
             }
             reject(grpcErrorToNativeError(error));
             return;

--- a/Control/lib/control-core/RequestHandler.js
+++ b/Control/lib/control-core/RequestHandler.js
@@ -64,6 +64,7 @@ class RequestHandler {
       delete this.requestList[index];
     } catch(error) {
       errorLogger('Request failed, ID: ' + index);
+      errorLogger(error);
       this.requestList[index].failed = true;
       this.requestList[index].message = error.details;
       if (error.envId) {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

In case of failure for `NewEnvironment` call, a special error object needs to be de-serialized and used