### PR TITLE
[OGUI-1524] Add task filtering in their respective tables

### DIFF
--- a/Control/public/common/task/epnTasksTable.js
+++ b/Control/public/common/task/epnTasksTable.js
@@ -21,7 +21,7 @@ import { getTaskStateClassAssociation } from '../enums/TaskState.js';
  * @return {vnode} table of the EPN tasks
  */
 export const epnTasksTable = (tasks = []) => {
-  const tableColumns = ['ID', 'Path', 'Ignored', 'State'];
+  const tableColumns = ['Path', 'ID', 'Ignored', 'State'];
 
   return h('table.table.table-sm', { style: 'margin-bottom: 0' }, [
     h('thead',
@@ -32,8 +32,8 @@ export const epnTasksTable = (tasks = []) => {
     h('tbody', [
       tasks.map(({ taskId, path, ignored, state }) =>
         h('tr', [
-          h('td.w-30', taskId),
           h('td.w-50', path),
+          h('td.w-30', taskId),
           h('td.w-10', ignored + ''),
           h(`td.w-10${getTaskStateClassAssociation(state)}`, state),
         ])

--- a/Control/public/task/Task.js
+++ b/Control/public/task/Task.js
@@ -37,8 +37,6 @@ export default class Task extends Observable {
 
     this.detectorPanels = RemoteData.notAsked(); // JSON containing information on detectors panels; isOpened, list of hosts
 
-    this._filterBy = new RegExp();
-
     this.taskTableModel = new TaskTableModel(model);
     this.taskTableModel.bubbleTo(this);
   }
@@ -168,21 +166,5 @@ export default class Task extends Observable {
   areTasksInDetector(data) {
     return Object.keys(data)
       .some((host) => data[host] && data[host].list && data[host].stdout && data[host].list.length > 0);
-  }
-
-  /**
-   * Given a string, create a regex which will be used Muto filter tasks by their name
-   * @param {String} filterBy
-   */
-  set filterBy(filterBy) {
-    this._filterBy = new RegExp(`.*${filterBy}.*`);
-    this.notify();
-  }  
-
-  /**
-   * Return a built regex for filtering tasks by their name
-   */
-  get filterBy() {
-    return this._filterBy;
   }
 }

--- a/Control/public/task/content.js
+++ b/Control/public/task/content.js
@@ -20,6 +20,7 @@ import {iconCircleX, iconCircleCheck} from '/js/src/icons.js';
 import {ROLES} from './../workflow/constants.js';
 import {isUserAllowedRole} from './../common/userRole.js';
 import {tasksPerHostPanel} from '../common/task/tasksPerHostPanel.js';
+import { HardwareComponent } from '../common/enums/HardwareComponent.js';
 
 /**
  * @file Content of the Task Page that displays list of tasks grouped by their host and detector
@@ -161,9 +162,14 @@ const toggleDetectorPanel = (model, taskPanel) =>
  * @return {vnode} - table with tasks details
  */
 const tasksTables = (taskTableModel, tasksByHost) => {
+  console.log(tasksByHost)
   return Object.keys(tasksByHost)
     .filter((hostname) => tasksByHost[hostname] && tasksByHost[hostname].list && tasksByHost[hostname].stdout)
-    .map((hostname) => tasksPerHostPanel({ taskTableModel }, { tasks: tasksByHost[hostname].list }, 'FLP'));
+    .map((hostname) => tasksPerHostPanel(
+      { taskTableModel },
+      { tasks: tasksByHost[hostname].list },
+      HardwareComponent.FLP)
+    );
 };
 
 /**

--- a/Control/public/task/content.js
+++ b/Control/public/task/content.js
@@ -104,20 +104,6 @@ const showContent = (model, items) => {
 };
 
 /**
- * Adds a search bar for the user to filter tasks by name
- * @param {Object} model 
- * @returns 
- */
-const searchTasks = (model) =>
-  h('.w-50',
-    h('input.form-control', {
-      id: 'searchTasksInput',
-      placeholder: 'Search tasks by name',
-      oninput: (e) => model.task.filterBy = e.target.value
-    })
-  );
-
-/**
  * Build a list of panels per detector with hosts and their respective tasks
  * @param {Object} model
  * @param {Map<String, JSON} detectors

--- a/Control/public/task/content.js
+++ b/Control/public/task/content.js
@@ -93,7 +93,6 @@ const showContent = (model, items) => {
   const isAdmin =  model.detectors.selected === 'GLOBAL' && isUserAllowedRole(ROLES.Admin, true);
   return h('.text-left.ph2', [
     h('.w-100.flex-row.pv2.items-center', [
-      searchTasks(model),
       isAdmin && h('.w-100.flex-row.flex-end.pv2.g2', [
         cleanResourcesButton(model.task),
         cleanTasksButton(model.task)

--- a/Control/test/public/page-tasks-mocha.js
+++ b/Control/test/public/page-tasks-mocha.js
@@ -44,10 +44,4 @@ describe('`pageTaskList` test-suite', async () => {
 
     assert.strictEqual(placeholder, 'Search tasks by name');
   });
-
-  it('should successfully update filter regex based on user\'s input', async() => {
-    await page.type('input[id=searchTasksInput]', 'task-x', {delay: 20})
-    const filterBy = await page.evaluate(() => window.model.task.filterBy.toString());
-    assert.strictEqual(filterBy, '/.*task-x.*/')
-  });
 });

--- a/Control/test/public/page-tasks-mocha.js
+++ b/Control/test/public/page-tasks-mocha.js
@@ -38,10 +38,4 @@ describe('`pageTaskList` test-suite', async () => {
     assert.strictEqual(calls['getTasks'], true);
     assert.strictEqual(location.search, '?page=taskList');
   });
-
-  it('should successfully add an input panel for searching tasks by name', async() => {
-    const placeholder = await page.evaluate(() => document.querySelector('body > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div > div > input').placeholder);
-
-    assert.strictEqual(placeholder, 'Search tasks by name');
-  });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds button which allow users to filter tasks by their state
* adds input search box to allow users to filter tasks by their name (FLP) / path (EPN)
* removes old filtering from tasks page