### PR TITLE
[OGUI-1402] Pass key to apricot when quering runtime entries

### DIFF
--- a/Control/lib/control-core/ApricotService.js
+++ b/Control/lib/control-core/ApricotService.js
@@ -67,11 +67,12 @@ class ApricotService {
    * * if key exists but there is no content, Apricot returns '{}'
    * * if key exists and there is content, Apricot returns content within payload attribute '{payload}'
    * @param {String} component - component for which it should query
+   * @param {String} key - key for which value should be retrieved
    * @returns {Promise<String>} - value stored by apricot
    */
-  async getRuntimeEntryByComponent(component) {
+  async getRuntimeEntryByComponent(component, key) {
     try {
-      const {payload = '{}'} = await this.apricotProxy[GetRuntimeEntry]({component});
+      const {payload = '{}'} = await this.apricotProxy[GetRuntimeEntry]({component, key});
       return payload;
     } catch (error) {
       const {code, details = ''} = error;

--- a/Control/lib/services/WorkflowTemplate.service.js
+++ b/Control/lib/services/WorkflowTemplate.service.js
@@ -61,7 +61,7 @@ class WorkflowTemplateService {
    */
   async retrieveWorkflowMappings() {
     try {
-      const mappingsString = await this._apricotGrpc.getRuntimeEntryByComponent(`${RUNTIME_COMPONENT}/${RUNTIME_KEY}`);
+      const mappingsString = await this._apricotGrpc.getRuntimeEntryByComponent(RUNTIME_COMPONENT, RUNTIME_KEY);
       const mappings = JSON.parse(mappingsString);
       return Array.isArray(mappings) ? mappings : [];
     } catch (error) {

--- a/Control/test/lib/control-core/mocha-apricot.service.test.js
+++ b/Control/test/lib/control-core/mocha-apricot.service.test.js
@@ -510,23 +510,23 @@ describe('ApricotService test suite', () => {
     let apricotService;
     before(() => {
       stub = sinon.stub();
-      stub.withArgs({component: 'COG/found-one'}).resolves({payload: JSON.stringify([{label: 'test', configuration: 'test_1'}])});
-      stub.withArgs({component: 'COG/not-found'}).rejects({code: 2, details: 'nil response for that key'});
-      stub.withArgs({component: 'COG/general-error'}).rejects({code: 2, details: 'some general error'});
+      stub.withArgs({component: 'COG', key: 'found-one'}).resolves({payload: JSON.stringify([{label: 'test', configuration: 'test_1'}])});
+      stub.withArgs({component: 'COG', key: 'not-found'}).rejects({code: 2, details: 'nil response for that key'});
+      stub.withArgs({component: 'COG', key: 'general-error'}).rejects({code: 2, details: 'some general error'});
       apricotService = new ApricotService({[GetRuntimeEntry]: stub});
     });
 
     it('should successfully return payload for component specified', async () => {
-      const content = await apricotService.getRuntimeEntryByComponent('COG/found-one');
+      const content = await apricotService.getRuntimeEntryByComponent('COG', 'found-one');
       assert.deepStrictEqual(content, JSON.stringify([{label: 'test', configuration: 'test_1'}]));
     });
 
     it('should reject with updated error code on gRPC error', async () => {
-      await assert.rejects(() => apricotService.getRuntimeEntryByComponent('COG/not-found'), {code: 5, details: 'nil response for that key'});
+      await assert.rejects(() => apricotService.getRuntimeEntryByComponent('COG', 'not-found'), {code: 5, details: 'nil response for that key'});
     });
 
     it('should successfully return payload for component specified', async () => {
-      await assert.rejects(() => apricotService.getRuntimeEntryByComponent('COG/general-error'), {code: 2, details: 'some general error'});
+      await assert.rejects(() => apricotService.getRuntimeEntryByComponent('COG', 'general-error'), {code: 2, details: 'some general error'});
     });
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the apricot and workflow services to pass KEY as separate parameter instead of added to the COMPONENT