### PR TITLE
[OGUI-1431] Retrieve and display second column with last successful calibration run

### DIFF
--- a/Control/lib/adapters/external/BookkeepingFilterAdapter.js
+++ b/Control/lib/adapters/external/BookkeepingFilterAdapter.js
@@ -63,7 +63,7 @@ class BookkeepingFilterAdapter {
 
     const calibrationStatusesString = BookkeepingFilterAdapter._parseValueIntoString(calibrationStatuses);
     if (calibrationStatusesString) {
-      filter += `&filter[calibrationStatuses]=${calibrationStatusesString}`;
+      filter += `&filter[calibrationStatuses][]=${calibrationStatusesString}`;
     }
     return filter;
   }

--- a/Control/lib/common/runCalibrationStatus.enum.js
+++ b/Control/lib/common/runCalibrationStatus.enum.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+*/
+
+/**
+ * Run Definitions as per Bookkeeping's implementation: https://github.com/AliceO2Group/Bookkeeping/blob/main/docs/RUN_DEFINITIONS.md 
+ */
+const RunCalibrationStatus = Object.freeze({
+  SUCCESS: 'SUCCESS',
+  NO_STATUS: 'NO STATUS',
+  FAILED: 'FAILED'
+});
+
+exports.RunCalibrationStatus = RunCalibrationStatus;

--- a/Control/lib/common/runDefinition.enum.js
+++ b/Control/lib/common/runDefinition.enum.js
@@ -15,8 +15,8 @@
 /**
  * Run Definitions as per Bookkeeping's implementation: https://github.com/AliceO2Group/Bookkeeping/blob/main/docs/RUN_DEFINITIONS.md 
  */
