### PR TITLE
[release/qcg/3.4.0]

### DIFF
--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/qc",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "jsroot",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "O2 Quality Control Web User Interface",
   "author": "George Raduta",
   "contributors": [


### PR DESCRIPTION
- fixes a bug which was resetting the tab in a layout to the first one every time there was an action on the layout (save, edit, cancel, update)        
- improves resilience so that QCG runs even if CCDB is not reachable
- adds in-memory object path for object tree to improve loading times. Object paths are changed quite rare and thus an interval is set on the server to refresh the in-memory list.
- improves About page to include QC, and CCDB status and versions plus brings back QCG version