### PR TITLE
[OGUI-1451] Allow users to defined hosts to ignore by runType through the usage of the KV store service

### DIFF
--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -88,7 +88,7 @@ module.exports.setup = (http, ws) => {
   const envCtrl = new EnvironmentController(envService, workflowService, lockService);
   const workflowController = new WorkflowTemplateController(workflowService);
 
-  const aliecsReqHandler = new AliecsRequestHandler(ctrlService);
+  const aliecsReqHandler = new AliecsRequestHandler(ctrlService, apricotService);
   aliecsReqHandler.setWs(ws);
   aliecsReqHandler.workflowService = workflowService;
 

--- a/Control/lib/common/kvStore/runtime.enum.js
+++ b/Control/lib/common/kvStore/runtime.enum.js
@@ -22,6 +22,7 @@ const RUNTIME_KEY = Object.freeze({
   FLP_VERSION: 'flp_suite_version',
   PDP_VERSION: 'pdp_o2pdpsuite_version',
   CALIBRATION_MAPPING: 'calibration-mappings',
+  RUN_TYPE_TO_HOST_MAPPING: 'runType-to-host-mapping'
 });
 
 module.exports = {RUNTIME_COMPONENT, RUNTIME_KEY};

--- a/Control/lib/control-core/CoreUtils.js
+++ b/Control/lib/control-core/CoreUtils.js
@@ -11,8 +11,6 @@
  * granted to it by virtue of its status as an Intergovernmental Organization
  * or submit itself to any jurisdiction.
 */
-const KNOWN_RUN_TYPES = ['SYNTHETIC', 'PHYSICS', 'COSMICS', 'TECHNICAL', 'REPLAY'];
-const KNOWN_FLPS = [''];
 
 /**
  * Shared methods used within Core Services/Controllers
@@ -69,17 +67,28 @@ class CoreUtils {
   }
 
   /**
+   * Given a payload with properties, extract the runType one
+   * @param {EnvironmentCreation} environmentPayload - object with properties required to create an environment
+   * @return {String} runType of the environment creation.
+   */
+  static getRunType(environmentPayload) {
+    const {vars} = environmentPayload;
+    return  vars['run_type'] ?? null;
+  }
+
+  /**
    * Checks for mandatory fields and parses variables to:
    * - replace new lines with spaces
    * @param {EnvironmentCreation} payload -  configuration for creating an environment in raw format
+   * @param {Array<String>} hostsToIgnore - list of hosts that should be removed from payload
    * @return {EnvironmentCreation} - validated and parsed configuration 
    */
-  static parseEnvironmentCreationPayload(payload) {
+  static parseEnvironmentCreationPayload(payload, hostsToIgnore = []) {
     const {workflowTemplate, vars} = payload;
     if (!workflowTemplate || !vars) {
       throw new Error(`Missing mandatory parameter 'workflowTemplate' or 'vars'`)
     }
-    payload = CoreUtils._removeFlpBasedOnRunType(payload);
+    payload = CoreUtils._removeHostsFromSelection(payload, hostsToIgnore);
     Object.keys(vars).forEach((key) => vars[key] = vars[key].trim().replace(/\r?\n/g, ' '));
     return payload;
   }
@@ -89,26 +98,23 @@ class CoreUtils {
    * @param {EnvironmentCreation} payload -  configuration for creating an environment in raw format
    * @returns {EnvironmentCreation} - validated and parsed configuration 
    */
-  static _removeFlpBasedOnRunType(payload) {
+  static _removeHostsFromSelection(payload, hostsToIgnore = []) {
     try {
       const {vars} = payload;
-      const {run_type = ''} = vars;
-      if (KNOWN_RUN_TYPES.includes(run_type.toLocaleUpperCase())) {
-        const {hosts} = vars;
-        const hostsJson = JSON.parse(hosts);
-        KNOWN_FLPS.forEach((knownHost) => {
-          try {
-            const index = hostsJson.findIndex((host) => knownHost === host);
-            if (index >= 0) {
-              hostsJson.splice(index, 1);
-            }
-            vars.hosts = JSON.stringify(hostsJson);
-            payload.vars = vars;
-          } catch (error) {
-            console.error(error);
+      const {hosts} = vars;
+      const hostsList = JSON.parse(hosts);
+      hostsToIgnore.forEach((knownHost) => {
+        try {
+          const index = hostsList.findIndex((host) => knownHost === host);
+          if (index >= 0) {
+            hostsList.splice(index, 1);
           }
-        });
-      }
+        } catch (error) {
+          console.error(error);
+        }
+      });
+      vars.hosts = JSON.stringify(hostsList);
+      payload.vars = vars;
     } catch (error) {
       console.error(error)
     }

--- a/Control/lib/control-core/CoreUtils.js
+++ b/Control/lib/control-core/CoreUtils.js
@@ -100,9 +100,8 @@ class CoreUtils {
    */
   static _removeHostsFromSelection(payload, hostsToIgnore = []) {
     try {
-      const {vars} = payload;
-      const {hosts} = vars;
-      const hostsList = JSON.parse(hosts);
+      const hostsAsString = payload?.vars?.hosts ?? '[]';
+      const hostsList = JSON.parse(hostsAsString);
       hostsToIgnore.forEach((knownHost) => {
         try {
           const index = hostsList.findIndex((host) => knownHost === host);
@@ -113,8 +112,7 @@ class CoreUtils {
           console.error(error);
         }
       });
-      vars.hosts = JSON.stringify(hostsList);
-      payload.vars = vars;
+      payload.vars.hosts = JSON.stringify(hostsList);
     } catch (error) {
       console.error(error)
     }

--- a/Control/test/lib/mocha-core-utils.test.js
+++ b/Control/test/lib/mocha-core-utils.test.js
@@ -34,35 +34,28 @@ describe('CoreUtils test suite', () => {
     });
   });
 
-  describe('Check `_removeFlpBasedOnRunType` test suite', () => {
-    it.skip('should remove flp145 for specific run_type', () => {
-      const KNOWN_RUN_TYPES = ['SYNTHETIC', 'PHYSICS', 'COSMICS', 'TECHNICAL', 'REPLAY'];
-
-      KNOWN_RUN_TYPES.forEach((runType) => {
-        const payload = {
-          vars: {
-            run_type: runType,
-            hosts: JSON.stringify(['alio2-cr1-flp145', 'alio2-cr1-flp146'])
-          }
-        };
-        const expectedPayload = {
-          vars: {
-            run_type: runType,
-            hosts: JSON.stringify(['alio2-cr1-flp146'])
-          }
-        }
-        assert.deepStrictEqual(CoreUtils._removeFlpBasedOnRunType(payload), expectedPayload);
-      });
-    });
-
-    it('should not remove flp145 for specific run_type', () => {
+  describe('Check `_removeHostsFromSelection` test suite', () => {
+    it('should remove requested hosts from payload for specific run_type', () => {
       const payload = {
         vars: {
-          run_type: 'CALIBRATION',
-          hosts: JSON.stringify(['alio2-cr1-flp145', 'alio2-cr1-flp146'])
+          hosts: JSON.stringify(['host-145', 'host-146'])
         }
       };
-      assert.deepStrictEqual(CoreUtils._removeFlpBasedOnRunType(payload), payload);
+      const expectedPayload = {
+        vars: {
+          hosts: JSON.stringify(['host-146'])
+        }
+      };
+      assert.deepStrictEqual(CoreUtils._removeHostsFromSelection(payload, ['host-145']), expectedPayload);
+    });
+
+    it('should not remove host that is not found', () => {
+      const payload = {
+        vars: {
+          hosts: JSON.stringify(['host-145', 'host-146'])
+        }
+      };
+      assert.deepStrictEqual(CoreUtils._removeHostsFromSelection(payload, ['host-222']), payload);
     })
   });
 
@@ -111,6 +104,7 @@ describe('CoreUtils test suite', () => {
           keyWithNoNewLine: 'value is good to be used',
           keyWithNewLine: 'value\nvalue-value',
           keyWithMultipleNewLines: 'value\nvaluevalue\r\nend',
+          hosts: '["host-1"]'
         }
       };
       const expectedPayload = {
@@ -119,6 +113,7 @@ describe('CoreUtils test suite', () => {
           keyWithNoNewLine: 'value is good to be used',
           keyWithNewLine: 'value value-value',
           keyWithMultipleNewLines: 'value valuevalue end',
+          hosts: '["host-1"]'
         }
       }
       assert.deepStrictEqual(CoreUtils.parseEnvironmentCreationPayload(payload), expectedPayload);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* allows users to define in the KV store service used what hosts should be ignored for specific runTypes
* In KV store the users should define it under:
   * component: `COG`
   * key: `runType-to-host-mapping`

e.g.
```
{
  "SYNTHETIC": ["flp1"]
}