### PR TITLE
[OGUI-1570] Update QC GH workflows to run lint first and only after coverage and tests

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -34,7 +34,7 @@ jobs:
       - run: (cd QualityControl; npm ci )
       - run: (cd QualityControl; npm run test )
   coverage:
-    name: Tests on ubuntu-latest
+    name: Tests and generate lcov reoprt coverage on ubuntu-latest
     runs-on: ubuntu-latest
     needs: lint-check
     steps:

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -10,8 +10,8 @@ on:
       - 'dev'
 
 jobs:
-  test:
-    name: Tests on ubuntu-latest
+  lint-check:
+    name: Check eslint rules on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,21 +20,34 @@ jobs:
         with:
           node-version: '20.x'
       - run: (cd QualityControl; npm ci )
-      - run: (cd QualityControl; npm run coverage )
+      - run: (cd QualityControl; npm run lint )
+  test:
+    name: Tests on ubuntu-latest only if lint-check passes
+    runs-on: ubuntu-latest
+    needs: lint-check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: (cd QualityControl; npm ci )
+      - run: (cd QualityControl; npm run test )
+  coverage:
+    name: Tests on ubuntu-latest
+    runs-on: ubuntu-latest
+    needs: lint-check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: (cd QualityControl; npm ci )
+      - run: (cd QualityControl; npm run coverage-lcov )
       - name: Send codecov report for QualityControl
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: qualitycontrol
           fail_ci_if_error: true
-  #coverage:  Job is currently disabled due to known issue with node-gyp on GH runners
-  #  name: Tests & coverage on macOS-latest
-  #  runs-on: macOS-latest
-  #  steps:
-  #    - uses: actions/checkout@v4
-  #    - name: Setup node
-  #      uses: actions/setup-node@v4
-  #      with:
-  #        node-version: '20.x'
-  #    - run: (cd QualityControl; npm ci )
-  #    - run: (cd QualityControl; npm run test)

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -20,10 +20,10 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon --watch index.js --watch lib --watch config.js index.js",
-    "eslint": "./node_modules/.bin/eslint --config eslint.config.js lib public",
-    "coverage": "npm run test && node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage.lcov test/test-index.js",
-    "node-test": "node --test test/test-index.js",
-    "test": "npm run eslint && npm run node-test"
+    "lint": "./node_modules/.bin/eslint --config eslint.config.js lib public",
+    "coverage-lcov": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage.lcov test/test-index.js",
+    "coverage-local": "node --test --experimental-test-coverage --test-reporter=spec test/test-index.js",
+    "test": "node --test test/test-index.js"
   },
   "files": [
     "common/",


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* splits the run of lint and test together
* splits the test command and coverage as it was by mistake running the tests twice
* ensures first `lint-check` is ran and passes. Only after, the test and coverage jobs are triggered. This will ensure less resources are used by GH Actions if lint fails