### PR TITLE
[OGUI-1387] Add error types and managers for gRPC and Express

### DIFF
--- a/Framework/Backend/errors/InvalidInputError.js
+++ b/Framework/Backend/errors/InvalidInputError.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * Specific error to throw when an user provided input is not valid
+ * Specific error to throw when a user provided input is not valid
  */
 class InvalidInputError extends Error {}
 

--- a/Framework/Backend/errors/InvalidInputError.js
+++ b/Framework/Backend/errors/InvalidInputError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an user provided input is not valid
+ */
+class InvalidInputError extends Error {}
+
+exports.InvalidInputError = InvalidInputError;

--- a/Framework/Backend/errors/NotFoundError.js
+++ b/Framework/Backend/errors/NotFoundError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an item is expected to exist but it does not
+ */
+class NotFoundError extends Error {}
+
+exports.NotFoundError = NotFoundError ;

--- a/Framework/Backend/errors/ServiceUnavailableError.js
+++ b/Framework/Backend/errors/ServiceUnavailableError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when a service is unavailable to respond to requests
+ */
+class ServiceUnavailableError extends Error {}
+
+exports.ServiceUnavailableError = ServiceUnavailableError ;

--- a/Framework/Backend/errors/TimeoutError.js
+++ b/Framework/Backend/errors/TimeoutError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an action timed out
+ */
+class TimeoutError extends Error {}
+
+exports.TimeoutError = TimeoutError;

--- a/Framework/Backend/errors/UnauthorizedAccessError.js
+++ b/Framework/Backend/errors/UnauthorizedAccessError.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Specific error to throw when an user does not meet the access control criteria
+ */
+class UnauthorizedAccessError extends Error {}
+
+exports.UnauthorizedAccessError = UnauthorizedAccessError;

--- a/Framework/Backend/errors/grpcErrorToNativeError.js
+++ b/Framework/Backend/errors/grpcErrorToNativeError.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const {InvalidInputError} = require('./InvalidInputError.js');
+const {NotFoundError} = require('./NotFoundError.js');
+const {ServiceUnavailableError} = require('./ServiceUnavailableError.js');
+const {TimeoutError} = require('./TimeoutError.js');
+const {UnauthorizedAccessError} = require('./UnauthorizedAccessError.js');
+
+/**
+ * @typedef GrpcError
+ * also known as gRPC Status Object
+ * 
+ * @property {number} code - code of the gRPC Status object
+ * @property {string} message - message of the gRPC Status object
+ */
+
+/**
+ * Convert a gRPC error to native error
+ * Code List source: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+ *
+ * @param {GrpcError} error - error object from gRPC Client library
+ * @returns {Error}
+ */
+const grpcErrorToNativeError = (error) => {
+  const { code, message } = error;
+
+  switch (code) {
+    case 3:
+      return new InvalidInputError(message);
+    case 4:
+      return new TimeoutError(message);
+    case 5:
+      return new NotFoundError(message);
+    case 7:
+      return new UnauthorizedAccessError(message);
+    case 14:
+      return new ServiceUnavailableError(message);
+    default:
+      return new Error(message);
+  }
+};
+
+exports.grpcErrorToNativeError = grpcErrorToNativeError;

--- a/Framework/Backend/errors/updateExpressResponseFromNativeError.js
+++ b/Framework/Backend/errors/updateExpressResponseFromNativeError.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const {InvalidInputError} = require('./InvalidInputError.js');
+const {NotFoundError} = require('./NotFoundError.js');
+const {ServiceUnavailableError} = require('./ServiceUnavailableError.js');
+const {TimeoutError} = require('./TimeoutError.js');
+const {UnauthorizedAccessError} = require('./UnauthorizedAccessError.js');
+
+/**
+ * Given an Express response object and an error, use the response object to set a custom status code and send the message
+ *
+ * @param {Response} response - express response to be used
+ * @param {InvalidInputError|UnauthorizedError|NotFoundError|TimeoutError|ServiceUnavailableError} error - the error instance to handle
+ * @returns {void}
+ */
+const updateAndSendExpressResponseFromNativeError = (response, error) => {
+  let status = 500;
+  let title = 'Unknown Error';
+  const {message, constructor} = error;
+  switch (constructor) {
+    case InvalidInputError:
+      status = 400;
+      title = 'Invalid Input';
+      break;
+    case UnauthorizedAccessError:
+      status = 403;
+      title = 'Unauthorized Access';
+      break;
+    case NotFoundError:
+      status = 404;
+      title = 'Not Found';
+      break;
+    case TimeoutError:
+      status = 408;
+      title = 'Timeout';
+      break;
+    case ServiceUnavailableError:
+      status = 503;
+      title = 'Service Unavailable';
+      break;
+  }
+
+  response.status(status).json({ errors: [{ status, title, detail: message || 'An error has occurred' }] });
+};
+
+exports.updateAndSendExpressResponseFromNativeError = updateAndSendExpressResponseFromNativeError;

