### PR TITLE
[OGUI-1394] Display transitino step of environment and prevent users controlof env

### DIFF
--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -151,6 +151,7 @@ export default class Model extends Observable {
         break;
       case 'environments':
         this.environment.list = RemoteData.success(message.payload);
+        this.environment.updateItemEnvironment(message.payload.environments)
         this.notify();
         break;
       case 'requests':

--- a/Control/public/environment/components/controlEnvironmentPanel.js
+++ b/Control/public/environment/components/controlEnvironmentPanel.js
@@ -74,8 +74,15 @@ export const controlEnvironmentPanel = (environment, item, isAllowedToControl = 
  * @param {boolean} isInTransition - if environment is currently transitioning
  * @return {vnode}
  */
-const controlButton = (buttonType, environment, item, label, type, stateToHide, isInTransition) => 
-  h(`button.btn${buttonType}`,
+const controlButton = (buttonType, environment, item, label, type, stateToHide, isInTransition) =>  {
+  let title = label;
+  if (isInTransition) {
+    title = 'Environment is currently transitioning, please wait';
+  } else if (item.state !== stateToHide) {
+    title = `'${label}' cannot be used in state '${item.state}'`;
+  } 
+
+  return h(`button.btn${buttonType}`,
     {
       id: `buttonTo${label}`,
       class: environment.itemControl.isLoading() ? 'loading' : '',
@@ -85,10 +92,10 @@ const controlButton = (buttonType, environment, item, label, type, stateToHide, 
         confirm(`Are you sure you want to ${label} this ${item.state} environment?`)
           && environment.controlEnvironment({id: item.id, type, runNumber: item.currentRunNumber});
       },
-      title: isInTransition ? 'Environment is currently transitioning, please wait' : '-'
+      title
     },
-    label
-  );
+    label);
+}
 
 /**
  * Create a button to shutdown env

--- a/Control/public/environment/components/environmentPanel.js
+++ b/Control/public/environment/components/environmentPanel.js
@@ -180,9 +180,10 @@ const environmentRunningPanels = ({currentRunNumber, userVars}) => {
  * @returns {vnode}
  */
 const environmentGeneralInfoContent = (environment) => {
-  const {state, userVars = {}, createdWhen, rootRole } = environment;
+  const {currentTransition = '-', state, userVars = {}, createdWhen, rootRole } = environment;
   return h('.flex-column', [
     rowForCard('ENV Created:', parseObject(createdWhen, 'createdWhen')),
+    rowForCard('Transitioning:', currentTransition),
     rowForCard('State:', state, {valueClasses: [ALIECS_STATE_COLOR[state]]}),
     rowForCard('Run Type:', userVars.run_type),
     rowForCard('RUN Started:', parseObject(userVars['run_start_time_ms'], 'run_start_time_ms')),

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -203,17 +203,13 @@ const environmentsTable = (model, list) => {
 const runColumn = (item) => {
   let classes = '';
   let text = '-';
-  const epnEnabled = Boolean(item.userVars.epn_enabled === 'true');
-  const {state: odcState} = parseOdcStatusPerEnv(item);
   if (item.currentRunNumber) {
     classes = 'bg-success white';
     text = item.currentRunNumber;
-  } else if (
-    ((epnEnabled && odcState === 'READY') || !epnEnabled) && item.state === 'CONFIGURED'
-  ) {
+  } else if (!item.currentTransition && item.state === 'CONFIGURED') {
     classes = 'bg-primary white';
     text = 'READY';
-  } else if ((epnEnabled && odcState !== '-' && odcState !== 'READY') && item.state === 'CONFIGURED') {
+  } else if ( item.currentTransition && item.state === 'CONFIGURED') {
     classes = 'bg-primary white';
     text = '...';
   }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* uses the new `currentTransition` field from AliECS to inform user if the environment is currently transitioning
* if it is the case, disables the buttons and lets the user know
* update the env-details page automatically with data via WebSockets