### PR TITLE
[OGUI-1309] Check for existence of owner in lock and split error throwing by type

### DIFF
--- a/Control/lib/dtos/DetectorLock.js
+++ b/Control/lib/dtos/DetectorLock.js
@@ -66,7 +66,7 @@ class DetectorLock {
    * @return {Boolean}
    */
   isOwnedBy(user) {
-    return this._owner.isSameUser(user);
+    return this._owner && this._owner.isSameUser(user);
   }
 
   /**

--- a/Control/lib/middleware/minimumRole.middleware.js
+++ b/Control/lib/middleware/minimumRole.middleware.js
@@ -48,6 +48,7 @@ const minimumRoleMiddleware = (minimumRole) => {
       }
       next();
     } catch (error) {
+      console.error(error);
       updateExpressResponseFromNativeError(res, error);
     }
   }


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [x] test are added
- [x] documentation is changed or added
- [x] FLP integration tests were ran successful

PR which:
* fixes a bug in which if the detector lock does not have an owner, an undefined error was thrown.
* split the error return for `lockOwnership` to differentiate between native and gRPC errors.
* add logging of error in `minimumRole` check