### PR TITLE
[OGUI-1423] Fix incorrect parameters being sent to addStats function

### DIFF
--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -350,7 +350,8 @@ export default class Log extends Observable {
     this.list = result.rows;
 
     this.resetStats();
-    result.rows.forEach(this.addStats.bind(this));
+    result.rows.forEach((log) => this.addStats(log));
+
     this.goToLastItem();
     this.notify();
   }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* specifies `log` parameter as passed one to function due to `forEach` passing by default the `index` as `increment` and completely messing up the statistics of logs.