### PR TITLE
[release/cog/1.61.0]

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.60.2",
+      "version": "1.61.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [


### PR DESCRIPTION
<h4>        Bug
</h4>
<ul>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1383'>OGUI-1383</a>] -         Failed deployment message not propagated to AliECS GUI due to bad deserialization of gRPC message
</li>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1393'>OGUI-1393</a>] -         Admins not being able to STOP a run without a lock
</li>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1395'>OGUI-1395</a>] -         GUI stuck if missing EPN data from ECS
</li>
</ul>
        
<h4>        New Feature
</h4>
<ul>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1394'>OGUI-1394</a>] -         Display environment transition and lock controls should inform the user the reason why the controls are disabled in transition
</li>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1396'>OGUI-1396</a>] -         Tasks counters should be summed up on server side
</li>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1397'>OGUI-1397</a>] -         Split display of tasks by components in individual panels and request information only on panel selection
</li>
<li>[<a href='https://alice.its.cern.ch/jira/browse/OGUI-1384'>OGUI-1384</a>] -         Use HTTPS module from nodejs to enable grafana healtcheck
</li>
</ul>

                                                                                                                                                                                            