### PR TITLE
[OGUI-1428] Remove usage of eval from front-end

### DIFF
--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -377,7 +377,7 @@ export default class Log extends Observable {
     }
     if (this.filter.setCriteria(field, operator, value)) {
       if (this.isLiveModeRunning()) {
-        this.model.ws.setFilter(this.model.log.filter.toFunction());
+        this.model.ws.setFilter(this.model.log.filter.toStringifyFunction());
         this.model.notification.show(
           `The current live session has been adapted to the new filter configuration.`, 'primary', 2000);
       } else if (this.isActiveModeQuery()) {
@@ -415,7 +415,7 @@ export default class Log extends Observable {
     // kill this interval when live mode is off
     this.liveInterval = setInterval(this.notify.bind(this), 1000);
 
-    this.model.ws.setFilter(this.model.log.filter.toFunction());
+    this.model.ws.setFilter(this.model.log.filter.toStringifyFunction());
 
     this.notify();
   }

--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -148,7 +148,7 @@ export default class LogFilter extends Observable {
    * Output of function is boolean.
    * @return {function.<WebSocketMessage, boolean>}
    */
-  toFunction() {
+  toStringifyFunction() {
     /**
      * This function will be stringified then sent to server so it can filter logs
      * 'DATA_PLACEHOLDER' will be replaced by the stringified filters too so the function contains de data
@@ -283,8 +283,7 @@ export default class LogFilter extends Observable {
     const criteriasJSON = JSON.stringify(this.criterias);
     const functionAsString = filterFunction.toString();
     const functionWithCriterias = functionAsString.replace('\'DATA_PLACEHOLDER\'', criteriasJSON);
-    const functionPure = eval(`(${functionWithCriterias})`);
-    return functionPure;
+    return functionWithCriterias;
   }
 
   /**


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* removes the usage of `eval` in InfoLogger project and passes the functions to backend as string