### PR TITLE
[OGUI-1398] Add 'to' parameter for Grafana Active Plots

### DIFF
--- a/Control/public/environment/components/environmentPanel.js
+++ b/Control/public/environment/components/environmentPanel.js
@@ -90,12 +90,12 @@ const environmentActionPanel = (environment, model) => {
  * @returns {vnode}
  */
 const environmentContent = (environment) => {
-  const isRunning = environment.state === 'RUNNING';
-  const {currentRunNumber} = environment;
+  const {state, currentRunNumber, currentTransition = undefined} = environment;
+  const isRunning = state === 'RUNNING';
   const {flp, qc, trg, epn} = environment.hardware;
   return h('.cardGroupColumn', {
   }, [
-    isRunning && environmentRunningPanels(environment),
+    isRunning && !currentTransition && environmentRunningPanels(environment),
     h('.cardGroupColumn', [
       h('.cardGroupRow', [
         isRunning && miniCard(
@@ -158,7 +158,7 @@ const environmentRunningPanels = ({currentRunNumber, userVars}) => {
   if (isMonitoringConfigured) {
     const THIRTY_MINUTES_IN_MS = 1000 * 60 * 30;
     const runStartParam = (Number.isInteger(runStart) && (Date.now() - runStart) < THIRTY_MINUTES_IN_MS)
-      ? `&from=${runStart}`
+      ? `&from=${runStart}&to=now`
       : '';
     readoutMonitoringSource = readoutPlot + '&var-run=' + currentRunNumber + runStartParam;
     flpMonitoringSource = flpStats + '&var-run=' + currentRunNumber;


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* add `to=now` as parameter for readout plots in AliECS GUI Running state to prevent error from grafana on invalid time range
* the GUI will also not display the plots if environment is still transitioning towards RUNNING state