### PR TITLE
Add new eslint dependency to dev-deps group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,11 @@ updates:
   groups:
     dev-dependencies:
       patterns:
-        # - "eslint"
+        - "eslint"
+        - "@eslint/js"
+        - "@stylistic/eslint-plugin-js"
+        - "eslint-plugin-jsdoc"
+        - "globals"
         - "mocha"
         - "nock"
         - "nyc"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,7 +68,11 @@ updates:
   groups:
     dev-dependencies:
       patterns:
-        # - "eslint"
+        - "eslint"
+        - "@eslint/js"
+        - "@stylistic/eslint-plugin-js"
+        - "eslint-plugin-jsdoc"
+        - "globals"
         - "mocha"
         - "nock"
         - "nyc"
@@ -93,7 +97,11 @@ updates:
   groups:
     dev-dependencies:
       patterns:
-        # - "eslint"
+        - "eslint"
+        - "@eslint/js"
+        - "@stylistic/eslint-plugin-js"
+        - "eslint-plugin-jsdoc"
+        - "globals"
         - "mocha"
         - "nock"
         - "nyc"


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [NA] test are added
- [NA] documentation is changed or added
- [NA] FLP integration tests were ran successful

PR which:
* adds back eslint and its new dependencies to the dependabot group `dev-dependency` so that they are all bumped into one PR