### PR TITLE
[OGUI-1596] Update grpcErrorToNativeError to provide option for developer to use either message or details

### DIFF
--- a/Framework/Backend/errors/grpcErrorCodes.enum.js
+++ b/Framework/Backend/errors/grpcErrorCodes.enum.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const GrpcErrorCodes = Object.freeze({
+  UNKNOWN: 2,
+  INVALID_INPUT: 3,
+  TIMEOUT: 4,
+  NOT_FOUND: 5,
+  UNAUTHORIZED_ACCESS: 7,
+  SERVICE_UNAVAILABLE: 14,
+});
+
+exports.GrpcErrorCodes = GrpcErrorCodes;

--- a/Framework/Backend/errors/grpcErrorToNativeError.js
+++ b/Framework/Backend/errors/grpcErrorToNativeError.js
@@ -16,14 +16,15 @@ const { NotFoundError } = require('./NotFoundError.js');
 const { ServiceUnavailableError } = require('./ServiceUnavailableError.js');
 const { TimeoutError } = require('./TimeoutError.js');
 const { UnauthorizedAccessError } = require('./UnauthorizedAccessError.js');
+const { GrpcErrorCodes } = require('./grpcErrorCodes.enum.js');
 
 /**
  * @typedef GrpcError
  * also known as gRPC Status Object https://grpc.github.io/grpc/node/grpc.html#~StatusObject
  *
- * @property {number} code - code of the gRPC Status object
- * @property {string} message - message of the gRPC Status object / includes code as well in the string
+ * @property {GrpcErrorCodes} code - code of the gRPC Status object
  * @property {string} details - details of the gRPC Status object
+ * @property {string} message - message of the gRPC Status object
  */
 
 /**
@@ -38,15 +39,15 @@ const grpcErrorToNativeError = (error, includeStatusCode = false) => {
   const { code, details, message } = error;
 
   switch (code) {
-    case 3:
+    case GrpcErrorCodes.INVALID_INPUT:
       return new InvalidInputError(includeStatusCode ? message : details);
-    case 4:
+    case GrpcErrorCodes.TIMEOUT:
       return new TimeoutError(includeStatusCode ? message : details);
-    case 5:
+    case GrpcErrorCodes.NOT_FOUND:
       return new NotFoundError(includeStatusCode ? message : details);
-    case 7:
+    case GrpcErrorCodes.UNAUTHORIZED_ACCESS:
       return new UnauthorizedAccessError(includeStatusCode ? message : details);
-    case 14:
+    case GrpcErrorCodes.SERVICE_UNAVAILABLE:
       return new ServiceUnavailableError(includeStatusCode ? message : details);
     default:
       return new Error(includeStatusCode ? message : details);

--- a/Framework/Backend/errors/grpcErrorToNativeError.js
+++ b/Framework/Backend/errors/grpcErrorToNativeError.js
@@ -31,24 +31,25 @@ const { UnauthorizedAccessError } = require('./UnauthorizedAccessError.js');
  * Code List source: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
  *
  * @param {GrpcError} error - error object from gRPC Client library
+ * @param {Boolean} includeStatusCode - whether to error message field or details field
  * @returns {Error}
  */
