### PR TITLE
[improv] Remove call to deprecated method

### DIFF
--- a/Control/test/config/apricot-grpc.js
+++ b/Control/test/config/apricot-grpc.js
@@ -55,10 +55,7 @@ const apricotGRPCServer = (config) => {
     if (error) {
       console.error(error);
       throw error;
-    } else {
-      server.start();
     }
-
   };
   server.bindAsync(address, credentials, bindCallback);
   return {server, calls};

--- a/Control/test/config/core-grpc.js
+++ b/Control/test/config/core-grpc.js
@@ -107,10 +107,7 @@ const coreGRPCServer = (config) => {
     if (error) {
       console.error(error);
       throw error;
-    } else {
-      server.start();
     }
-
   };
   server.bindAsync(address, credentials, bindCallback);
   return {server, calls};


### PR DESCRIPTION
PR which:
* removes call to grpc-js server `start()` as it is deprecated and no longer needed