--- a/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
+++ b/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+/* eslint-disable max-len */
+const {grpcErrorToNativeError} = require('../../errors/grpcErrorToNativeError.js');
+const {InvalidInputError} = require('../../errors/InvalidInputError.js');
+const {NotFoundError} = require('../../errors/NotFoundError.js');
+const {ServiceUnavailableError} = require('../../errors/ServiceUnavailableError.js');
+const {TimeoutError} = require('../../errors/TimeoutError.js');
+const {UnauthorizedAccessError} = require('../../errors/UnauthorizedAccessError.js');
+
+const assert = require('assert');
+
+describe(`'grpcErrorToNativeError' test suite`, function() {
+  it('should successfully convert gRPC errors to native errors', () => {
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 3, message: 'invalid'}), new InvalidInputError('invalid'));
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 4, message: 'timeout'}), new TimeoutError('timeout'));
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 5, message: 'not-found'}), new NotFoundError('not-found'));
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 7, message: 'unauthorized'}), new UnauthorizedAccessError('unauthorized'));
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 14, message: 'service-unavailable'}), new ServiceUnavailableError('service-unavailable'));
+    assert.deepStrictEqual(grpcErrorToNativeError({code: 100, message: 'standard-error'}), new Error('standard-error'));
+    assert.deepStrictEqual(grpcErrorToNativeError({message: 'standard-error'}), new Error('standard-error'));
+  })
+});

--- a/Framework/Backend/test/errors/mocha-updateExpressResponseFromNativeError.js
+++ b/Framework/Backend/test/errors/mocha-updateExpressResponseFromNativeError.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+/* eslint-disable max-len */
+const {InvalidInputError} = require('../../errors/InvalidInputError.js');
+const {NotFoundError} = require('../../errors/NotFoundError.js');
+const {ServiceUnavailableError} = require('../../errors/ServiceUnavailableError.js');
+const {TimeoutError} = require('../../errors/TimeoutError.js');
+const {UnauthorizedAccessError} = require('../../errors/UnauthorizedAccessError.js');
+const {updateAndSendExpressResponseFromNativeError} = require('../../errors/updateExpressResponseFromNativeError.js');
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+describe(`'updateAndSendExpressResponseFromNativeError' test suite`, function() {
+  let response;
+  before(() => {
+    response = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub(),
+    }
+  });
+
+  it('should successfully update response based on InvalidInputError', () => {
+    updateAndSendExpressResponseFromNativeError(response, new InvalidInputError('Bad Parameters received'))
+    assert.ok(response.status.calledWith(400))
+    assert.ok(response.json.calledWith({errors: [{status: 400, title: 'Invalid Input', detail: 'Bad Parameters received'}]}))
+  });
+  it('should successfully update response based on UnauthorizedAccessError', () => {
+    updateAndSendExpressResponseFromNativeError(response, new UnauthorizedAccessError('You shall not pass'))
+    assert.ok(response.status.calledWith(403))
+    assert.ok(response.json.calledWith({errors: [{status: 403, title: 'Unauthorized Access', detail: 'You shall not pass'}]}))
+  });
+  it('should successfully update response based on NotFoundError', () => {
+    updateAndSendExpressResponseFromNativeError(response, new NotFoundError('Entity could not be found'))
+    assert.ok(response.status.calledWith(404))
+    assert.ok(response.json.calledWith({errors: [{status: 404, title: 'Not Found', detail: 'Entity could not be found'}]}))
+  });
+  it('should successfully update response based on TimeoutError', () => {
+    updateAndSendExpressResponseFromNativeError(response, new TimeoutError('Ran out of time'))
+    assert.ok(response.status.calledWith(408))
+    assert.ok(response.json.calledWith({errors: [{status: 408, title: 'Timeout', detail: 'Ran out of time'}]}))
+  });
+  it('should successfully update response based on ServiceUnavailableError', () => {
+    updateAndSendExpressResponseFromNativeError(response, new ServiceUnavailableError('Service does not want to cooperate'))
+    assert.ok(response.status.calledWith(503))
+    assert.ok(response.json.calledWith({errors: [{status: 503, title: 'Service Unavailable', detail: 'Service does not want to cooperate'}]}))
+  });
+  it('should successfully update response based on general Error', () => {
+    updateAndSendExpressResponseFromNativeError(response, new Error('Some Error happened'))
+    assert.ok(response.status.calledWith(500))
+    assert.ok(response.json.calledWith({errors: [{status: 500, title: 'Unknown Error', detail: 'Some Error happened'}]}))
+  });
+});


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds a few Error Types that are to be shared by the GUIs services
* adds a way for services to convert from a gRPC error to Express native error;
* adds a way for controllers to update Express response based on the service thrown error