-const grpcErrorToNativeError = (error) => {
-  const { code, details } = error;
+const grpcErrorToNativeError = (error, includeStatusCode = false) => {
+  const { code, details, message } = error;
 
   switch (code) {
     case 3:
-      return new InvalidInputError(details);
+      return new InvalidInputError(includeStatusCode ? message : details);
     case 4:
-      return new TimeoutError(details);
+      return new TimeoutError(includeStatusCode ? message : details);
     case 5:
-      return new NotFoundError(details);
+      return new NotFoundError(includeStatusCode ? message : details);
     case 7:
-      return new UnauthorizedAccessError(details);
+      return new UnauthorizedAccessError(includeStatusCode ? message : details);
     case 14:
-      return new ServiceUnavailableError(details);
+      return new ServiceUnavailableError(includeStatusCode ? message : details);
     default:
-      return new Error(details);
+      return new Error(includeStatusCode ? message : details);
   }
 };
 

--- a/Framework/Backend/errors/grpcErrorToNativeError.js
+++ b/Framework/Backend/errors/grpcErrorToNativeError.js
@@ -19,10 +19,11 @@ const { UnauthorizedAccessError } = require('./UnauthorizedAccessError.js');
 
 /**
  * @typedef GrpcError
- * also known as gRPC Status Object
+ * also known as gRPC Status Object https://grpc.github.io/grpc/node/grpc.html#~StatusObject
  *
  * @property {number} code - code of the gRPC Status object
- * @property {string} message - message of the gRPC Status object
+ * @property {string} message - message of the gRPC Status object / includes code as well in the string
+ * @property {string} details - details of the gRPC Status object
  */
 
 /**
@@ -33,21 +34,21 @@ const { UnauthorizedAccessError } = require('./UnauthorizedAccessError.js');
  * @returns {Error}
  */
 const grpcErrorToNativeError = (error) => {
-  const { code, message } = error;
+  const { code, details } = error;
 
   switch (code) {
     case 3:
-      return new InvalidInputError(message);
+      return new InvalidInputError(details);
     case 4:
-      return new TimeoutError(message);
+      return new TimeoutError(details);
     case 5:
-      return new NotFoundError(message);
+      return new NotFoundError(details);
     case 7:
-      return new UnauthorizedAccessError(message);
+      return new UnauthorizedAccessError(details);
     case 14:
-      return new ServiceUnavailableError(message);
+      return new ServiceUnavailableError(details);
     default:
-      return new Error(message);
+      return new Error(details);
   }
 };
 

--- a/Framework/Backend/index.js
+++ b/Framework/Backend/index.js
@@ -33,6 +33,7 @@ const { ServiceUnavailableError } = require('./errors/ServiceUnavailableError.js
 const { TimeoutError } = require('./errors/TimeoutError.js');
 const { UnauthorizedAccessError } = require('./errors/UnauthorizedAccessError.js');
 const { grpcErrorToNativeError } = require('./errors/grpcErrorToNativeError.js');
+const { GrpcErrorCodes } = require('./errors/grpcErrorCodes.enum.js');
 const {
   updateAndSendExpressResponseFromNativeError,
 } = require('./errors/updateAndSendExpressResponseFromNativeError.js');
@@ -78,6 +79,8 @@ exports.ServiceUnavailableError = ServiceUnavailableError;
 exports.TimeoutError = TimeoutError;
 
 exports.UnauthorizedAccessError = UnauthorizedAccessError;
+
+exports.GrpcErrorCodes = GrpcErrorCodes;
 
 exports.grpcErrorToNativeError = grpcErrorToNativeError;
 

--- a/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
+++ b/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
@@ -23,15 +23,64 @@ const assert = require('assert');
 
 describe('\'grpcErrorToNativeError\' test suite', () => {
   it('should successfully convert gRPC errors to native errors', () => {
-    assert.deepStrictEqual(grpcErrorToNativeError({ code: 3, message: 'invalid' }), new InvalidInputError('invalid'));
-    assert.deepStrictEqual(grpcErrorToNativeError({ code: 4, message: 'timeout' }), new TimeoutError('timeout'));
-    assert.deepStrictEqual(grpcErrorToNativeError({ code: 5, message: 'not-found' }), new NotFoundError('not-found'));
-    assert.deepStrictEqual(grpcErrorToNativeError({ code: 7, message: 'unauthorized' }), new UnauthorizedAccessError('unauthorized'));
     assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 14, message: 'service-unavailable' }),
+      grpcErrorToNativeError({ code: 3, message: '3: invalid', details: 'invalid' }),
+      new InvalidInputError('invalid'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 4, message: '4: timeout', details: 'timeout' }),
+      new TimeoutError('timeout'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 5, message: '5: not-found', details: 'not-found' }),
+      new NotFoundError('not-found'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 7, message: 'unauthorized', details: 'unauthorized' }),
+      new UnauthorizedAccessError('unauthorized'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 14, message: 'service-unavailable', details: 'service-unavailable' }),
       new ServiceUnavailableError('service-unavailable'),
     );
