### PR TITLE
[OGUI-1408] Allow clicking on task summary table counter which will  filter task tables

### DIFF
--- a/Control/public/common/task/TaskTableModel.js
+++ b/Control/public/common/task/TaskTableModel.js
@@ -62,6 +62,17 @@ export class TaskTableModel extends Observable {
   }
 
   /**
+   * Sets the filter state to a specified state
+   * @param {TaskState} state - state to set the filter to
+   */
+  setFilterState(state) {
+    if (TASK_STATES.includes(state)) {
+      this._filterBy.state = [state];
+      this.notify();
+    }
+  }
+
+  /**
    * Given a user input value, filters the tasks by name
    * @param {string} name - name to filter by
    */

--- a/Control/public/common/utils.js
+++ b/Control/public/common/utils.js
@@ -92,7 +92,7 @@ const getTasksByEpn = (tasks) => {
  */
 const getTaskShortName = (taskName) => {
   const regex = new RegExp(`tasks/.*@`);
-  const matchedTaskName = taskName.match(regex);
+  const matchedTaskName = taskName?.match(regex);
   if (matchedTaskName) {
     taskName = matchedTaskName[0].replace('tasks/', '').replace('@', '');
   }

--- a/Control/public/pages/Environment/Environment.page.js
+++ b/Control/public/pages/Environment/Environment.page.js
@@ -55,14 +55,22 @@ export const EnvironmentPageContent = (model) => h('.scroll-y.absolute-fill', [
 const showEnvironmentPage = (model, environmentInfo) => {
   const {state, currentTransition = undefined} = environmentInfo;
   const isRunningStable = !currentTransition && state === EnvironmentState.RUNNING;
-  const {services: {detectors: {availability = {}} = {}}} = model;
+  const { services: { detectors: { availability = {} } = {} } } = model;
+
+  const onRowClick = async (component, state) => {
+    model.router.go(`?page=environment&id=${environmentInfo.id}&panel=${component}`, true, true);
+    model.environment.taskTableModel.setFilterState(state);
+    
+    document.getElementById('environment-tabs-navigation-header').scrollIntoView({ behavior: 'auto', block: 'center' });
+    await model.environment.getEnvironment({ id: environmentInfo.id }, false, component);
+  }
 
   return h('.w-100.p1.g2.flex-column', [
     environmentStateSummary(environmentInfo),
     environmentActionPanel(model, environmentInfo),
     isRunningStable && monitoringRunningPlotsPanel(environmentInfo),
     h('.flex-row.g2.z-index-one', [
-      environmentTasksSummaryTable(environmentInfo, availability),
+      environmentTasksSummaryTable(environmentInfo, availability, onRowClick),
     ]),
     environmentNavigationTabs(model, environmentInfo),
   ]);

--- a/Control/public/pages/Environment/Environment.page.js
+++ b/Control/public/pages/Environment/Environment.page.js
@@ -57,6 +57,12 @@ const showEnvironmentPage = (model, environmentInfo) => {
   const isRunningStable = !currentTransition && state === EnvironmentState.RUNNING;
   const { services: { detectors: { availability = {} } = {} } } = model;
 
+  /**
+   * Given a component and a state, navigate silently to the environment page with the component as the panel
+   * @param {HardwareComponent} component - component to navigate to
+   * @param {TaskState} state - state to filter by
+   * @return {Promise<void>} - promise to navigate to the page
+   */
   const onRowClick = async (component, state) => {
     model.router.go(`?page=environment&id=${environmentInfo.id}&panel=${component}`, true, true);
     model.environment.taskTableModel.setFilterState(state);

--- a/Control/public/pages/Environment/components/environmentNavigationTabs.js
+++ b/Control/public/pages/Environment/components/environmentNavigationTabs.js
@@ -83,7 +83,9 @@ export const environmentNavigationTabs = (model, item) => {
           );
         }),
     ]),
-    h('.tab-content', Object.entries(panels)
+    h('.tab-content', {
+      id: 'environment-tabs-navigation-header'
+    }, Object.entries(panels)
       .filter(([id]) => parameters.panel === id)
       .map(([id, {content}]) =>  h(`.tab-panel.active`, {id: `${id}-pane`}, content(model.environment, item, id)))
     )

--- a/Control/public/pages/Environment/components/environmentTasksSummaryTable.js
+++ b/Control/public/pages/Environment/components/environmentTasksSummaryTable.js
@@ -100,9 +100,8 @@ const rowForTaskSate = (state, hardware, onRowClick) => {
             );
         } else {
           return h(`td.text-center${taskClass}.actionable-icon`, {
-              onclick: () => onRowClick && onRowClick(componentInLowerCase, state),
-            },
-            hardware[componentInLowerCase].tasks.states[state] ?? '-');
+            onclick: () => onRowClick && onRowClick(componentInLowerCase, state),
+          }, hardware[componentInLowerCase].tasks.states[state] ?? '-');
         }
       })
   ]);

--- a/Control/public/task/content.js
+++ b/Control/public/task/content.js
@@ -147,7 +147,6 @@ const toggleDetectorPanel = (model, taskPanel) =>
  * @return {vnode} - table with tasks details
  */
 const tasksTables = (taskTableModel, tasksByHost) => {
-  console.log(tasksByHost)
   return Object.keys(tasksByHost)
     .filter((hostname) => tasksByHost[hostname] && tasksByHost[hostname].list && tasksByHost[hostname].stdout)
     .map((hostname) => tasksPerHostPanel(


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* allows users to click on a counter from the Task Summary table which will redirect them to the panel of the task and apply the state filter