### PR TITLE
[OGUI-1386] Add services versions to about page

### DIFF
--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -101,7 +101,7 @@ export default class Model extends Observable {
     this.frameworkInfo = RemoteData.loading();
     this.notify();
 
-    const {result, ok} = await this.loader.get(`/api/status/framework`);
+    const {result, ok} = await this.loader.get(`/api/getFrameworkInfo`);
     if (!ok) {
       this.frameworkInfo = RemoteData.failure(result.message);
     } else {

--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -101,7 +101,7 @@ export default class Model extends Observable {
     this.frameworkInfo = RemoteData.loading();
     this.notify();
 
-    const {result, ok} = await this.loader.get(`/api/getFrameworkInfo`);
+    const {result, ok} = await this.loader.get(`/api/status/framework`);
     if (!ok) {
       this.frameworkInfo = RemoteData.failure(result.message);
     } else {

--- a/QualityControl/README.md
+++ b/QualityControl/README.md
@@ -8,6 +8,7 @@ QCG is a web graphical user interface for [O<sup>2</sup> Quality Control](https:
 - [Local Configuration](#local-configuration)
     - [HTTP](#http)
     - [CCDB](#ccdb)
+    - [QC](#qc)
 - [Run QCG locally](#run-qcg-locally)
 - [Enable HTTPS](#enable-https)
 - [Features](#features)
@@ -60,6 +61,10 @@ Edit the `ccdb` section to define a custom:
 - `[prefix = '']` - prefix to use for filtering on pathName
 - `[cachePrefix = 'qc']` - prefix to use for building the cache of object paths from CCDB
 - `[cacheRefreshRate = 120 * 1000]` - interval on which the paths of objects from CCDB should be refreshed
+
+#### QC
+Attribute to define if QCG is to be started as part of a QC integrated environment.
+- `enabled = false`
 
 ## Run QCG locally 
 

--- a/QualityControl/config-default.js
+++ b/QualityControl/config-default.js
@@ -35,6 +35,9 @@ export const config = {
     cachePrefix: 'qc',
     cacheRefreshRate: 120 * 1000,
   },
+  qc: {
+    enabled: false,
+  },
 
   /*
    * Consul configuration object

--- a/QualityControl/lib/QCModel.js
+++ b/QualityControl/lib/QCModel.js
@@ -47,7 +47,7 @@ const jsonDb = new JsonFileService(config.dbFile || `${__dirname}/../db.json`);
 export const userService = new UserService(jsonDb);
 export const layoutService = new LayoutController(jsonDb);
 
-const statusService = new StatusService({ version: packageJSON?.version ?? '-' });
+const statusService = new StatusService({ version: packageJSON?.version ?? '-' }, { qc: config.qc ?? {} });
 export const statusController = new StatusController(statusService);
 
 export let consulService = undefined;

--- a/QualityControl/lib/QCModel.js
+++ b/QualityControl/lib/QCModel.js
@@ -12,11 +12,13 @@
  * or submit itself to any jurisdiction.
  */
 
-import { config } from './config/configProvider.js';
-// Import projPackage from './../package.json';
-import { openFile, toJSON } from 'jsroot';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { readFileSync } from 'fs';
 
-import { ConsulService } from '@aliceo2/web-ui';
+import { openFile, toJSON } from 'jsroot';
+import { Log, ConsulService } from '@aliceo2/web-ui';
+
 import { CcdbService } from './services/CcdbService.js';
 import { QcObjectService } from './services/QcObject.service.js';
 import { UserService } from './services/UserService.js';
@@ -27,23 +29,24 @@ import { LayoutController } from './controllers/LayoutController.js';
 import { StatusController } from './controllers/StatusController.js';
 import { ObjectController } from './controllers/ObjectController.js';
 
-import { Log } from '@aliceo2/web-ui';
+import { config } from './config/configProvider.js';
+
 const log = new Log(`${process.env.npm_config_log_label ?? 'qcg'}/model`);
 
 /*
  * --------------------------------------------------------
  * Initialization of model according to config file
  */
-const projPackage = {}; // TODO
-export const statusController = new StatusController(config, projPackage);
 
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const packageJSON = JSON.parse(readFileSync(`${__dirname}/../package.json`));
+
 const jsonDb = new JsonFileService(config.dbFile || `${__dirname}/../db.json`);
 export const userService = new UserService(jsonDb);
 export const layoutService = new LayoutController(jsonDb);
+
+export const statusController = new StatusController(config, { version: packageJSON?.version ?? '-' });
 
 export let consulService = undefined;
 if (config.consul) {

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -39,7 +39,7 @@ export const setup = (http) => {
   http.post('/writeLayout', layoutService.updateLayout.bind(layoutService));
 
   http.get('/status/gui', statusController.getQCGStatus.bind(statusController), { public: true });
-  http.get('/getFrameworkInfo', statusController.frameworkInfo.bind(statusController), { public: true });
+  http.get('/status/framework', statusController.getFrameworkInfo.bind(statusController), { public: true });
 
   http.get('/checkUser', userService.addUser.bind(userService));
 

--- a/QualityControl/lib/controllers/StatusController.js
+++ b/QualityControl/lib/controllers/StatusController.js
@@ -12,152 +12,43 @@
  * or submit itself to any jurisdiction.
  */
 
-import { Log } from '@aliceo2/web-ui';
-const log = new Log(`${process.env.npm_config_log_label ?? 'qcg'}/status`);
-
 /**
- * Gateway for all calls with regards to the status
- * of the framework and its dependencies
+ * Gateway for all calls with regards to the status of the framework and its dependencies
  */
 export class StatusController {
   /**
-   * Setup StatusController
-   * @param {JSON} config - of the framework
-   * @param {JSON} projPackage - package json file
+   * Setup StatusController with its service
+   * @param {StatusService} statusService - service to be used for retrieving status about dependencies
    */
-  constructor(config, projPackage) {
-    if (!config) {
-      throw new Error('Empty Framework configuration');
-    }
-    this.config = config;
-    this.projPackage = projPackage;
+  constructor(statusService) {
+    /**
+     * @type {StatusService}
+     */
+    this._statusService = statusService;
   }
 
   /**
-   * Set connector that is used for retrieving general information
-   * about objects (e.g. CCDB)
-   * @param {CcdbService} connector - ccdbService
-   * @returns {undefined}
-   */
-  setDataConnector(connector) {
-    this.connector = connector;
-  }
-
-  /**
-   * Set connector used for live mode for retrieving paths
-   * of objects (e.g. Consul)
-   * @param {ConsulService} liveConnector - consul service instance
-   * @returns {undefined}
-   */
-  setLiveModeConnector(liveConnector) {
-    this.liveConnector = liveConnector;
-  }
-
-  /**
-   * Method to use response object to reply with status and information about QCG
-   * @param {Request} req - HTTP request object
+   * Method to use response object to reply with status and information about QCG for FLP - HealthChecks (via Consul)
+   * @param {Request} _ - HTTP request object
    * @param {Response} res - HTTP response object
    * @returns {undefined}
    */
-  async getQCGStatus(req, res) {
-    let result = {};
-    if (this.projPackage && this.projPackage.version) {
-      result.version = this.projPackage.version;
-    }
-    if (this.config.http) {
-      const qc = { hostname: this.config.http.hostname, port: this.config.http.port };
-      result = Object.assign(result, qc);
-      result.status = { ok: true };
-    }
-    res.status(200).json(result);
+  async getQCGStatus(_, res) {
+    res.status(200).json(this._statusService.retrieveOwnStatus());
   }
 
   /**
    * Send back information and status about the framework and its dependencies
-   * @param {Request} req - HTTP request object
+   * @param {Request} _ - HTTP request object
    * @param {Response} res - HTTP response object
    * @returns {undefined}
    */
-  async frameworkInfo(req, res) {
+  async getFrameworkInfo(_, res) {
     try {
-      const info = await this.getFrameworkInfo();
+      const info = await this._statusService.retrieveFrameworkInfo();
       res.status(200).json(info);
     } catch (error) {
-      this.logError(error);
-      res.status(502).json({ message: error.message | error });
-    }
-  }
-
-  /**
-   * Send back info about the framework
-   * @returns {object} - object containing status and framework information
-   */
-  async getFrameworkInfo() {
-    const result = {};
-    result.qcg = {};
-    if (this.projPackage && this.projPackage.version) {
-      result.qcg.version = this.projPackage.version;
-    }
-    if (this.config.http) {
-      const qc = { hostname: this.config.http.hostname, port: this.config.http.port };
-      result.qcg = Object.assign(result.qcg, qc);
-      result.qcg.status = { ok: true };
-    }
-    result.ccdb = this.config.ccdb ?? {};
-    result.ccdb.status = await this.getDataConnectorStatus();
-    if (this.config.consul) {
-      result.consul = this.config.consul;
-      result.consul.status = await this.getLiveModeConnectorStatus();
-    }
-    if (this.config.quality_control) {
-      result.quality_control = this.config.quality_control;
-    }
-    return result;
-  }
-
-  /**
-   * Retrieve Data Connector status
-   * @returns {Promise<Resolve, Reject>} - status of the data connector
-   */
-  async getDataConnectorStatus() {
-    if (!this.connector) {
-      return { ok: false, message: 'Data connector was not configured' };
-    }
-    try {
-      await this.connector.isConnectionUp();
-      return { ok: true };
-    } catch (err) {
-      this.logError(err);
-      return { ok: false, message: err.message || err };
-    }
-  }
-
-  /**
-   * Retrieve Live Connector status
-   * @returns {Promise<Resolve, Reject>} - status of the live mode connector
-   */
-  async getLiveModeConnectorStatus() {
-    if (!this.liveConnector) {
-      return { ok: false, message: 'Live Mode was not configured' };
-    }
-    try {
-      await this.liveConnector.getConsulLeaderStatus();
-      return { ok: true };
-    } catch (err) {
-      this.logError(err);
-      return { ok: false, message: err.message || err };
-    }
-  }
-
-  /**
-   * Log the error based on containing a stack trace or not
-   * @param {Error|string} err - error object or string message to be logged
-   * @returns {undefined}
-   */
-  logError(err) {
-    log.error(err.message || err);
-    if (err.stack) {
-      log.trace(err);
+      res.status(503).json({ message: error.message || error });
     }
   }
 }

--- a/QualityControl/lib/services/Status.service.js
+++ b/QualityControl/lib/services/Status.service.js
@@ -56,9 +56,7 @@ export class StatusService {
   async retrieveFrameworkInfo() {
     return {
       qcg: this.retrieveOwnStatus(),
-      ccdb: {
-        status: await this.retrieveDataServiceStatus(),
-      },
+      ccdb: await this.retrieveDataServiceStatus(),
       consul: {
         status: await this.retrieveOnlineServiceStatus(),
       },
@@ -71,10 +69,10 @@ export class StatusService {
    */
   async retrieveDataServiceStatus() {
     try {
-      await this._dataService.isConnectionUp();
-      return { ok: true };
+      const { version } = await this._dataService.retrieveVersion();
+      return { status: { ok: true }, version };
     } catch (err) {
-      return { ok: false, message: err.message || err };
+      return { status: { ok: false, message: err.message || err } };
     }
   }
 

--- a/QualityControl/lib/services/Status.service.js
+++ b/QualityControl/lib/services/Status.service.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { Log } from '@aliceo2/web-ui';
+
+/**
+ * Service for retrieving information and status of QCG dependencies
+ */
+export class StatusService {
+  /**
+   * Setup StatusService constructor and initialize needed dependencies
+   * @param {object} packageInfo - object containing partial information from package.json file
+   */
+  constructor(packageInfo) {
+    this._logger = new Log(`${process.env.npm_config_log_label ?? 'qcg'}/status-service`);
+
+    /**
+     * @type {CcdbService}
+     */
+    this._dataService = undefined;
+
+    /**
+     * @type {ConsulService}
+     */
+    this._onlineService = undefined;
+
+    this._packageInfo = packageInfo;
+  }
+
+  /**
+   * Method that builds an object with some information about the server itself
+   * @returns {object} - info on version, host and port where application is deployed
+   */
+  retrieveOwnStatus() {
+    return {
+      status: { ok: true },
+      version: this._packageInfo?.version ?? '-',
+    };
+  }
+
+  /**
+   * Send back info about the framework
+   * @returns {object} - object containing status and framework information
+   */
+  async retrieveFrameworkInfo() {
+    return {
+      qcg: this.retrieveOwnStatus(),
+      ccdb: {
+        status: await this.retrieveDataServiceStatus(),
+      },
+      consul: {
+        status: await this.retrieveOnlineServiceStatus(),
+      },
+    };
+  }
+
+  /**
+   * Retrieve data service (CCDB) status and issue if any
+   * @returns {Promise<{object}>} - status of the data service
+   */
+  async retrieveDataServiceStatus() {
+    try {
+      await this._dataService.isConnectionUp();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, message: err.message || err };
+    }
+  }
+
+  /**
+   * Retrieve status of the online service (Consul) if it was configured and issue if any
+   * @returns {Promise<Resolve, Reject>} - status of the online service
+   */
+  async retrieveOnlineServiceStatus() {
+    if (!this._onlineService) {
+      return { ok: false, message: 'Live Mode was not configured' };
+    }
+    try {
+      await this._onlineService.getConsulLeaderStatus();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, message: err.message || err };
+    }
+  }
+
+  /*
+   * Getters & Setters
+   */
+
+  /**
+   * Set service to be used for querying status of data layer (CCDB)
+   * @param {CcdbService} dataService - service used for retrieving QC objects
+   */
+  set dataService(dataService) {
+    this._dataService = dataService;
+  }
+
+  /**
+   * Set service to be used for querying status of online mode provider (Consul)
+   * @param {ConsulService} onlineService - service used for retrieving list of objects currently being produced
+   */
+  set onlineService(onlineService) {
+    this._onlineService = onlineService;
+  }
+}

--- a/QualityControl/public/frameworkInfo/FrameworkInfo.js
+++ b/QualityControl/public/frameworkInfo/FrameworkInfo.js
@@ -37,7 +37,7 @@ export default class FrameworkInfo extends Observable {
     this.item = RemoteData.loading();
     this.notify();
 
-    const { result, ok } = await this.model.loader.get('/api/getFrameworkInfo');
+    const { result, ok } = await this.model.loader.get('/api/status/framework');
     if (!ok) {
       this.item = RemoteData.failure(result.message);
       this.model.notification.show('Unable to retrieve framework information', 'danger', 2000);

--- a/QualityControl/test/lib/services/status-service.test.js
+++ b/QualityControl/test/lib/services/status-service.test.js
@@ -28,17 +28,17 @@ export const statusServiceTestSuite = async () => {
     });
     it('should return status in error is data connector throws error', async () => {
       statusService.dataService = {
-        isConnectionUp: stub().throws(new Error('Service is currently unavailable')),
+        retrieveVersion: stub().throws(new Error('Service is currently unavailable')),
       };
       const result = await statusService.retrieveDataServiceStatus();
-      assert.deepStrictEqual(result, { ok: false, message: 'Service is currently unavailable' });
+      assert.deepStrictEqual(result, { status: { ok: false, message: 'Service is currently unavailable' } });
     });
     it('should successfully return status ok if data connector passed checks', async () => {
       statusService.dataService = {
-        isConnectionUp: stub().resolves(),
+        retrieveVersion: stub().resolves({ version: '0.0.1' }),
       };
       const response = await statusService.retrieveDataServiceStatus();
-      assert.deepStrictEqual(response, { ok: true });
+      assert.deepStrictEqual(response, { status: { ok: true }, version: '0.0.1' });
     });
   });
 
@@ -70,15 +70,13 @@ export const statusServiceTestSuite = async () => {
   describe('`retrieveFrameworkInfo()` tests', () => {
     it('should successfully build an object with framework information from all used sources', async () => {
       const statusService = new StatusService();
-      statusService.dataService = { isConnectionUp: stub().resolves() };
+      statusService.dataService = { retrieveVersion: stub().resolves({ version: '0.0.1-beta' }) };
       statusService.onlineService = { getConsulLeaderStatus: stub().rejects(new Error('Live mode was not configured')) };
 
       const response = await statusService.retrieveFrameworkInfo();
       const result = {
         qcg: { version: '-', status: { ok: true } },
-        ccdb: {
-          status: { ok: true },
-        },
+        ccdb: { status: { ok: true }, version: '0.0.1-beta' },
         consul: { status: { ok: false, message: 'Live mode was not configured' } },
       };
       assert.deepStrictEqual(response, result);

--- a/QualityControl/test/lib/services/status-service.test.js
+++ b/QualityControl/test/lib/services/status-service.test.js
@@ -76,10 +76,20 @@ export const statusServiceTestSuite = async () => {
       const response = await statusService.retrieveFrameworkInfo();
       const result = {
         qcg: { version: '-', status: { ok: true } },
+        qc: { status: { ok: true }, version: 'Not part of an FLP deployment' },
         ccdb: { status: { ok: true }, version: '0.0.1-beta' },
         consul: { status: { ok: false, message: 'Live mode was not configured' } },
       };
       assert.deepStrictEqual(response, result);
+    });
+
+    describe('`retrieveQcVersion()` tests', () => {
+      it('should return message that is not part of an FLP deployment', async () => {
+        const statusService = new StatusService();
+        const response = statusService.retrieveQcVersion();
+        const result = { status: { ok: true }, version: 'Not part of an FLP deployment' };
+        assert.deepStrictEqual(response, result);
+      });
     });
   });
 

--- a/QualityControl/test/lib/services/status-service.test.js
+++ b/QualityControl/test/lib/services/status-service.test.js
@@ -86,7 +86,7 @@ export const statusServiceTestSuite = async () => {
     describe('`retrieveQcVersion()` tests', () => {
       it('should return message that is not part of an FLP deployment', async () => {
         const statusService = new StatusService();
-        const response = statusService.retrieveQcVersion();
+        const response = await statusService.retrieveQcVersion();
         const result = { status: { ok: true }, version: 'Not part of an FLP deployment' };
         assert.deepStrictEqual(response, result);
       });

--- a/QualityControl/test/lib/services/status-service.test.js
+++ b/QualityControl/test/lib/services/status-service.test.js
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/* eslint-disable require-jsdoc */
+/* eslint-disable max-len */
+
+import { stub } from 'sinon';
+import assert from 'assert';
+
+import { StatusService } from './../../../lib/services/Status.service.js';
+
+export const statusServiceTestSuite = async () => {
+  describe('`retrieveDataServiceStatus()` tests', () => {
+    let statusService;
+    before(() => {
+      statusService = new StatusService({ version: '0.1.1' });
+    });
+    it('should return status in error is data connector throws error', async () => {
+      statusService.dataService = {
+        isConnectionUp: stub().throws(new Error('Service is currently unavailable')),
+      };
+      const result = await statusService.retrieveDataServiceStatus();
+      assert.deepStrictEqual(result, { ok: false, message: 'Service is currently unavailable' });
+    });
+    it('should successfully return status ok if data connector passed checks', async () => {
+      statusService.dataService = {
+        isConnectionUp: stub().resolves(),
+      };
+      const response = await statusService.retrieveDataServiceStatus();
+      assert.deepStrictEqual(response, { ok: true });
+    });
+  });
+
+  describe('`retrieveOnlineServiceStatus()` tests', () => {
+    let statusService;
+    before(() => {
+      statusService = new StatusService();
+    });
+    it('should successfully return status with error if no online service was configured', async () => {
+      const response = await statusService.retrieveOnlineServiceStatus();
+      assert.deepStrictEqual(response, { ok: false, message: 'Live Mode was not configured' });
+    });
+    it('should return status in error if online service threw an error', async () => {
+      statusService.onlineService = {
+        getConsulLeaderStatus: stub().rejects(new Error('Unable to retrieve status of live mode')),
+      };
+      const response = await statusService.retrieveOnlineServiceStatus();
+      assert.deepStrictEqual(response, { ok: false, message: 'Unable to retrieve status of live mode' });
+    });
+    it('should successfully return status ok if online service passed checks', async () => {
+      statusService.onlineService = {
+        getConsulLeaderStatus: stub().resolves(),
+      };
+      const response = await statusService.retrieveOnlineServiceStatus();
+      assert.deepStrictEqual(response, { ok: true });
+    });
+  });
+
+  describe('`retrieveFrameworkInfo()` tests', () => {
+    it('should successfully build an object with framework information from all used sources', async () => {
+      const statusService = new StatusService();
+      statusService.dataService = { isConnectionUp: stub().resolves() };
+      statusService.onlineService = { getConsulLeaderStatus: stub().rejects(new Error('Live mode was not configured')) };
+
+      const response = await statusService.retrieveFrameworkInfo();
+      const result = {
+        qcg: { version: '-', status: { ok: true } },
+        ccdb: {
+          status: { ok: true },
+        },
+        consul: { status: { ok: false, message: 'Live mode was not configured' } },
+      };
+      assert.deepStrictEqual(response, result);
+    });
+  });
+
+  describe('`retrieveOwnStatus()` tests', () => {
+    it('should successfully return an object with status and version of itself', async () => {
+      const statusService = new StatusService({ version: '0.0.1' });
+      const res = {
+        status: stub().returnsThis(),
+        json: stub(),
+      };
+      const result = statusService.retrieveOwnStatus({}, res);
+
+      assert.deepStrictEqual(result, {
+        status: { ok: true },
+        version: '0.0.1',
+      });
+    });
+
+    it('should successfully return an object with status and no version of itself', async () => {
+      const statusService = new StatusService();
+      const res = {
+        status: stub().returnsThis(),
+        json: stub(),
+      };
+      const result = statusService.retrieveOwnStatus({}, res);
+
+      assert.deepStrictEqual(result, {
+        status: { ok: true },
+        version: '-',
+      });
+    });
+  });
+};

--- a/QualityControl/test/mocha-index.js
+++ b/QualityControl/test/mocha-index.js
@@ -19,11 +19,13 @@ import configurationTestSuite from './lib/config/public-config.test.js';
  * Controllers
  */
 import { layoutControllerTestSuite } from './lib/controllers/layout-controller.test.js';
+import { statusControllerTestSuite } from './lib/controllers/status-controller.test.js';
 
 /**
  * Services
  */
 import { ccdbServiceTestSuite } from './lib/services/ccdb-service.test.js';
+import { statusServiceTestSuite } from './lib/services/status-service.test.js';
 
 import { commonLibraryQcObjectUtilsTestSuite as objectUtilityTestSuite } from './common/library/qcObject/utils.test.js';
 import {
@@ -42,8 +44,10 @@ describe('Common Library - Test Suite', () => {
 
 describe('Services - Test Suite', async () => {
   describe('CcdbService - Test Suite', async () => await ccdbServiceTestSuite());
+  describe('StatusService - Test Suite', async () => await statusServiceTestSuite());
 });
 
 describe('Controllers - Test Suite', async () => {
   describe('LayoutController test suite', async () => await layoutControllerTestSuite());
+  describe('StatusController test suite', async () => await statusControllerTestSuite());
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* extracts `StatusService` and `StatusController` as they were part of the same file.
* renames API routes to follow convention.
* adds CCDB version retrieval as per CCDB monitor points.
* adds QC version retrieval as per QC recommendation.
* adds QCG version retrieval from `package.json`
* adapts tests of `ObjectService` and `ObjectController` following migration from CommonJS to ES6
* removes `hosts` and `ports` from about page as QCG is meant to go public