### PR TITLE
[OGUI-1481] Allow admin/global roles to toggle layout official

### DIFF
--- a/QualityControl/public/layout/list/page.js
+++ b/QualityControl/public/layout/list/page.js
@@ -90,11 +90,11 @@ function table(model, layouts, searchBy) {
           h(
             'tr',
             [
-              h('th', 'Official'),
+              h('th', h('.text-center', 'Official')),
               h('th', 'Name'),
               h('th', 'Owner'),
               h('th', 'Description'),
-              h('th', 'Actions'),
+              h('th', h('.text-right', 'Actions')),
             ],
           ),
         ),
@@ -124,14 +124,11 @@ function rows(model, layouts, searchBy) {
         .map((layout) => {
           const key = `key${layout.name}`;
           const { isOfficial } = layout;
-          const userName = model.session.name;
-          const userId = model.session.personid;
-          const isOwner = userId === layout.owner_id && userName === layout.owner_name;
           const isMinimumGlobal = model.session.access.some((role) => isUserRoleSufficient(role, UserRole.GLOBAL));
           const isOnline = model.layout.doesLayoutContainOnlineObjects(layout) ? 'success' : '';
           return h('tr', { key: key }, [
             h('td', {
-            }, isOfficial ? h('.primary.f4', [iconBadge(), ' ']) : ' '),
+            }, isOfficial ? h('.primary.f4.text-center', [iconBadge(), ' ']) : ' '),
             h('td.w-20', [
               h('.flex-row.items-center', { class: isOnline }, [
                 h('a', {
@@ -143,7 +140,7 @@ function rows(model, layouts, searchBy) {
             h('td.w-30', layout.owner_name),
             h('td.w-30', layout.description ?? '-'),
             h('td', h('.text-right', [
-              isOwner && isMinimumGlobal && h('button.btn.btn-sm', {
+              isMinimumGlobal && h('button.btn.btn-sm', {
                 onclick: () => model.layout.toggleOfficial(layout.id, !layout.isOfficial),
               }, layout.isOfficial ? 'Un-official' : 'Official'),
             ])),

--- a/QualityControl/test/lib/controllers/layout-controller.test.js
+++ b/QualityControl/test/lib/controllers/layout-controller.test.js
@@ -399,17 +399,17 @@ export const layoutControllerTestSuite = async () => {
       assert.ok(res.json.calledWith({ message: 'Invalid request body to update layout' }));
     });
 
-    it('should return error due to user not being owner of the layout to patch', async () => {
+    it('should return error due to layout not found to patch', async () => {
       const jsonStub = sinon.createStubInstance(JsonFileService, {
-        readLayout: sinon.stub().resolves(LAYOUT_MOCK_1),
+        readLayout: sinon.stub().rejects(new Error('Unable to find layout')),
       });
       const layoutConnector = new LayoutController(jsonStub);
 
       const req = { params: { id: 'mylayout' }, session: { personid: 2 }, body: { isOfficial: true } };
       await layoutConnector.patchLayoutHandler(req, res);
 
-      assert.ok(res.status.calledWith(403), 'Response status was not 403');
-      assert.ok(res.json.calledWith({ message: 'Only the owner of the layout can update it' }));
+      assert.ok(res.status.calledWith(404), 'Response status was not 403');
+      assert.ok(res.json.calledWith({ message: 'Unable to find layout with id: mylayout' }));
     });
 
     it('should return error due to layout update operation failing', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* removes back-end check on request being sent from owner of layout to toggle "official" status of layout
* removes front-end check to display button for "official" status change if user is not owner, but keeps the check that user has a role of at least "global"
* improves the button placement for layout official change