### PR TITLE
[OGUI-1418] Add ways for removing specific FLPs based on run_type

### DIFF
--- a/Control/test/lib/mocha-core-utils.test.js
+++ b/Control/test/lib/mocha-core-utils.test.js
@@ -15,7 +15,7 @@
 
 const assert = require('assert');
 
-const CoreUtils = require('./../../lib/control-core/CoreUtils.js');
+const CoreUtils = require('../../lib/control-core/CoreUtils.js');
 
 describe('CoreUtils test suite', () => {
   describe('Check parseMethodNameString', () => {
@@ -32,6 +32,38 @@ describe('CoreUtils test suite', () => {
       assert.strictEqual(CoreUtils.parseMethodNameString(undefined), undefined);
       assert.strictEqual(CoreUtils.parseMethodNameString(''), '');
     });
+  });
+
+  describe('Check `_removeFlpBasedOnRunType` test suite', () => {
+    it('should remove flp145 for specific run_type', () => {
+      const KNOWN_RUN_TYPES = ['SYNTHETIC', 'PHYSICS', 'COSMICS', 'TECHNICAL', 'REPLAY'];
+
+      KNOWN_RUN_TYPES.forEach((runType) => {
+        const payload = {
+          vars: {
+            run_type: runType,
+            hosts: JSON.stringify(['alio2-cr1-flp145', 'alio2-cr1-flp146'])
+          }
+        };
+        const expectedPayload = {
+          vars: {
+            run_type: runType,
+            hosts: JSON.stringify(['alio2-cr1-flp146'])
+          }
+        }
+        assert.deepStrictEqual(CoreUtils._removeFlpBasedOnRunType(payload), expectedPayload);
+      });
+    });
+
+    it('should not remove flp145 for specific run_type', () => {
+      const payload = {
+        vars: {
+          run_type: 'CALIBRATION',
+          hosts: JSON.stringify(['alio2-cr1-flp145', 'alio2-cr1-flp146'])
+        }
+      };
+      assert.deepStrictEqual(CoreUtils._removeFlpBasedOnRunType(payload), payload);
+    })
   });
 
   describe('Check parseFrameworkInfo', () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

During HI-2023 there were servers identified as not suitable for specific `run_type`s. 
Shifters received instructions not to use those servers but to ensure they are never used, the GUI is to remove specific servers before deploying environment. 

PR which:
* before environment deployment request, verifies that `HOSTS` do not include specific servers