### PR TITLE
[OGUI-1400] Fix issue with deadline not being applied to unary call

### DIFF
--- a/Control/lib/control-core/ControlService.js
+++ b/Control/lib/control-core/ControlService.js
@@ -168,7 +168,7 @@ class ControlService {
    * @param {JSON} options - optional parameters that are to be set to the gRPC call (e.g deadline)
    * @return {Promise}
    */
-  executeCommandNoResponse(method, body = {}, options = {}) {
+  executeCommandNoResponse(method, body = {}, options = undefined) {
     return this.ctrlProx[method](body, options);
   }
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* fixes a bug in which because an empty object was being sent as parameter instead of `undefined`, a deadline was not being applied when making a `NewEnvironment` unary call