### PR TITLE
[OGUI-1418] Add # active clients to API status request

### DIFF
--- a/Control/lib/services/Status.service.js
+++ b/Control/lib/services/Status.service.js
@@ -274,14 +274,14 @@ class StatusService {
    * @returns {JSON}
    */
   getGuiStatus() {
-    let gui = {
-      name: 'AliECS GUI'
+    return {
+      name: 'AliECS GUI',
+      version: projPackage?.version ?? '-',
+      status: {
+        ok: true, configured: true, isCritical: true
+      },
+      clients: this?._wsService?._ws?.server?.clients?.size ?? 0
     };
-    if (projPackage?.version) {
-      gui.version = projPackage.version;
-    }
-    gui.status = {ok: true, configured: true, isCritical: true};
-    return gui;
   }
 
   /**

--- a/Control/test/lib/services/mocha-status-service.test.js
+++ b/Control/test/lib/services/mocha-status-service.test.js
@@ -128,7 +128,7 @@ describe('StatusService test suite', () => {
 
   describe('Test GUI Status retrieval via StatusService', async () => {
     const config = {http: {hostname: 'local', port: 8081}};
-    const expectedInfo = {name: 'AliECS GUI'};
+    const expectedInfo = {name: 'AliECS GUI', clients: 0};
 
     it('should successfully retrieve status and info about AliECS GUI that it is running', async () => {
       const status = new StatusService(config, {}, {});


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

To improve monitoring of the GUIs, number of active clients will be passed on to Monitoring service.
PR which:
* will send number of clients to API GET `/status/gui` request