-    assert.deepStrictEqual(grpcErrorToNativeError({ code: 100, message: 'standard-error' }), new Error('standard-error'));
-    assert.deepStrictEqual(grpcErrorToNativeError({ message: 'standard-error' }), new Error('standard-error'));
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 100, message: 'standard-error', details: 'standard-error' }),
+      new Error('standard-error'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ message: 'standard-error', details: 'standard-error' }),
+      new Error('standard-error'),
+    );
+  });
+
+  it('should successfully convert gRPC errors to native errors', () => {
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 3, message: '3: invalid', details: 'invalid' }, true),
+      new InvalidInputError('3: invalid'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 4, message: '4: timeout', details: 'timeout' }, true),
+      new TimeoutError('4: timeout'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 5, message: '5: not-found', details: 'not-found' }, true),
+      new NotFoundError('5: not-found'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 7, message: '7: unauthorized', details: 'unauthorized' }, true),
+      new UnauthorizedAccessError('7: unauthorized'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 14, message: '14: service-unavailable', details: 'service-unavailable' }, true),
+      new ServiceUnavailableError('14: service-unavailable'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ code: 100, message: '100: standard-error', details: 'standard-error' }, true),
+      new Error('100: standard-error'),
+    );
+    assert.deepStrictEqual(
+      grpcErrorToNativeError({ message: 'code: standard-error', details: 'standard-error' }, true),
+      new Error('code: standard-error'),
+    );
   });
 });

--- a/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
+++ b/Framework/Backend/test/errors/mocha-grpcErrorToNativeError.js
@@ -12,75 +12,81 @@
  * or submit itself to any jurisdiction.
  */
 
+const assert = require('assert');
+
 const { grpcErrorToNativeError } = require('../../errors/grpcErrorToNativeError.js');
+const { GrpcErrorCodes: {
+  INVALID_INPUT, TIMEOUT, NOT_FOUND, UNAUTHORIZED_ACCESS, SERVICE_UNAVAILABLE, UNKNOWN,
+} } = require('../../errors/grpcErrorCodes.enum.js');
 const { InvalidInputError } = require('../../errors/InvalidInputError.js');
 const { NotFoundError } = require('../../errors/NotFoundError.js');
 const { ServiceUnavailableError } = require('../../errors/ServiceUnavailableError.js');
 const { TimeoutError } = require('../../errors/TimeoutError.js');
 const { UnauthorizedAccessError } = require('../../errors/UnauthorizedAccessError.js');
 
