### PR TITLE
[OGUI-1513] Add self-declared critical error state in summary table for FLP/QC/TRG tasks

### DIFF
--- a/Control/lib/adapters/EnvironmentInfoAdapter.js
+++ b/Control/lib/adapters/EnvironmentInfoAdapter.js
@@ -11,6 +11,7 @@
  * or submit itself to any jurisdiction.
  */
 
+const {FlpTaskState} = require('./../common/taskState.enum.js');
 const QC_NODES_NAME_REGEX = /alio2-cr1-q(c|me|ts)[0-9]{2}/;
 
 /**
@@ -165,7 +166,12 @@ class EnvironmentInfoAdapter {
     const {tasks = [], includedDetectors = []} = environment;
 
     for (const task of tasks) {
-      const {state = 'NOT-KNOWN', status = 'NOT-KNOWN', deploymentInfo: {hostname = ''} = {}} = task;
+      const {critical = false, status = 'NOT-KNOWN', deploymentInfo: {hostname = ''} = {}} = task;
+      let {state = FlpTaskState.UNKNOWN} = task;
+
+      if (state === FlpTaskState.ERROR && critical) {
+        state = FlpTaskState.ERROR_CRITICAL;
+      }
 
       if (hostname.match(QC_NODES_NAME_REGEX)) {
         qcTasksTotal++;

--- a/Control/lib/common/taskState.enum.js
+++ b/Control/lib/common/taskState.enum.js
@@ -1,0 +1,42 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+module.exports.FlpTaskState = Object.freeze({
+  ERROR: 'ERROR',
+  ERROR_CRITICAL: 'ERROR_CRITICAL', // GUI specific state to distinguish errors
+  RUNNING: 'RUNNING',
+  STANDBY: 'STANDBY',
+  CONFIGURED: 'CONFIGURED',
+  DONE: 'DONE',
+  MIXED: 'MIXED',
+  UNKNOWN: 'UNKNOWN',
+  INVARIANT: 'INVARIANT',
+});
+
+module.exports.EpnTaskState = Object.freeze({
+  IDLE: 'IDLE',
+  EXITING: 'EXITING',
+  RESETTING_DEVICE: 'RESETTING DEVICE',
+  INITIALIZING_DEVICE: 'INITIALIZING DEVICE',
+  INITIALIZED: 'INITIALIZED',
+  BINDING: 'BINDING',
+  BOUND: 'BOUND',
+  CONNECTING: 'CONNECTING',
+  DEVICE_READY: 'DEVICE READY',
+  INITIALIZING_TASK: 'INITIALIZING TASK',
+  READY: 'READY',
+  RUNNING: 'RUNNING',
+  RESETTING_TASK: 'RESETTING TASK',
+  OK: 'OK',
+  ERROR: 'ERROR',
+});

--- a/Control/lib/typedefs/TaskInfo.js
+++ b/Control/lib/typedefs/TaskInfo.js
@@ -26,4 +26,5 @@
  * @property {String} pid
  * @property {String} sandboxStdout
  * @property {boolean} claimable 
+ * @property {boolean} critical
  */

--- a/Control/public/common/enums/TaskState.js
+++ b/Control/public/common/enums/TaskState.js
@@ -13,6 +13,7 @@
 
 export const FlpTaskState = Object.freeze({
   ERROR: 'ERROR',
+  ERROR_CRITICAL: 'ERROR_CRITICAL', // GUI specific state to distinguish errors
   RUNNING: 'RUNNING',
   STANDBY: 'STANDBY',
   CONFIGURED: 'CONFIGURED',
@@ -28,7 +29,12 @@ export const FlpTaskState = Object.freeze({
  */
 export const FLP_TASK_STATES = Object.values(FlpTaskState)
   .sort((a, b) => {
-    if (a === FlpTaskState.ERROR) {
+    
+    if (a === FlpTaskState.ERROR_CRITICAL) {
+      return -1;
+    } else if (b === FlpTaskState.ERROR_CRITICAL) {
+      return 1;
+    } else if (a === FlpTaskState.ERROR) {
       return -1;
     } else if (b === FlpTaskState.ERROR) {
       return 1;
@@ -102,6 +108,7 @@ export const EPN_TASK_STATES = Object.values(EpnTaskState)
 export function getTaskStateClassAssociation(state) {
   switch (state) {
     case FlpTaskState.ERROR:
+    case FlpTaskState.ERROR_CRITICAL:
     case EpnTaskState.ERROR:
       return '.danger';
     case FlpTaskState.RUNNING:

--- a/Control/public/environment/components/environmentEpnTasksSummaryTable.js
+++ b/Control/public/environment/components/environmentEpnTasksSummaryTable.js
@@ -50,7 +50,6 @@ const hardwareComponentsTableHeaderRow = (hardware) => h('tr', [
  */
 const rowForTaskSate = (state, hardware) => {
   const taskClass = getTaskStateClassAssociation(state);
-  console.log(state, taskClass)
   return h('tr', [
     h(`td${taskClass}`, state), h(`td.text-center${taskClass}`, hardware?.epn?.tasks?.states[state] ?? '-'),
   ]);


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds a new self-declared state in GUI  of the tasks that are critical and in error. 