### PR TITLE
[OGUI-1514] Add state of ODC (of EPN hardware) in info

### DIFF
--- a/Control/lib/adapters/EnvironmentInfoAdapter.js
+++ b/Control/lib/adapters/EnvironmentInfoAdapter.js
@@ -246,7 +246,7 @@ class EnvironmentInfoAdapter {
       /**
        * @type {Array<DeviceInfo>} devices
        */
-      const {devices = [], ddsSessionId = '', ddsSessionStatus = ''} = JSON.parse(odc);
+      const {devices = [], ddsSessionId = '', ddsSessionStatus = '', state = ''} = JSON.parse(odc);
       const states = {};
       const hosts = new Set();
       for (const device of devices) {
@@ -260,7 +260,7 @@ class EnvironmentInfoAdapter {
           states
         },
         hosts: hosts.size,
-        info: {ddsSessionId, ddsSessionStatus}
+        info: {ddsSessionId, ddsSessionStatus, state}
       };
     } catch (error) {
       return {
@@ -269,7 +269,7 @@ class EnvironmentInfoAdapter {
           states: {},
         },
         hosts: 0,
-        info: {ddsSessionId: '-', ddsSessionStatus: '-'}
+        info: {ddsSessionId: '-', ddsSessionStatus: '-', state: '-'}
       };
     }
   }

--- a/Control/public/common/utils.js
+++ b/Control/public/common/utils.js
@@ -109,8 +109,8 @@ const getTaskShortName = (taskName) => {
  */
 const parseOdcStatusPerEnv = (environment) => {
   try {
-    if (environment.integratedServicesData && environment.integratedServicesData['odc']) {
-      const {state} = JSON.parse(environment.integratedServicesData['odc']);
+    if (environment?.hardware?.epn?.info) {
+      const {state} = environment.hardware.epn.info;
       const styleClass = ODC_STATE_COLOR[state] ?? '';
       return {state, styleClass};
     }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds back the state of ODC under the hardware component parent (EPN) as information; It was initially lost in the removal of 'integratedServicesData' due to its size limitations.
* this is then displayed in env-overview and env-details
