### PR TITLE
Update project runners to using node 18

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Control; npm ci )
       - run: (cd Control; npm test )
   coverage:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Control; npm ci )
       - run: (cd Control; npm run coverage )
       - run: (cd Control; ./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov)

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Framework/Backend; openssl req -new  -newkey rsa:2048 -days 365 -nodes -x509 -subj "/C=CH/ST=Test/L=Test/O=Tst/CN=localhost" -keyout test.key -out test.pem)
       - run: (cd Framework; npm ci )
       - run: (cd Framework; npm test )
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Framework; npm ci )
       - run: (cd Framework; npm run coverage )
       - run: (cd Framework; ./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov)
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: cd Framework; npm ci
       - run: cd Framework; npm test
   control-compatibility:
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Framework; npm ci)
       - run: (cd Control; npm ci)
       - run: (cd Control; npm i --save ../Framework)
@@ -82,7 +82,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Framework; npm ci)
       - run: (cd QualityControl; npm ci)
       - run: (cd QualityControl; npm i --save ../Framework)
@@ -102,7 +102,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd Framework; npm ci)
       - run: (cd InfoLogger; npm ci)
       - run: (cd InfoLogger; npm i --save ../Framework)

--- a/.github/workflows/infologger.yml
+++ b/.github/workflows/infologger.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd InfoLogger; npm ci )
       - run: (cd InfoLogger; npm test )
   coverage:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd InfoLogger; npm ci )
       - run: (cd InfoLogger; npm run coverage )
       - run: (cd InfoLogger; ./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov)

--- a/.github/workflows/proto-sync.yml
+++ b/.github/workflows/proto-sync.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Copy new proto file(s)
       run: |
         git clone https://github.com/AliceO2Group/Control.git aliecs

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd QualityControl; npm ci )
       - run: (cd QualityControl; npm test )
   coverage:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: (cd QualityControl; npm ci )
       - run: (cd QualityControl; npm run coverage )
       - run: (cd QualityControl; ./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov)

--- a/Control/package.json
+++ b/Control/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/AliceO2Group/WebUi.git"
   },
   "engines": {
-    "node": ">= 16.x"
+    "node": ">= 18.x"
   },
   "homepage": "https://alice-o2-project.web.cern.ch/",
   "scripts": {

--- a/Framework/package.json
+++ b/Framework/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/AliceO2Group/WebUi.git"
   },
   "engines": {
-    "node": ">= 16.x"
+    "node": ">= 18.x"
   },
   "homepage": "https://alice-o2-project.web.cern.ch/",
   "scripts": {

--- a/InfoLogger/package.json
+++ b/InfoLogger/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/AliceO2Group/WebUi.git"
   },
   "engines": {
-    "node": ">= 16.x"
+    "node": ">= 18.x"
   },
   "homepage": "https://alice-o2-project.web.cern.ch/",
   "scripts": {

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/AliceO2Group/WebUi.git"
   },
   "engines": {
-    "node": ">= 16.x"
+    "node": ">= 18.x"
   },
   "type": "module",
   "homepage": "https://alice-o2-project.web.cern.ch/",


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [x] test are added
- [x] documentation is changed or added
- [x] FLP integration tests were ran successful

PR which:
* updates GH actions to use NodeJS 18 as test environment, similar to PROD environment
* updates package.json `engines` condition to point to v18