### PR TITLE
[OGUI-1386] Run Status checks in parallel and improve naming

### DIFF
--- a/QualityControl/lib/services/Status.service.js
+++ b/QualityControl/lib/services/Status.service.js
@@ -62,13 +62,16 @@ export class StatusService {
    * @returns {object} - object containing status and framework information
    */
   async retrieveFrameworkInfo() {
+    const [qc, data_service_ccdb, online_service_consul] = await Promise.all([
+      this.retrieveQcVersion(),
+      this.retrieveDataServiceStatus(),
+      this.retrieveOnlineServiceStatus(),
+    ]);
     return {
       qcg: this.retrieveOwnStatus(),
-      qc: await this.retrieveQcVersion(),
-      ccdb: await this.retrieveDataServiceStatus(),
-      consul: {
-        status: await this.retrieveOnlineServiceStatus(),
-      },
+      qc,
+      data_service_ccdb,
+      online_service_consul,
     };
   }
 
@@ -91,13 +94,13 @@ export class StatusService {
    */
   async retrieveOnlineServiceStatus() {
     if (!this._onlineService) {
-      return { ok: false, message: 'Live Mode was not configured' };
+      return { status: { ok: true }, version: 'Live Mode was not configured' };
     }
     try {
       await this._onlineService.getConsulLeaderStatus();
-      return { ok: true };
+      return { status: { ok: true } };
     } catch (err) {
-      return { ok: false, message: err.message || err };
+      return { status: { ok: false }, message: err.message || err };
     }
   }
 

--- a/QualityControl/lib/services/Status.service.js
+++ b/QualityControl/lib/services/Status.service.js
@@ -100,7 +100,7 @@ export class StatusService {
       await this._onlineService.getConsulLeaderStatus();
       return { status: { ok: true } };
     } catch (err) {
-      return { status: { ok: false }, message: err.message || err };
+      return { status: { ok: false, message: err.message || err } };
     }
   }
 

--- a/QualityControl/test/lib/services/status-service.test.js
+++ b/QualityControl/test/lib/services/status-service.test.js
@@ -47,23 +47,23 @@ export const statusServiceTestSuite = async () => {
     before(() => {
       statusService = new StatusService();
     });
-    it('should successfully return status with error if no online service was configured', async () => {
+    it('should successfully return status if no online service was configured with customized version', async () => {
       const response = await statusService.retrieveOnlineServiceStatus();
-      assert.deepStrictEqual(response, { ok: false, message: 'Live Mode was not configured' });
+      assert.deepStrictEqual(response, { status: { ok: true }, version: 'Live Mode was not configured' });
     });
     it('should return status in error if online service threw an error', async () => {
       statusService.onlineService = {
         getConsulLeaderStatus: stub().rejects(new Error('Unable to retrieve status of live mode')),
       };
       const response = await statusService.retrieveOnlineServiceStatus();
-      assert.deepStrictEqual(response, { ok: false, message: 'Unable to retrieve status of live mode' });
+      assert.deepStrictEqual(response, { status: { ok: false, message: 'Unable to retrieve status of live mode' } });
     });
     it('should successfully return status ok if online service passed checks', async () => {
       statusService.onlineService = {
         getConsulLeaderStatus: stub().resolves(),
       };
       const response = await statusService.retrieveOnlineServiceStatus();
-      assert.deepStrictEqual(response, { ok: true });
+      assert.deepStrictEqual(response, { status: { ok: true } });
     });
   });
 
@@ -71,14 +71,14 @@ export const statusServiceTestSuite = async () => {
     it('should successfully build an object with framework information from all used sources', async () => {
       const statusService = new StatusService();
       statusService.dataService = { retrieveVersion: stub().resolves({ version: '0.0.1-beta' }) };
-      statusService.onlineService = { getConsulLeaderStatus: stub().rejects(new Error('Live mode was not configured')) };
+      statusService.onlineService = { getConsulLeaderStatus: stub().rejects(new Error('Online mode failed to retrieve')) };
 
       const response = await statusService.retrieveFrameworkInfo();
       const result = {
         qcg: { version: '-', status: { ok: true } },
         qc: { status: { ok: true }, version: 'Not part of an FLP deployment' },
-        ccdb: { status: { ok: true }, version: '0.0.1-beta' },
-        consul: { status: { ok: false, message: 'Live mode was not configured' } },
+        data_service_ccdb: { status: { ok: true }, version: '0.0.1-beta' },
+        online_service_consul: { status: { ok: false, message: 'Online mode failed to retrieve' } },
       };
       assert.deepStrictEqual(response, result);
     });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which adds further improvements on the newly added status service:
- runs status retrieval commands in parallel rather than sequential;
- improves the name of the keys displayed in about page to include both purpose of the service and framework name used behind