### PR TITLE
[OGUI-1434] Show info in red for template and disable button

### DIFF
--- a/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
+++ b/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
@@ -185,10 +185,11 @@ export class EnvironmentCreationModel extends Observable {
    * @return {boolean}
    */
   get isReady() {
+    const isWorkflowLoaded = this._defaultWorkflow.isSuccess();
     const isLabelSelected = Boolean(this._selectedConfigurationLabel);
     const areHostsSelected = this._model.workflow.form.hosts?.length > 0;
     const areEpnsCounted = !isNaN(this._creationModel.variables['odc_n_epns']);
-    return isLabelSelected && areHostsSelected && areEpnsCounted;
+    return isWorkflowLoaded && isLabelSelected && areHostsSelected && areEpnsCounted;
   }
 
 }

--- a/Control/public/pages/EnvironmentCreation/components/workflowTemplate.component.js
+++ b/Control/public/pages/EnvironmentCreation/components/workflowTemplate.component.js
@@ -24,9 +24,12 @@ export const workflowTemplateComponent = (workflow) =>
     NotAsked: () => null,
     Loading: () => 'Retrieving information from AliECS...',
     Success: ({template, repository, revision}) => h('.flex-column.p2.f6', [
-      h('.flex-row',h('h5.w-30.f6', 'Template: '), h('.w-70', template)),
-      h('.flex-row',h('h5.w-30.f6', 'Repository: '), h('.w-70', repository)),
-      h('.flex-row',h('h5.w-30.f6', 'Revision: '), h('.w-70', revision)),
+      h('.flex-row', h('h5.w-30.f6', 'Template: '), h('.w-70', template)),
+      h('.flex-row', h('h5.w-30.f6', 'Repository: '), h('.w-70', repository)),
+      h('.flex-row', h('h5.w-30.f6', 'Revision: '), h('.w-70', revision)),
     ]),
-    Failure: () => h('.error', 'Unable to retrieve default workflow template information from AliECS')
+    Failure: () => h('.danger.text-center', [
+      h('p', 'Missing workflow template information from AliECS.'),
+      h('p', 'Please contact an administrator.')
+    ])
   });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* displays an informative message in bright red in case there were issues in retrieving information for the default workflow template
* keeps the button disabled if the template was not loaded successfully