### PR TITLE
[OGUI-1344] Link user actions for destroying environment to new delete endpoint

### DIFF
--- a/Control/public/environment/components/controlEnvironmentPanel.js
+++ b/Control/public/environment/components/controlEnvironmentPanel.js
@@ -111,7 +111,7 @@ const shutdownEnvButton = (environment, item, isInTransition) =>
     disabled: isInTransition || environment.itemControl.isLoading(),
     style: {display: (item.state === 'CONFIGURED' || item.state == 'DEPLOYED') ? '' : 'none'},
     onclick: () => confirm(`Are you sure you want to SHUTDOWN this ${item.state} environment?`)
-      && environment.destroyEnvironment({id: item.id, runNumber: item.currentRunNumber}),
+      && environment.destroyEnvironment(item.id, item.currentRunNumber),
     title: isInTransition ? 'Environment is currently transitioning, please wait' : 'Shutdown environment'
   }, 'SHUTDOWN');
 
@@ -129,9 +129,7 @@ const killEnvButton = (environment, item) =>
       style: 'margin-left: .3em',
       disabled: environment.itemControl.isLoading() || !_isKillActionAllowed(item, environment.model),
       onclick: () => confirm(`Are you sure you want to KILL this ${item.state} environment?`)
-        && environment.destroyEnvironment({
-          id: item.id, allowInRunningState: true, force: true, runNumber: item.currentRunNumber
-        }),
+        && environment.destroyEnvironment(item.id, item.currentRunNumber, true, true),
       title: 'Kill environment'
     }, 'KILL'),
     h('.p2.dropdown-menu-right#flp_selection_info.text-center', {style: 'width: 400px'}, [

--- a/Control/public/utilities/jsonDelete.js
+++ b/Control/public/utilities/jsonDelete.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import {jsonFetch} from './jsonFetch.js';
+
+/**
+ * Build and send a DELETE request to a remote endpoint, and extract the response.
+ * @param {String} endpoint - the remote endpoint to send request to
+ * @param {RequestInit} options - the request options, see {@see fetch } native function
+ * @return {Promise<Resolve<Object>.Error<{message: String}>>} resolve with the result of the request or reject with the error message
+ */
+export const jsonDelete = async (endpoint, options) => {
+  if (options.body && typeof options.body === 'object') {
+    options.body = JSON.stringify(options.body);
+  }
+  try {
+    const result = await jsonFetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      ...options
+    });
+    return result;
+  } catch (error) {
+    return Promise.reject({message: error.message || error});
+  }
+}


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* links the destroy buttons to use new endpoint from server
* adds a new `jsonDelete` module which is a wrapper for `DELETE` methods which uses `fetchClient`