### PR TITLE
[OGUI-1422] Patch lock service to return state on successful lock action

### DIFF
--- a/Control/public/lock/Lock.js
+++ b/Control/public/lock/Lock.js
@@ -101,8 +101,8 @@ export default class Lock extends Observable {
       this.model.notification.show(result.message, 'danger');
       return;
     }
-
-    this.model.notification.show(`Lock ${entity} taken`, 'success');
+    this.padlockState = RemoteData.success(result);
+    this.model.notification.show(`Lock ${entity} taken`, 'success', 1500);
   }
 
   /**
@@ -115,7 +115,8 @@ export default class Lock extends Observable {
       this.model.notification.show(result.message, 'danger');
       return;
     }
-    this.model.notification.show(`Lock ${entity} forced`, 'success');
+    this.padlockState = RemoteData.success(result);
+    this.model.notification.show(`Lock ${entity} forced`, 'success', 1500);
   }
 
   /**
@@ -129,6 +130,7 @@ export default class Lock extends Observable {
       return;
     }
 
-    this.model.notification.show(`Lock ${entity} released`, 'success');
+    this.padlockState = RemoteData.success(result);
+    this.model.notification.show(`Lock ${entity} released`, 'success', 1500);
   }
 }

--- a/Control/test/lib/mocha-lock.test.js
+++ b/Control/test/lib/mocha-lock.test.js
@@ -59,27 +59,20 @@ describe('Lock test suite', () => {
 
   it('Should lock and unlock', () => {
     lock.lockDetector(req, res);
-    assert.ok(res.status.calledWith(200));
+    assert.ok(res.status.calledWith(201));
     lock.unlockDetector(req, res);
-    assert.ok(res.status.calledWith(200));
+    assert.ok(res.status.calledWith(201));
     assert.deepStrictEqual(lock.state(), {lockedBy: {}, lockedByName: {}});
   });
 
-  it('Should fail to release empty lock', () => {
+  it('Should be able to release lock even if empty', () => {
     lock.unlockDetector(req, res);
-     assert.ok(res.status.calledWith(403));
-  });
-
-  it('Should fail to lock once again by same user', () => {
-    lock.lockDetector(req, res);
     assert.ok(res.status.calledWith(200));
-    lock.lockDetector(req, res);
-    assert.ok(res.status.calledWith(403));
   });
 
   it('Should fail to lock if another user holds the lock', () => {
     lock.lockDetector(req, res);
-    assert.ok(res.status.calledWith(200));
+    assert.ok(res.status.calledWith(201));
     req.session.personid = 2;
     lock.lockDetector(req, res);
     assert.ok(res.status.calledWith(403));
@@ -87,7 +80,7 @@ describe('Lock test suite', () => {
 
   it('Should force lock occupied lock if user has admin rights', () => {
     lock.lockDetector(req, res);
-    assert.ok(res.status.calledWith(200));
+    assert.ok(res.status.calledWith(201));
     lock.forceUnlock(req, res);
     assert.ok(res.status.calledWith(200));
     assert.deepStrictEqual(lock.state(), {lockedBy: {}, lockedByName: {}});
@@ -96,7 +89,7 @@ describe('Lock test suite', () => {
   it('Should fail to force lock occupied lock if user has no admin rights', () => {
     req.session.access = [];
     lock.lockDetector(req, res);
-    assert.ok(res.status.calledWith(200));
+    assert.ok(res.status.calledWith(201));
     lock.forceUnlock(req, res);
     assert.ok(res.status.calledWith(403));
     assert.deepStrictEqual(lock.state(), {lockedBy: {test: 1}, lockedByName: {test: 'Test'}});


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
- returns the state of locks after a successful action executed by the user so that out of sync locks, are re-set
- does not throw error when attempting to lock, if lock was already taken by the user requesting it
- does not throw error when attempting to release lock, if lock was not taken