### PR TITLE
[OGUI-1309] Add button for select * take all locks on flp section panel

### DIFF
--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -135,6 +135,25 @@ export default class FlpSelection extends Observable {
   }
 
   /**
+   * Method which checks if a detector is available and current user has the lock for it. 
+   * If so, it will select the detector and all its associated FLPs
+   * @returns {Promise<void>}
+   */
+  selectAllAvailableDetectors() {
+    const activeDetectors = this.activeDetectors.isSuccess() ? this.activeDetectors.payload.detectors : [];
+    const detectors = this.detectors.isSuccess() ? this.detectors.payload : [];
+    const availableDetectors = detectors.filter((detector) =>
+      !activeDetectors.includes(detector) && this.workflow.model.lock.isLockedByCurrentUser(detector)
+    );
+
+    this.selectedDetectors.push(...availableDetectors);
+    for (const detector of availableDetectors) {
+      this.setHostsForDetector(detector, true);
+    }
+    this.notify();
+  }
+
+  /**
    * Given a name of a detector, it checks if it is part of the active list
    * @param {String} name 
    * @returns {boolean}

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -16,6 +16,7 @@ import {h, iconPulse} from '/js/src/index.js';
 import pageLoading from './../../../common/pageLoading.js';
 import {detectorLockButton} from './../../../lock/lockButton.js';
 import {dcsPropertiesRow} from '../../../common/dcs/dcsPropertiesRow.js';
+import {DetectorLockAction} from '../../../common/enums/DetectorLockAction.enum.js';
 
 /**
  * Create a selection area for all detectors retrieved from AliECS
@@ -28,7 +29,15 @@ export default (model, onlyGlobal = false) => {
   const detectors = model.lock.padlockState;
   const areDetectorsReady = activeDetectors.isSuccess() && detectors.isSuccess();
   return h('.w-100', [
-    h('.w-100.flex-row.panel-title.p2', h('h5.w-100.bg-gray-light', 'Detectors Selection')),
+    h('.w-100.flex-row.panel-title.p2', [
+      h('h5.w-100.bg-gray-light.flex-grow.items-center.flex-row.justify-center', 'Detectors Selection'),
+      h('button.btn.btn-primary.f6.ml1', {
+        onclick: async () => {
+          await model.lock.actionOnLock('ALL', DetectorLockAction.TAKE, false);
+          model.workflow.flpSelection.selectAllAvailableDetectors();
+        }
+      }, 'Select All')
+    ]),
     h('.w-100.p2.panel',
       (activeDetectors.isLoading() || detectors.isLoading()) && pageLoading(2),
       (areDetectorsReady) && detectorsSelectionArea(model, Object.keys(detectors.payload), onlyGlobal),


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds a button "Select All" to the FLP selection panel (reused on multiple pages) which is a shortcut for the user to:
  * take the lock for all available detectors
  * select all those detectors and their hosts