### PR TITLE
[O2B-994] Rate limiter

### DIFF
--- a/Framework/Backend/config-default.json
+++ b/Framework/Backend/config-default.json
@@ -16,7 +16,9 @@
     "portSecure": 8443,
     "key": "test.key",
     "cert": "test.pem",
-    "tls": false
+    "tls": false,
+    "rate_limit": 2000,
+    "rate_limit_window": 5000
   },
   "mysql": {
     "host": "127.0.0.1",

--- a/Framework/Backend/test/mocha-http.js
+++ b/Framework/Backend/test/mocha-http.js
@@ -293,3 +293,25 @@ describe('HTTP constructor checks', () => {
     assert.strictEqual(httpServer.limit, '10Mb', 'Provided limit was not set')
   });
 });
+
+describe('Rate limiter', async () => {
+  const period = config.http.rate_limit_window;
+  it('should rate limit all requests made', async () => {
+    // 22 requests made in the previous tests
+    const max = config.http.rate_limit;    
+    for (let i = 0; i <= max - 22; i++) {
+      await request(httpServer)
+        .get('/')
+        .expect(302);
+    }
+    await request(httpServer)
+      .get('/')
+      .expect(429);
+  }).timeout(period);
+  it('should reset after the time window', async () => {
+    await new Promise(resolve => setTimeout(resolve, period));
+    await request(httpServer)
+      .get('/')
+      .expect(302);
+  }).timeout(period + 50);
+});

--- a/Framework/package-lock.json
+++ b/Framework/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "express": "^4.18.0",
+        "express-rate-limit": "^6.9.0",
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.0",
         "kafkajs": "^2.2.0",
@@ -2022,6 +2023,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.9.0.tgz",
+      "integrity": "sha512-AnISR3V8qy4gpKM62/TzYdoFO9NV84fBx0POXzTryHU/qGUJBWuVGd+JhbvtVmKBv37t8/afmqdnv16xWoQxag==",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express/node_modules/debug": {


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [x] test are added
- [ ] documentation is changed or added
- [ ] FLP integration tests were ran successful

- Added a configurable rate limiter. Hosts can set the requests limit (http.rate_limit) and the period of time in which to limit the requests in milliseconds (http.rate_limit_window) in config.json