### PR TITLE
[OGUI-1479] Add new LayoutShow URL to allow redirect from other GUIs

### DIFF
--- a/QualityControl/lib/controllers/LayoutController.js
+++ b/QualityControl/lib/controllers/LayoutController.js
@@ -99,6 +99,8 @@ export class LayoutController {
       layoutName = name;
     } else if (runDefinition && pdpBeamType) {
       layoutName = `${runDefinition}_${pdpBeamType}`;
+    } else if (runDefinition) {
+      layoutName = runDefinition;
     } else {
       updateExpressResponseFromNativeError(res, new InvalidInputError('Missing query parameters'));
       return;

--- a/QualityControl/public/services/Layout.service.js
+++ b/QualityControl/public/services/Layout.service.js
@@ -98,6 +98,21 @@ export default class LayoutService {
   }
 
   /**
+   * Method to retrieve a layout by specific parameters as query parameters
+   * @param {String} runDefinition - definition of the run
+   * @param {String} [pdpBeamType] - optional beam type
+   * @return {Layout} - layout identified if any
+   */
+  async getLayoutByQuery(runDefinition, pdpBeamType) {
+    let url = `/api/layout?runDefinition=${runDefinition}`;
+    if (pdpBeamType) {
+      url += `&pdpBeamType=${pdpBeamType}`;
+    }
+    const { result, ok } = await this.loader.get(url);
+    return ok ? result : null;
+  }
+
+  /**
    * Method to remove a layout by its Id
    * @param {string} layoutId - layout id to be removed by
    * @returns {RemoteData} - result within a RemoteData object


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* makes `pdpBeamType` query param optional on back-end
* adds new entry URL for a layout with parameters:
  * `runDefintion` - mandatory
  * `[pdpBeamType]` - optional
  * `[detector]` - optional
* this URL is to be used by other GUIs to redirect users to specific layouts and tabs