### PR TITLE
Add documentation on using NodeJS profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 | [Quality Control GUI](./QualityControl) | [![Actions Status](https://github.com/AliceO2Group/WebUi/workflows/QualityControl/badge.svg)](https://github.com/AliceO2Group/WebUi/actions) | [![codecov](https://codecov.io/gh/AliceO2Group/WebUi/branch/dev/graph/badge.svg?flag=qualitycontrol)](https://codecov.io/gh/AliceO2Group/WebUi) |
 | [Bookkeeping](https://github.com/AliceO2Group/Bookkeeping) | [![Actions Status](https://github.com/AliceO2Group/Bookkeeping/workflows/Bookkeeping/badge.svg)](https://github.com/AliceO2Group/Bookkeeping/actions) | [![codecov](https://codecov.io/gh/AliceO2Group/Bookkeeping/branch/main/graph/badge.svg)](https://codecov.io/gh/AliceO2Group/WebUi) |
 | [Run Condition Table](https://github.com/AliceO2Group/Bookkeeping) | [![Actions Status](https://github.com/AliceO2Group/RunConditionTable/workflows/Tests/badge.svg)](https://github.com/AliceO2Group/RunConditionTable/actions) | [![codecov](https://codecov.io/gh/AliceO2Group/RunConditionTable/branch/master/graph/badge.svg)](https://codecov.io/gh/AliceO2Group/RunConditionTable) |
+
+## General Documentation
+Documentation below can be applied to all the aforementioned projects with small changes applied depending on the project. 
+- [NodeJS Profiling](./documentation/NODEJS_PROFILING.md)

--- a/documentation/NODEJS_PROFILING.md
+++ b/documentation/NODEJS_PROFILING.md
@@ -1,0 +1,11 @@
+# NodeJS Profiling
+
+NodeJS provides a built-in profiler which allows developer to analyse and optimise their code. Official documentation and in-depth details can be found [here](https://nodejs.org/en/docs/guides/simple-profiling).
+
+## Summary of how to:
+1. Start WebUI server that is to be investigated with: `node --prof index.js`
+2. Execute for a few times at an interval the user scenarios that are suspected to be causing a big stress on the server. During this time, NodeJS will automatically create and update a file with the analysis details while the server is running.
+3. Once done, stop the server.
+4. Use the NodeJS generated log file prefixed with `isolate-` to get a report of the activities by running: `node --prof-process isolate-<rest_of_log_file_name>.log > processed.txt`
+5. Open the `processed.txt` file in your preferred editor, analyse the `[Summary]` section and identify `Components/Sub-Sections` that have a high number of `ticks` or increased percentage from the total.
+6. Proceed to analyse sub-sections that appear to be taking lots of resources.


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does

Adds documentation on how to use the in-house NodeJS profiling tool to analyse what processes are taking the most resources.