### PR TITLE
[OGUI-1431] Fix run retrieval based on new filters

### DIFF
--- a/Control/lib/adapters/RunSummaryAdapter.js
+++ b/Control/lib/adapters/RunSummaryAdapter.js
@@ -29,11 +29,13 @@ class RunSummaryAdapter {
    */
   static toEntity(run) {
     const {
+      id,
       runNumber,
       environmentId,
       definition,
       calibrationStatus,
       runType,
+      runDuration,
       startTime,
       endTime,
     } = run;
@@ -45,11 +47,13 @@ class RunSummaryAdapter {
     detectors.sort();
 
     return {
+      id,
       runNumber,
       environmentId,
       definition,
       calibrationStatus,
       runType: runType?.name,
+      runDuration,
       startTime,
       detectors,
       endTime,

--- a/Control/lib/services/Run.service.js
+++ b/Control/lib/services/Run.service.js
@@ -84,7 +84,11 @@ class RunService {
       calibrationRunsPerDetector[detector] = [];
       for (const calibrationConfiguration of calibrationConfigurationList) {
         const runTypeId = this._runTypes[calibrationConfiguration.runType];
-        const runInfo = await this._bkpService.getRun(RUN_DEFINITIONS.CALIBRATION, runTypeId, detector);
+        const runInfo = await this._bkpService.getRun({
+          definitions: RUN_DEFINITIONS.CALIBRATION,
+          runTypes: runTypeId,
+          detectors: detector
+        });
         if (runInfo) {
           calibrationRunsPerDetector[detector].push(runInfo);
         }

--- a/Control/lib/typedefs/RunSummary.js
+++ b/Control/lib/typedefs/RunSummary.js
@@ -17,10 +17,12 @@
  * RunSummary is an object which contains just a summary of an entire run entity: https://github.com/AliceO2Group/Bookkeeping/blob/main/lib/domain/entities/Run.js
  *
  * @property {Number} runNumber 
+ * @property {Number} id 
  * @property {String} environmentId
  * @property {String} definition
  * @property {String} calibrationStatus
  * @property {String} runType
+ * @property {Number} runDuration
  * @property {Number} startTime
  * @property {Number} endTime
  * @property {Array<String>} detectors

--- a/Control/test/lib/services/mocha-bookkeeping.service.test.js
+++ b/Control/test/lib/services/mocha-bookkeeping.service.test.js
@@ -61,7 +61,9 @@ describe('BookkeepingService test suite', () => {
 
   describe(`'getRun' test suite`, async () => {
     let runToReturn = {
+      id: 123,
       runNumber: 123,
+      runDuration: 100,
       environmentId: 'abc',
       definition: 'CALIBRATION',
       calibrationStatus: 'good',

--- a/Control/test/lib/services/mocha-run.service.test.js
+++ b/Control/test/lib/services/mocha-run.service.test.js
@@ -66,11 +66,11 @@ describe(`'RunService' test suite`, async () => {
 
     it('should return an object with calibration runs grouped by detector', async () => {
       const getRun = sinon.stub();
-      getRun.withArgs(RUN_DEFINITIONS.CALIBRATION, 0, 'TPC').resolves({runNumber: 1});
-      getRun.withArgs(RUN_DEFINITIONS.CALIBRATION, 1, 'TPC').resolves({runNumber: 2});
-      getRun.withArgs(RUN_DEFINITIONS.CALIBRATION, 2, 'ABC').resolves({runNumber: 3});
-      getRun.withArgs(RUN_DEFINITIONS.CALIBRATION, 1, 'ABC').resolves({runNumber: 4});
-      getRun.withArgs(RUN_DEFINITIONS.CALIBRATION, 1, 'XYZ').resolves(undefined);
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 0, detectors: 'TPC'}).resolves({runNumber: 1});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'TPC'}).resolves({runNumber: 2});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 2, detectors: 'ABC'}).resolves({runNumber: 3});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'ABC'}).resolves({runNumber: 4});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'XYZ'}).resolves(undefined);
 
       const runSrv = new RunService({getRun}, {});
       runSrv._runTypes = {
@@ -83,7 +83,7 @@ describe(`'RunService' test suite`, async () => {
           {runType: 'NOISE', configuration: 'cpv-noise', label: 'CPV NOISE'},
           {runType: 'PULSE', configuration: 'cpv-pulse', label: 'CPV PULSE'},
         ],
-        ABC:  [
+        ABC: [
           {runType: 'SOMEOTHER', configuration: 'abc-someother', label: 'ABC SOME OTHER'},
         ],
         XYZ: [


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the RunSummaryAdapter to also keep `runDuration` and `id` of the run to be used later in front-end
* updates the way in which the RunServices passes parameters to BookkeepingService