### PR TITLE
[OGUI-1492] Keep name of current displayed tab from layout in URL

### DIFF
--- a/QualityControl/public/Model.js
+++ b/QualityControl/public/Model.js
@@ -174,7 +174,8 @@ export default class Model extends Observable {
 
     this.services.layout.getLayoutsByUserId(this.session.personid);
 
-    switch (this.router.params.page) {
+    const { params } = this.router;
+    switch (params.page) {
       case 'layoutList':
         this.page = 'layoutList';
         setBrowserTabTitle('QCG-Layouts');
@@ -182,15 +183,15 @@ export default class Model extends Observable {
         break;
       case 'layoutShow':
         setBrowserTabTitle('QCG-LayoutShow');
-        if (!this.router.params.layoutId) {
+        if (!params.layoutId) {
           this.notification.show('layoutId in URL was missing. Redirecting to layout page', 'warning', 3000);
           this.router.go('?page=layoutList', true);
           return;
         }
-        this.layout.loadItem(this.router.params.layoutId)
+        this.layout.loadItem(this.router.params.layoutId, params?.tab ?? '')
           .then(() => {
             this.page = 'layoutShow';
-            if (this.router.params.edit) {
+            if (params.edit) {
               this.layout.edit();
 
               // Replace silently and immediately URL to remove 'edit' parameter after a layout creation

--- a/QualityControl/public/common/buildQueryParametersString.js
+++ b/QualityControl/public/common/buildQueryParametersString.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Given an existing object of used parameters and new ones to add/update, return a string with desired URL format
+ * @param {Object<String, String>} currentParameters - current parameters in the URL
+ * @param {Object<String, String>} parameters - object containing what parameters should be added or updated
+ * @returns {string} - updated URL
+ */
+export function buildQueryParametersString(currentParameters, parameters) {
+  Object.assign(currentParameters, parameters);
+  let url = '?';
+
+  Object.keys(currentParameters).forEach((param) => {
+    url += `${param}=${currentParameters[param]}&`;
+  });
+  return url.substring(0, url.length - 1);
+}


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* keeps currently displayed tab name in the URL to allow for easy share
* when loading a layout, if tab name is specified it will attempt to open the exact that one.