### PR TITLE
[OGUI-1316] Fix issue in which tab index was reset to 0 after layout action

### DIFF
--- a/QualityControl/lib/dtos/LayoutDto.js
+++ b/QualityControl/lib/dtos/LayoutDto.js
@@ -44,7 +44,7 @@ export const LayoutDto = Joi.object({
   tabs: Joi.array().min(1).max(45).items(TabsDto).required(),
   owner_id: Joi.number().min(0).required(),
   owner_name: Joi.string().required(),
-  description: Joi.string().max(100).optional(),
+  description: Joi.string().min(0).max(100).optional(),
   collaborators: Joi.array().items(UserDto).default([]),
   displayTimestamp: Joi.boolean().default(false),
   autoTabChange: Joi.number().min(0).max(600).default(0),

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -283,7 +283,6 @@ export default class Layout extends Observable {
     } else {
       this.model.notification.show(result.payload, 'danger');
     }
-    this.model.router.go(`?page=layoutShow&layoutId=${this.item.id}`, false, false);
     this.notify();
   }
 
@@ -328,6 +327,7 @@ export default class Layout extends Observable {
       throw new Error(`index ${index} does not exist`);
     }
     this.tab = this.item.tabs[index];
+    this._tabIndex = index;
     this.model.object.loadObjects(this.tab.objects.map((object) => object.name), this.filter);
     const { columns } = this.item.tabs[index];
     if (columns > 0) {
@@ -453,7 +453,7 @@ export default class Layout extends Observable {
     this.editEnabled = false;
     this.editingTabObject = null;
     this.item = this.editOriginalClone;
-    this.selectTab(0);
+    this.selectTab(this._tabIndex);
     this.notify();
   }
 
@@ -693,7 +693,7 @@ export default class Layout extends Observable {
       }, time * 1000);
     } else {
       clearInterval(this.tabInterval);
-      this.selectTab(0);
+      this.selectTab(this._tabIndex);
     }
   }
 }

--- a/QualityControl/public/layout/view/panels/filters.js
+++ b/QualityControl/public/layout/view/panels/filters.js
@@ -67,7 +67,7 @@ const filter = (model, placeholder, key, type = 'text', width = '.w-10') =>
  */
 const updateFiltersButton = (model) => h('.w-20.text-right', h('button.btn.btn-primary', {
   onclick: () => {
-    model.layout.selectTab(0);
+    model.layout.selectTab(model.layout.tabIndex);
     model.layout.setFilterToURL();
   },
 }, 'Update'));


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* fixes a bug in which after a layout action (edit, save, cancel, applyFilter) would open the tab index 0 instead of keeping the current tab selection.
* fixes a bug in which a layout would not be created/edited if description field was empty