### PR TITLE
[OGUI-1519] Split "Select all" button functionality into 2 buttons

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.70.0",
+      "version": "1.70.1",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.70.1",
+  "version": "1.70.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.70.1",
+      "version": "1.70.2",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.70.1",
+  "version": "1.70.2",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/lock/lockButton.js
+++ b/Control/public/lock/lockButton.js
@@ -49,6 +49,7 @@ export const detectorLockButton = (model, detector, lockState, isIcon = false) =
   const element = isIcon ? '.flex-row.items-center.actionable-icon' : 'button.btn';
 
   return h(`${element}.${detectorLockButtonClass}`, {
+    id: `detectorLockButtonFor${detector}`,
     title: isDetectorLockTaken ? `Lock is taken by ${lockState.owner.fullName}` : 'Lock is free',
     disabled: isDetectorLockTaken && !lockModel.isLockedByCurrentUser(detector),
     onclick: detectorLockHandler,

--- a/Control/public/workflow/panels/flps/FlpSelection.js
+++ b/Control/public/workflow/panels/flps/FlpSelection.js
@@ -137,19 +137,20 @@ export default class FlpSelection extends Observable {
   /**
    * Method which checks if a detector is available and current user has the lock for it. 
    * If so, it will select the detector and all its associated FLPs
+   * @param {Array<String>} detectorsToSelect - list of detectors to select
    * @returns {Promise<void>}
    */
-  selectAllAvailableDetectors() {
+  selectAllAvailableDetectors(detectorsToSelect) {
+    this.selectedDetectors = [];
     const activeDetectors = this.activeDetectors.isSuccess() ? this.activeDetectors.payload.detectors : [];
-    const detectors = this.detectors.isSuccess() ? this.detectors.payload : [];
-    const availableDetectors = detectors.filter((detector) =>
+    detectorsToSelect.filter((detector) =>
       !activeDetectors.includes(detector) && this.workflow.model.lock.isLockedByCurrentUser(detector)
-    );
+    )
+      .forEach((detector) => {
+        this.selectedDetectors.push(detector);
+        this.setHostsForDetector(detector, true);
 
-    this.selectedDetectors.push(...availableDetectors);
-    for (const detector of availableDetectors) {
-      this.setHostsForDetector(detector, true);
-    }
+      });
     this.notify();
   }
 

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -29,14 +29,18 @@ export default (model, onlyGlobal = false) => {
   const detectors = model.lock.padlockState;
   const areDetectorsReady = activeDetectors.isSuccess() && detectors.isSuccess();
   return h('.w-100', [
-    h('.w-100.flex-row.panel-title.p2', [
-      h('h5.w-100.bg-gray-light.flex-grow.items-center.flex-row.justify-center', 'Detectors Selection'),
-      h('button.btn.btn-primary.f6.ml1', {
+    h('.w-100.flex-row.panel-title.p2.f6', [
+      h('button.btn.btn-sm', {
         onclick: async () => {
           await model.lock.actionOnLock('ALL', DetectorLockAction.TAKE, false);
+        }
+      }, 'Lock Available'),
+      h('h5.w-100.bg-gray-light.flex-grow.items-center.flex-row.justify-center', 'Detectors Selection'),
+      h('button.btn.btn-primary.btn-sm', {
+        onclick: async () => {
           model.workflow.flpSelection.selectAllAvailableDetectors();
         }
-      }, 'Select All')
+      }, 'Select Available')
     ]),
     h('.w-100.p2.panel',
       (activeDetectors.isLoading() || detectors.isLoading()) && pageLoading(2),

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -98,6 +98,7 @@ const detectorSelectionPanel = (model, name) => {
       detectorLockButton(model, name, lockState, true),
       h('a.menu-item.w-wrapped', {
         className,
+        id: `detectorSelectionButtonFor${name}`,
         title,
         style,
         onclick: () => {

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -57,6 +57,8 @@ export default (model, onlyGlobal = false) => {
     ]),
     h('.w-100.p2.panel',
       (activeDetectors.isLoading() || detectors.isLoading()) && pageLoading(2),
+      (!areDetectorsReady) && h('.f7.flex-column',
+        `Loading detectors...active: ${activeDetectors.kind} and all: ${detectors.kind}`),
       (areDetectorsReady) && detectorsSelectionArea(model, allowedDetectors, onlyGlobal),
       (activeDetectors.isFailure() || detectors.isFailure()) && h('.f7.flex-column', 'Unavailable to load detectors'),
     )

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -59,7 +59,7 @@ export default (model, onlyGlobal = false) => {
       (activeDetectors.isLoading() || detectors.isLoading()) && pageLoading(2),
       (!areDetectorsReady) && h('.f7.flex-column',
         `Loading detectors...active: ${activeDetectors.kind} and all: ${detectors.kind}`),
-      (areDetectorsReady) && detectorsSelectionArea(model, allowedDetectors, onlyGlobal),
+      (areDetectorsReady) && detectorsSelectionArea(model, allowedDetectors),
       (activeDetectors.isFailure() || detectors.isFailure()) && h('.f7.flex-column', 'Unavailable to load detectors'),
     )
   ]);

--- a/Control/public/workflow/panels/flps/detectorsPanel.js
+++ b/Control/public/workflow/panels/flps/detectorsPanel.js
@@ -27,24 +27,37 @@ import {DetectorLockAction} from '../../../common/enums/DetectorLockAction.enum.
 export default (model, onlyGlobal = false) => {
   const {activeDetectors} = model.workflow.flpSelection;
   const detectors = model.lock.padlockState;
+  let allowedDetectors = [];
+
   const areDetectorsReady = activeDetectors.isSuccess() && detectors.isSuccess();
+  if (areDetectorsReady) {
+    allowedDetectors = JSON.parse(JSON.stringify(detectors.payload));
+    if (onlyGlobal) {
+      delete allowedDetectors.TST;
+    }
+    allowedDetectors = Object.keys(allowedDetectors);
+  }
+
   return h('.w-100', [
     h('.w-100.flex-row.panel-title.p2.f6', [
-      h('button.btn.btn-sm', {
+      areDetectorsReady && h('button.btn.btn-sm', {
         onclick: async () => {
           await model.lock.actionOnLock('ALL', DetectorLockAction.TAKE, false);
+          if (onlyGlobal) {
+            await model.lock.actionOnLock('TST', DetectorLockAction.RELEASE, false);
+          }
         }
       }, 'Lock Available'),
       h('h5.w-100.bg-gray-light.flex-grow.items-center.flex-row.justify-center', 'Detectors Selection'),
-      h('button.btn.btn-primary.btn-sm', {
+      areDetectorsReady && h('button.btn.btn-primary.btn-sm', {
         onclick: async () => {
-          model.workflow.flpSelection.selectAllAvailableDetectors();
+          model.workflow.flpSelection.selectAllAvailableDetectors(allowedDetectors);
         }
       }, 'Select Available')
     ]),
     h('.w-100.p2.panel',
       (activeDetectors.isLoading() || detectors.isLoading()) && pageLoading(2),
-      (areDetectorsReady) && detectorsSelectionArea(model, Object.keys(detectors.payload), onlyGlobal),
+      (areDetectorsReady) && detectorsSelectionArea(model, allowedDetectors, onlyGlobal),
       (activeDetectors.isFailure() || detectors.isFailure()) && h('.f7.flex-column', 'Unavailable to load detectors'),
     )
   ]);
@@ -52,18 +65,16 @@ export default (model, onlyGlobal = false) => {
 
 /**
  * Display an area with selectable elements representing detectors
- * @param {Object} model
- * @param {Array<string>} list
- * @param {boolean} onlyGlobal - if only global detectors should be displayed
+ * @param {Model} model - root model of the application
+ * @param {Array<string>} detectors - list of detectors to allow selection of
  * @return {vnode}
  */
-const detectorsSelectionArea = (model, list, onlyGlobal) => {
+const detectorsSelectionArea = (model, detectors) => {
   return h('.w-100.m1.text-left.shadow-level1.grid.g2', {
     style: 'max-height: 40em;'
   }, [
-    list
+    detectors
       .filter((name) => (name === model.detectors.selected || !model.detectors.isSingleView()))
-      .filter((name) => !onlyGlobal || (onlyGlobal && name !== 'TST'))
       .map((name) => detectorSelectionPanel(model, name))
   ]);
 };

--- a/Control/test/integration/core-tests.js
+++ b/Control/test/integration/core-tests.js
@@ -28,7 +28,7 @@ describe('Control', function() {
 
   before(async () => {
     // Start browser to test UI
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: 'new'});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: true});
     page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 770});
     exports.page = page;

--- a/Control/test/integration/core-tests.js
+++ b/Control/test/integration/core-tests.js
@@ -70,6 +70,7 @@ describe('Control', function() {
   it('should have redirected to default page "/?page=environments"', async () => {
     const location = await page.evaluate(() => window.location);
     assert.strictEqual(location.search, '?page=environments', 'Could not load home page of AliECS GUI');
+    await page.waitForTimeout(4000);
   });
 
   require('./create-new-environment');

--- a/Control/test/integration/core-tests.js
+++ b/Control/test/integration/core-tests.js
@@ -28,7 +28,7 @@ describe('Control', function() {
 
   before(async () => {
     // Start browser to test UI
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: true});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'], headless: 'new'});
     page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 770});
     exports.page = page;

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -32,7 +32,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
   it('should successfully load newEnvironment page', async () => {
     await page.goto(url + '?page=newEnvironmentAdvanced', {waitUntil: 'networkidle0'});
     const location = await page.evaluate(() => window.location);
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(2000);
     assert.strictEqual(location.search, '?page=newEnvironmentAdvanced');
   });
 

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -84,7 +84,12 @@ describe('`pageNewEnvironment` test-suite', async () => {
     await page.screenshot({
       path: 'lock-selection.png',
     });
-    await page.waitForSelector('#detectorLockButtonForTST', {timeout: 2000});
+    const detectors = await page.evaluate(() => JSON.stringify(window.model.lock.padlockState));
+    const activeDetectors = await page.evaluate(() => JSON.stringify(window.model.workflow.flpSelection.activeDetectors));
+    console.log('Detectors are:' , detectors);
+    console.log('Active Detectors are:' , activeDetectors);
+    
+    await page.waitForSelector('#detectorLockButtonForTST', {timeout: 6000});
     await page.evaluate(() => document.querySelector('#detectorLockButtonForTST').click());
     await page.waitForTimeout(1000);
     await page.waitForSelector('#detectorSelectionButtonForTST', {timeout: 2000});

--- a/Control/test/integration/create-new-environment.js
+++ b/Control/test/integration/create-new-environment.js
@@ -77,12 +77,18 @@ describe('`pageNewEnvironment` test-suite', async () => {
       }
     }
     await page.evaluate(() => window.model.workflow.form.variables);
+    await page.waitForTimeout(2000);
   });
 
   it('should have successfully lock and select detector from area list', async () => {
-    await page.evaluate(() => document.querySelector('.m1 > div:nth-child(1) > div > div').click());
+    await page.screenshot({
+      path: 'lock-selection.png',
+    });
+    await page.waitForSelector('#detectorLockButtonForTST', {timeout: 2000});
+    await page.evaluate(() => document.querySelector('#detectorLockButtonForTST').click());
     await page.waitForTimeout(1000);
-    await page.evaluate(() => document.querySelector('.m1 > div:nth-child(1) > div > a:nth-child(2)').click());
+    await page.waitForSelector('#detectorSelectionButtonForTST', {timeout: 2000});
+    await page.evaluate(() => document.querySelector('#detectorSelectionButtonForTST').click());
     await page.waitForTimeout(1000);
     const selectedDet = await page.evaluate(() => window.model.workflow.flpSelection.selectedDetectors);
     assert.deepStrictEqual(selectedDet, ['TST'], 'Missing detector selection');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* splits the "Select All" button in 2 new buttons:
  * "LockAll" - lock all available detectors. Depending on page source, it will not lock TST one
  * "Select All" - select all available detectors for which the user has the lock and detector is not already active