### PR TITLE
[OGUI-1518] Reduce drawing pad size for grid

### DIFF
--- a/QualityControl/public/Model.js
+++ b/QualityControl/public/Model.js
@@ -118,6 +118,9 @@ export default class Model extends Observable {
     JSROOT.settings.ApproxTextSize = true;
     JSROOT.settings.fFrameLineColor = 16;
     JSROOT.settings.PreferSavedPoints = true;
+    JSROOT.settings.SmallPad = {
+      height: 10,
+    };
 
     /*
      * Init first page


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

JSROOT by default will hide certain elements if the size of the plot is smaller than default values. In our case, the grid was being hidden which is very important to the users.