-const RUN_DEFINITIONS = Object.freeze({
+const RunDefinitions = Object.freeze({
   CALIBRATION: 'CALIBRATION'
 });
 
-exports.RUN_DEFINITIONS = RUN_DEFINITIONS;
+exports.RunDefinitions = RunDefinitions;

--- a/Control/lib/services/Run.service.js
+++ b/Control/lib/services/Run.service.js
@@ -16,7 +16,7 @@ const {Log} = require('@aliceo2/web-ui');
 const {grpcErrorToNativeError} = require('./../errors/grpcErrorToNativeError.js');
 
 const {RUNTIME_COMPONENT: {COG}, RUNTIME_KEY: {CALIBRATION_MAPPING}} = require('./../common/kvStore/runtime.enum.js');
-const {RUN_DEFINITIONS} = require('./../common/runDefinition.enum.js')
+const {RunDefinitions} = require('./../common/runDefinition.enum.js')
 const {LOG_LEVEL} = require('./../common/logLevel.enum.js');
 const {RunCalibrationStatus} = require('./../common/runCalibrationStatus.enum.js');
 
@@ -91,23 +91,21 @@ class RunService {
       for (const calibrationConfiguration of calibrationConfigurationList) {
         const runTypeId = this._runTypes[calibrationConfiguration.runType];
         const lastCalibrationRun = await this._bkpService.getRun({
-          definitions: RUN_DEFINITIONS.CALIBRATION,
+          definitions: RunDefinitions.CALIBRATION,
           runTypes: runTypeId,
           detectors: detector
         });
         const lastSuccessfulCalibrationRun = await this._bkpService.getRun({
-          definitions: RUN_DEFINITIONS.CALIBRATION,
+          definitions: RunDefinitions.CALIBRATION,
           runTypes: runTypeId,
           detectors: detector,
           calibrationStatuses: RunCalibrationStatus.SUCCESS
         });
         if (lastCalibrationRun || lastSuccessfulCalibrationRun) {
-          {
-            calibrationRunsPerDetector[detector].push({
-              lastCalibrationRun,
-              lastSuccessfulCalibrationRun,
-            });
-          }
+          calibrationRunsPerDetector[detector].push({
+            lastCalibrationRun,
+            lastSuccessfulCalibrationRun,
+          });
         }
       }
     }

--- a/Control/lib/services/Run.service.js
+++ b/Control/lib/services/Run.service.js
@@ -17,7 +17,8 @@ const {grpcErrorToNativeError} = require('./../errors/grpcErrorToNativeError.js'
 
 const {RUNTIME_COMPONENT: {COG}, RUNTIME_KEY: {CALIBRATION_MAPPING}} = require('./../common/kvStore/runtime.enum.js');
 const {RUN_DEFINITIONS} = require('./../common/runDefinition.enum.js')
-const {LOG_LEVEL} = require('../common/logLevel.enum.js');
+const {LOG_LEVEL} = require('./../common/logLevel.enum.js');
+const {RunCalibrationStatus} = require('./../common/runCalibrationStatus.enum.js');
 
 /**
  * @class
@@ -89,13 +90,24 @@ class RunService {
       calibrationRunsPerDetector[detector] = [];
       for (const calibrationConfiguration of calibrationConfigurationList) {
         const runTypeId = this._runTypes[calibrationConfiguration.runType];
-        const runInfo = await this._bkpService.getRun({
+        const lastCalibrationRun = await this._bkpService.getRun({
           definitions: RUN_DEFINITIONS.CALIBRATION,
           runTypes: runTypeId,
           detectors: detector
         });
-        if (runInfo) {
-          calibrationRunsPerDetector[detector].push(runInfo);
+        const lastSuccessfulCalibrationRun = await this._bkpService.getRun({
+          definitions: RUN_DEFINITIONS.CALIBRATION,
+          runTypes: runTypeId,
+          detectors: detector,
+          calibrationStatuses: RunCalibrationStatus.SUCCESS
+        });
+        if (lastCalibrationRun || lastSuccessfulCalibrationRun) {
+          {
+            calibrationRunsPerDetector[detector].push({
+              lastCalibrationRun,
+              lastSuccessfulCalibrationRun,
+            });
+          }
         }
       }
     }

--- a/Control/public/pages/CalibrationRuns/components/calibrationRunGroups.js
+++ b/Control/public/pages/CalibrationRuns/components/calibrationRunGroups.js
@@ -43,11 +43,13 @@ export const groupedCalibrationRunsPanel = (calibrationsRunsByDetector) => {
  * @param {Array<RunSummary>} runs - list of runs for which to build the components
  * @return {vnode}
  */
-const calibrationRunsPerDetectorCard = (runs) =>
+const calibrationRunsPerDetectorCard = (runGroups) =>
   miniCard(null, [
-    runs.map((run) =>
-      h('.p1.flex-row.g2', [
-        calibrationRunCard(run),
-      ])
+    runGroups.map((group) =>
+      h('.p1.flex-row.g2', 
+        [
+          calibrationRunCard(group.lastCalibrationRun),
+          calibrationRunCard(group.lastSuccessfulCalibrationRun),
+        ])
     )
   ], ['m1', 'g1', 'p1']);

--- a/Control/test/lib/services/mocha-run.service.test.js
+++ b/Control/test/lib/services/mocha-run.service.test.js
@@ -16,7 +16,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const {RUN_DEFINITIONS} = require('./../../../lib/common/runDefinition.enum.js');
+const {RunDefinitions} = require('./../../../lib/common/runDefinition.enum.js');
 const {RunService} = require('./../../../lib/services/Run.service.js');
 const {NotFoundError} = require('./../../../lib/errors/NotFoundError.js');
 
@@ -66,15 +66,15 @@ describe(`'RunService' test suite`, async () => {
 
     it('should return an object with calibration runs grouped by detector', async () => {
       const getRun = sinon.stub();
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 0, detectors: 'TPC'}).resolves({runNumber: 1});
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 0, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 1});
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'TPC'}).resolves({runNumber: 2});
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 0, detectors: 'TPC'}).resolves({runNumber: 1});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 0, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 1});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 1, detectors: 'TPC'}).resolves({runNumber: 2});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 1, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
 
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 2, detectors: 'ABC'}).resolves({runNumber: 3});
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 2, detectors: 'ABC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 2, detectors: 'ABC'}).resolves({runNumber: 3});
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 2, detectors: 'ABC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
 
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'XYZ'}).resolves(undefined);
+      getRun.withArgs({definitions: RunDefinitions.CALIBRATION, runTypes: 1, detectors: 'XYZ'}).resolves(undefined);
 
       const runSrv = new RunService({getRun}, {});
       runSrv._runTypes = {

--- a/Control/test/lib/services/mocha-run.service.test.js
+++ b/Control/test/lib/services/mocha-run.service.test.js
@@ -67,9 +67,13 @@ describe(`'RunService' test suite`, async () => {
     it('should return an object with calibration runs grouped by detector', async () => {
       const getRun = sinon.stub();
       getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 0, detectors: 'TPC'}).resolves({runNumber: 1});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 0, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 1});
       getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'TPC'}).resolves({runNumber: 2});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'TPC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
+
       getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 2, detectors: 'ABC'}).resolves({runNumber: 3});
-      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'ABC'}).resolves({runNumber: 4});
+      getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 2, detectors: 'ABC', calibrationStatuses: 'SUCCESS'}).resolves({runNumber: 2});
+
       getRun.withArgs({definitions: RUN_DEFINITIONS.CALIBRATION, runTypes: 1, detectors: 'XYZ'}).resolves(undefined);
 
       const runSrv = new RunService({getRun}, {});
@@ -93,11 +97,11 @@ describe(`'RunService' test suite`, async () => {
       const result = await runSrv.retrieveCalibrationRunsGroupedByDetector();
       assert.deepStrictEqual(result, {
         TPC: [
-          {runNumber: 1},
-          {runNumber: 2},
+          {lastCalibrationRun: {runNumber: 1}, lastSuccessfulCalibrationRun: {runNumber: 1}},
+          {lastCalibrationRun: {runNumber: 2}, lastSuccessfulCalibrationRun: {runNumber: 2}}
         ],
         ABC: [
-          {runNumber: 3},
+          {lastCalibrationRun: {runNumber: 3}, lastSuccessfulCalibrationRun: {runNumber: 2}},
         ],
         XYZ: []
       });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
- updates runservice to retrieve also the last successful calibration run for each detector/runtype pair
- updates the BookkeepingFilterAdapter to add filter as array for calibrationStatuses
- adds this new information in a second column in calibration page
- renames run definitions enum in Pascal case