### PR TITLE
[OGUI-1572] Display actions for all locks only for global and above

### DIFF
--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.74.0",
+      "version": "1.74.1",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/lock/lockPage.js
+++ b/Control/public/lock/lockPage.js
@@ -60,11 +60,9 @@ export const content = (model) => {
         Failure: (error) => errorPage(error),
         Success: (detectorsLocksState) => h('.flex-column', [
           h('.flex-row.g2.pv2', [
-            isUserAllowedRole(ROLES.Admin) && [
+            isUserAllowedRole(ROLES.Global) && [
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.RELEASE, true, 'Force Release ALL'),
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.TAKE, true, 'Force Take ALL'),
-            ],
-            isUserAllowedRole(ROLES.Detector) && [
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.RELEASE, false, 'Release ALL*'),
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.TAKE, false, 'Take ALL*'),
             ],


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* ensures buttons for ALL actions on lock are not displayed if user is not Global or above