-const assert = require('assert');
-
 describe('\'grpcErrorToNativeError\' test suite', () => {
-  it('should successfully convert gRPC errors to native errors', () => {
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 3, message: '3: invalid', details: 'invalid' }),
-      new InvalidInputError('invalid'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 4, message: '4: timeout', details: 'timeout' }),
-      new TimeoutError('timeout'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 5, message: '5: not-found', details: 'not-found' }),
-      new NotFoundError('not-found'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 7, message: 'unauthorized', details: 'unauthorized' }),
-      new UnauthorizedAccessError('unauthorized'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 14, message: 'service-unavailable', details: 'service-unavailable' }),
-      new ServiceUnavailableError('service-unavailable'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 100, message: 'standard-error', details: 'standard-error' }),
-      new Error('standard-error'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ message: 'standard-error', details: 'standard-error' }),
-      new Error('standard-error'),
-    );
+  const testCases = [
+    {
+      grpcError: { code: UNKNOWN, message: `${UNKNOWN}: Error is unknown`, details: 'Error is unknown' },
+      expectedError: Error,
+      expectedMessage: `${UNKNOWN}: Error is unknown`,
+      expectedDetails: 'Error is unknown',
+    },
+    {
+      grpcError: { code: INVALID_INPUT, message: `${INVALID_INPUT}: Invalid input details`, details: 'Invalid input details' },
+      expectedError: InvalidInputError,
+      expectedMessage: `${INVALID_INPUT}: Invalid input details`,
+      expectedDetails: 'Invalid input details',
+    },
+    {
+      grpcError: { code: TIMEOUT, message: `${TIMEOUT}: Timeout occurred`, details: 'Timeout occurred' },
+      expectedError: TimeoutError,
+      expectedMessage: `${TIMEOUT}: Timeout occurred`,
+      expectedDetails: 'Timeout occurred',
+    },
+    {
+      grpcError: { code: NOT_FOUND, message: `${NOT_FOUND}: Not found`, details: 'Not found' },
+      expectedError: NotFoundError,
+      expectedMessage: `${NOT_FOUND}: Not found`,
+      expectedDetails: 'Not found',
+    },
+    {
+      grpcError: { code: UNAUTHORIZED_ACCESS, message: `${UNAUTHORIZED_ACCESS}: Unauthorized access`, details: 'Unauthorized access details' },
+      expectedError: UnauthorizedAccessError,
+      expectedMessage: `${UNAUTHORIZED_ACCESS}: Unauthorized access`,
+      expectedDetails: 'Unauthorized access details',
+    },
+    {
+      grpcError: { code: SERVICE_UNAVAILABLE, message: `${SERVICE_UNAVAILABLE}: Service unavailable`, details: 'Service unavailable details' },
+      expectedError: ServiceUnavailableError,
+      expectedMessage: `${SERVICE_UNAVAILABLE}: Service unavailable`,
+      expectedDetails: 'Service unavailable details',
+    },
+    {
+      grpcError: { code: 100, message: '100: Unknown Code and Error', details: 'Unknown Code and Error' },
+      expectedError: Error,
+      expectedMessage: '100: Unknown Code and Error',
+      expectedDetails: 'Unknown Code and Error',
+    },
+  ];
+
+  testCases.forEach(({ grpcError: { code, details }, expectedError, expectedDetails }) => {
+    it(`should convert gRPC error with code ${code} and pass DETAILS in error of type ${expectedError}`, () => {
+      assert.deepStrictEqual(grpcErrorToNativeError({ code, details }), new expectedError(expectedDetails));
+    });
   });
 
-  it('should successfully convert gRPC errors to native errors', () => {
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 3, message: '3: invalid', details: 'invalid' }, true),
-      new InvalidInputError('3: invalid'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 4, message: '4: timeout', details: 'timeout' }, true),
-      new TimeoutError('4: timeout'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 5, message: '5: not-found', details: 'not-found' }, true),
-      new NotFoundError('5: not-found'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 7, message: '7: unauthorized', details: 'unauthorized' }, true),
-      new UnauthorizedAccessError('7: unauthorized'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 14, message: '14: service-unavailable', details: 'service-unavailable' }, true),
-      new ServiceUnavailableError('14: service-unavailable'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ code: 100, message: '100: standard-error', details: 'standard-error' }, true),
-      new Error('100: standard-error'),
-    );
-    assert.deepStrictEqual(
-      grpcErrorToNativeError({ message: 'code: standard-error', details: 'standard-error' }, true),
-      new Error('code: standard-error'),
-    );
+  testCases.forEach(({ grpcError: { code, message }, expectedError, expectedMessage }) => {
+    it(`should convert gRPC error with code ${code} and pass MESSAGE in error of type ${expectedError.name}`, () => {
+      assert.deepStrictEqual(grpcErrorToNativeError({ code, message }, true), new expectedError(expectedMessage));
+    });
+  });
+
+  it('should handle gRPC error with unknown code gracefully', () => {
+    assert.deepStrictEqual(grpcErrorToNativeError({ code: 999, details: 'unknown-error' }), new Error('unknown-error'));
+  });
+
+  it('should handle gRPC error without message gracefully', () => {
+    assert.deepStrictEqual(grpcErrorToNativeError({ code: 3 }), new InvalidInputError(''));
   });
 });


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is new feature explain how plan to use it
- [x] test are added
- [x] documentation is changed or added
- [x] FLP integration tests were ran successful

PR which:
* allows usage of either `details` or `message` for the custom error class
* this is due to the fact that the `message` includes also the error key and code which is not needed as the custom error class already describes that but it might be useful to developers