### PR TITLE
[OGUI-1565] Display infologger link to each task in env-details

### DIFF
--- a/Control/public/common/buttons/infoLoggerRedirectButton.js
+++ b/Control/public/common/buttons/infoLoggerRedirectButton.js
@@ -51,7 +51,7 @@ export const infoLoggerButtonLink = (
     if (facility) {
       href += `"facility":{"match":"${facility}"},`;
     }
-    if (pid){
+    if (pid) {
       href += `"pid":{"match":"${pid}"},`;
     }
     if (href.slice(-1) === ',') { // remove trailing comma

--- a/Control/public/common/buttons/infoLoggerRedirectButton.js
+++ b/Control/public/common/buttons/infoLoggerRedirectButton.js
@@ -29,7 +29,7 @@ import { redirectButtonLink } from './redirectButtonLink.js';
  * @returns {vnode} - button as link allowing user to open InfoLogger in a new tab
  */
 export const infoLoggerButtonLink = (
-  { partition, run, hostname, system, facility },
+  { partition, run, hostname, system, facility, pid },
   label = 'InfoLogger',
   source = ''
 ) => {
@@ -49,6 +49,9 @@ export const infoLoggerButtonLink = (
     }
     if (facility) {
       href += `"facility":{"match":"${facility}"},`;
+    }
+    if(pid){
+      href += `"pid":{"match":"${pid}"},`;
     }
     if (href.slice(-1) === ',') { // remove trailing comma
       href = href.slice(0, -1);

--- a/Control/public/common/buttons/infoLoggerRedirectButton.js
+++ b/Control/public/common/buttons/infoLoggerRedirectButton.js
@@ -59,7 +59,7 @@ export const infoLoggerButtonLink = (
     }
     href += '}';
     let title = `Open InfoLogger GUI`;
-    const classList = ['ph2', 'btn', 'primary', 'w-100', ...className]
+    const classList = ['ph2', 'btn', 'primary', 'w-100', ...className];
     return redirectButtonLink(href, label, title, true, classList);
   }
   return;

--- a/Control/public/common/buttons/infoLoggerRedirectButton.js
+++ b/Control/public/common/buttons/infoLoggerRedirectButton.js
@@ -32,7 +32,7 @@ export const infoLoggerButtonLink = (
   { partition, run, hostname, system, facility, pid },
   label = 'InfoLogger',
   source = '',
-  className = ['ph2', 'btn', 'primary', 'w-100']
+  className = []
 ) => {
   if (source) {
     let href = `${source}?q={`;
@@ -51,7 +51,7 @@ export const infoLoggerButtonLink = (
     if (facility) {
       href += `"facility":{"match":"${facility}"},`;
     }
-    if(pid){
+    if (pid){
       href += `"pid":{"match":"${pid}"},`;
     }
     if (href.slice(-1) === ',') { // remove trailing comma
@@ -59,7 +59,8 @@ export const infoLoggerButtonLink = (
     }
     href += '}';
     let title = `Open InfoLogger GUI`;
-    return redirectButtonLink(href, label, title, true, className);
+    const classList = ['ph2', 'btn', 'primary', 'w-100', ...className]
+    return redirectButtonLink(href, label, title, true, classList);
   }
   return;
 };

--- a/Control/public/common/buttons/infoLoggerRedirectButton.js
+++ b/Control/public/common/buttons/infoLoggerRedirectButton.js
@@ -31,7 +31,8 @@ import { redirectButtonLink } from './redirectButtonLink.js';
 export const infoLoggerButtonLink = (
   { partition, run, hostname, system, facility, pid },
   label = 'InfoLogger',
-  source = ''
+  source = '',
+  className = ['ph2', 'btn', 'primary', 'w-100']
 ) => {
   if (source) {
     let href = `${source}?q={`;
@@ -58,7 +59,7 @@ export const infoLoggerButtonLink = (
     }
     href += '}';
     let title = `Open InfoLogger GUI`;
-    return redirectButtonLink(href, label, title, true, ['ph2', 'btn', 'primary', 'w-100']);
+    return redirectButtonLink(href, label, title, true, className);
   }
   return;
 };

--- a/Control/public/common/showTableItem.js
+++ b/Control/public/common/showTableItem.js
@@ -15,17 +15,43 @@
 import {h} from '/js/src/index.js';
 import {parseObject} from './utils.js';
 
+import { infoLoggerButtonLink } from './buttons/infoLoggerRedirectButton.js';
+
 /**
  * Generic table to show properties of an object
  * This can be forked to show more specific data (format date, colors, more buttons...)
  * @param {Object} item - object to be shown
  * @return {vnode} table view
  */
-export default (item) => h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
-  h('tbody', Object.keys(item).map((columnName) => h('tr', [
-    h('th', columnName),
-    typeof item[columnName] === 'object' ?
-      h('td', parseObject(item[columnName], columnName)) :
-      h('td', item[columnName])
-  ]))),
+export default (item,loggerObject) => h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
+  h('tbody', Object.keys(item).map((columnName) => 
+    h('tr', [
+      h('th', columnName),
+      typeof item[columnName] === 'object' ?
+        h('td', parseObject(item[columnName], columnName)) :
+        h('td', item[columnName]),
+   
+    ]))),
+  h('tr', [
+    h('th', 'InfoLogger'),
+    h('td.p2.flex-row.bg-primary.white', [
+      h('.p2.flex-row.bg-primary.white', [
+        h('.flex-row.flex-grow-1.g2', [
+          
+          infoLoggerButtonLink(
+            { 
+              run: loggerObject.run, 
+              hostname:loggerObject.hostname, 
+              partition:loggerObject.partition,
+              pid: item.pid
+            },
+            'InfoLogger GUI' + ' ' + item.pid,
+            loggerObject.url
+          ),
+         
+        ]),
+      ]),
+      
+    ])
+  ])
 ]);

--- a/Control/public/common/showTableItem.js
+++ b/Control/public/common/showTableItem.js
@@ -15,15 +15,13 @@
 import {h} from '/js/src/index.js';
 import {parseObject} from './utils.js';
 
-import { infoLoggerButtonLink } from './buttons/infoLoggerRedirectButton.js';
-
 /**
  * Generic table to show properties of an object
  * This can be forked to show more specific data (format date, colors, more buttons...)
  * @param {Object} item - object to be shown
  * @return {vnode} table view
  */
-export default (item,loggerObject) => 
+export default (item) => 
   h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
     h('tbody', Object.keys(item).map((columnName) => 
       h('tr', [
@@ -33,26 +31,4 @@ export default (item,loggerObject) =>
           h('td', item[columnName]),
      
       ]))),
-    h('tr', [
-      h('th', 'InfoLogger'),
-      h('td.p2.flex-row.bg-primary.white', [
-        h('.p2.flex-row.bg-primary.white', [
-          h('.flex-row.flex-grow-1.g2', [
-            
-            infoLoggerButtonLink(
-              { 
-                run: loggerObject.run, 
-                hostname:loggerObject.hostname, 
-                partition:loggerObject.partition,
-                pid: loggerObject.pid
-              },
-              'InfoLogger GUI' + ' PID ' + loggerObject.pid,
-              loggerObject.url
-            ),
-           
-          ]),
-        ]),
-        
-      ])
-    ])
   ]);

--- a/Control/public/common/showTableItem.js
+++ b/Control/public/common/showTableItem.js
@@ -21,14 +21,11 @@ import {parseObject} from './utils.js';
  * @param {Object} item - object to be shown
  * @return {vnode} table view
  */
-export default (item) => 
-  h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
-    h('tbody', Object.keys(item).map((columnName) => 
-      h('tr', [
-        h('th', columnName),
-        typeof item[columnName] === 'object' ?
-          h('td', parseObject(item[columnName], columnName)) :
-          h('td', item[columnName]),
-     
-      ]))),
-  ]);
+export default (item) => h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
+  h('tbody', Object.keys(item).map((columnName) => h('tr', [
+    h('th', columnName),
+    typeof item[columnName] === 'object' ?
+      h('td', parseObject(item[columnName], columnName)) :
+      h('td', item[columnName])
+  ]))),
+]);

--- a/Control/public/common/showTableItem.js
+++ b/Control/public/common/showTableItem.js
@@ -23,35 +23,36 @@ import { infoLoggerButtonLink } from './buttons/infoLoggerRedirectButton.js';
  * @param {Object} item - object to be shown
  * @return {vnode} table view
  */
-export default (item,loggerObject) => h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
-  h('tbody', Object.keys(item).map((columnName) => 
+export default (item,loggerObject) => 
+  h('table.table.shadow-level2', {style: 'white-space: pre-wrap;'}, [
+    h('tbody', Object.keys(item).map((columnName) => 
+      h('tr', [
+        h('th', columnName),
+        typeof item[columnName] === 'object' ?
+          h('td', parseObject(item[columnName], columnName)) :
+          h('td', item[columnName]),
+     
+      ]))),
     h('tr', [
-      h('th', columnName),
-      typeof item[columnName] === 'object' ?
-        h('td', parseObject(item[columnName], columnName)) :
-        h('td', item[columnName]),
-   
-    ]))),
-  h('tr', [
-    h('th', 'InfoLogger'),
-    h('td.p2.flex-row.bg-primary.white', [
-      h('.p2.flex-row.bg-primary.white', [
-        h('.flex-row.flex-grow-1.g2', [
-          
-          infoLoggerButtonLink(
-            { 
-              run: loggerObject.run, 
-              hostname:loggerObject.hostname, 
-              partition:loggerObject.partition,
-              pid: item.pid
-            },
-            'InfoLogger GUI' + ' ' + item.pid,
-            loggerObject.url
-          ),
-         
+      h('th', 'InfoLogger'),
+      h('td.p2.flex-row.bg-primary.white', [
+        h('.p2.flex-row.bg-primary.white', [
+          h('.flex-row.flex-grow-1.g2', [
+            
+            infoLoggerButtonLink(
+              { 
+                run: loggerObject.run, 
+                hostname:loggerObject.hostname, 
+                partition:loggerObject.partition,
+                pid: loggerObject.pid
+              },
+              'InfoLogger GUI' + ' PID ' + loggerObject.pid,
+              loggerObject.url
+            ),
+           
+          ]),
         ]),
-      ]),
-      
+        
+      ])
     ])
-  ])
-]);
+  ]);

--- a/Control/public/common/task/flpTasksTable.js
+++ b/Control/public/common/task/flpTasksTable.js
@@ -27,6 +27,7 @@ import { getTaskStateClassAssociation } from '../enums/TaskState.js';
 export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
   const tableColumns = ['Name', 'PID', 'Locked', 'Status', 'State', 'Host Name', 'More'];
 
+ 
   return h('.scroll-auto.panel', [
     h('table.table.table-sm', {style: 'margin-bottom: 0'}, [
       h('thead',
@@ -53,7 +54,10 @@ export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
             ),
           ]),
           taskTableModel.openedTaskViews[task.taskId] && taskTableModel.tasksAsRemoteDataById[task.taskId]
-          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId],loggerObject),
+          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId],{
+            ...loggerObject,
+            pid: task.pid
+          }),
         ]),
       ])
     ])
@@ -74,7 +78,6 @@ const showTaskDetailsTable = (taskRemoteData,loggerObject) => h('tr',
       style: 'font-size: 0.25em; text-align: center;', colspan: 7
     }, pageLoading()),
     Success: (data) => h('td', {colspan: 7}, 
-
       showTableItem(data, loggerObject),
     ),
     Failure: (_error) => h('td.shadow-level3.m5',

--- a/Control/public/common/task/flpTasksTable.js
+++ b/Control/public/common/task/flpTasksTable.js
@@ -59,10 +59,11 @@ export const flpTasksTable = (
                   title: 'More Details',
                   onclick: () => taskTableModel.toggleTaskView(task.taskId),
                 }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom()),
-                infoLoggerButtonLink({
-                  pid: task.pid,
-                  ...logFilterFields
-                },
+                infoLoggerButtonLink(
+                  {
+                    pid: task.pid,
+                    ...logFilterFields
+                  },
                   'ILG',
                   infoLoggerUrl,
                   ['btn-sm'],

--- a/Control/public/common/task/flpTasksTable.js
+++ b/Control/public/common/task/flpTasksTable.js
@@ -24,12 +24,17 @@ import { infoLoggerButtonLink } from '../buttons/infoLoggerRedirectButton.js';
  * For a given list of FLP tasks, build a table with tasks details and buttons to allow for retrieving more details per task
  * @param {Array<Task>} [tasks = []] - list of tasks to build table for
  * @param {TaskTableModel} taskTableModel - task table model to use for features such as filtering and retrieving more details of task
+ * @param {loggerObject} loggerObject - object with information that will help building the InfoLogger link
+ * @param {object} loggerObject.fields - fields to be used in the InfoLogger query
+ * @param {string} loggerObject.url - URL to redirect to Info
  * @return {vnode} - table of the FLP tasks
  */
-export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
+export const flpTasksTable = (
+  tasks,
+  taskTableModel,
+  { fields: logFilterFields, url: infoLoggerUrl }
+) => {
   const tableColumns = ['Name', 'PID', 'Locked', 'Status', 'State', 'Host Name', 'More'];
-
- 
   return h('.scroll-auto.panel', [
     h('table.table.table-sm', {style: 'margin-bottom: 0'}, [
       h('thead',
@@ -48,28 +53,25 @@ export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
             h('td.w-10', task.status),
             h(`td.w-10${getTaskStateClassAssociation(task.state)}`, task.state),
             h('td.w-20', task?.deploymentInfo?.hostname),
-            h('td.w-100.btn-group',
-              h('boutton.btn-sm.btn-default', {
-                title: 'More Details',
-                onclick: () => taskTableModel.toggleTaskView(task.taskId),
-              }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom()),
-              infoLoggerButtonLink(
-                { 
-                  run: loggerObject.run, 
-                  hostname:loggerObject.hostname, 
-                  partition:loggerObject.partition,
-                  pid: loggerObject.pid
+            h('td',
+              h('.flex-row', [
+                h('button.btn-sm.btn-default', {
+                  title: 'More Details',
+                  onclick: () => taskTableModel.toggleTaskView(task.taskId),
+                }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom()),
+                infoLoggerButtonLink({
+                  pid: task.pid,
+                  ...logFilterFields
                 },
-                'ILG',
-                loggerObject.url
-              ),
+                  'ILG',
+                  infoLoggerUrl,
+                  ['btn-sm'],
+                ),
+              ]),
             ),
           ]),
           taskTableModel.openedTaskViews[task.taskId] && taskTableModel.tasksAsRemoteDataById[task.taskId]
-          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId],{
-            ...loggerObject,
-            pid: task.pid
-          }),
+          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId]),
         ]),
       ])
     ])
@@ -82,16 +84,13 @@ export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
  * @param {RemoteData} taskRemoteData - remote data object with task details
  * @return {vnode} - table with task details
  */
-const showTaskDetailsTable = (taskRemoteData,loggerObject) => h('tr',
-    
+const showTaskDetailsTable = (taskRemoteData) => h('tr',
   taskRemoteData.match({
     NotAsked: () => null,
     Loading: () => h('td.shadow-level3.m5', {
       style: 'font-size: 0.25em; text-align: center;', colspan: 7
     }, pageLoading()),
-    Success: (data) => h('td', {colspan: 7}, 
-      showTableItem(data, loggerObject),
-    ),
+    Success: (data) => h('td', {colspan: 7}, showTableItem(data)),
     Failure: (_error) => h('td.shadow-level3.m5',
       {style: 'text-align: center;', colspan: 7, title: 'Could not load arguments'},
       [iconCircleX(), ' ', _error]),

--- a/Control/public/common/task/flpTasksTable.js
+++ b/Control/public/common/task/flpTasksTable.js
@@ -18,6 +18,8 @@ import {
 import pageLoading from '../pageLoading.js';
 import showTableItem from '../showTableItem.js';
 import { getTaskStateClassAssociation } from '../enums/TaskState.js';
+import { infoLoggerButtonLink } from '../buttons/infoLoggerRedirectButton.js';
+
 /**
  * For a given list of FLP tasks, build a table with tasks details and buttons to allow for retrieving more details per task
  * @param {Array<Task>} [tasks = []] - list of tasks to build table for
@@ -46,11 +48,21 @@ export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
             h('td.w-10', task.status),
             h(`td.w-10${getTaskStateClassAssociation(task.state)}`, task.state),
             h('td.w-20', task?.deploymentInfo?.hostname),
-            h('td.w-10',
+            h('td.w-100.btn-group',
               h('boutton.btn-sm.btn-default', {
                 title: 'More Details',
                 onclick: () => taskTableModel.toggleTaskView(task.taskId),
-              }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom())
+              }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom()),
+              infoLoggerButtonLink(
+                { 
+                  run: loggerObject.run, 
+                  hostname:loggerObject.hostname, 
+                  partition:loggerObject.partition,
+                  pid: loggerObject.pid
+                },
+                'ILG',
+                loggerObject.url
+              ),
             ),
           ]),
           taskTableModel.openedTaskViews[task.taskId] && taskTableModel.tasksAsRemoteDataById[task.taskId]

--- a/Control/public/common/task/flpTasksTable.js
+++ b/Control/public/common/task/flpTasksTable.js
@@ -18,14 +18,13 @@ import {
 import pageLoading from '../pageLoading.js';
 import showTableItem from '../showTableItem.js';
 import { getTaskStateClassAssociation } from '../enums/TaskState.js';
-
 /**
  * For a given list of FLP tasks, build a table with tasks details and buttons to allow for retrieving more details per task
  * @param {Array<Task>} [tasks = []] - list of tasks to build table for
  * @param {TaskTableModel} taskTableModel - task table model to use for features such as filtering and retrieving more details of task
  * @return {vnode} - table of the FLP tasks
  */
-export const flpTasksTable = (tasks, taskTableModel) => {
+export const flpTasksTable = (tasks, taskTableModel,loggerObject) => {
   const tableColumns = ['Name', 'PID', 'Locked', 'Status', 'State', 'Host Name', 'More'];
 
   return h('.scroll-auto.panel', [
@@ -47,14 +46,14 @@ export const flpTasksTable = (tasks, taskTableModel) => {
             h(`td.w-10${getTaskStateClassAssociation(task.state)}`, task.state),
             h('td.w-20', task?.deploymentInfo?.hostname),
             h('td.w-10',
-              h('button.btn-sm.btn-default', {
+              h('boutton.btn-sm.btn-default', {
                 title: 'More Details',
                 onclick: () => taskTableModel.toggleTaskView(task.taskId),
               }, taskTableModel.openedTaskViews[task.taskId] ? iconChevronTop() : iconChevronBottom())
             ),
           ]),
           taskTableModel.openedTaskViews[task.taskId] && taskTableModel.tasksAsRemoteDataById[task.taskId]
-          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId]),
+          && showTaskDetailsTable(taskTableModel.tasksAsRemoteDataById[task.taskId],loggerObject),
         ]),
       ])
     ])
@@ -67,13 +66,17 @@ export const flpTasksTable = (tasks, taskTableModel) => {
  * @param {RemoteData} taskRemoteData - remote data object with task details
  * @return {vnode} - table with task details
  */
-const showTaskDetailsTable = (taskRemoteData) => h('tr',
+const showTaskDetailsTable = (taskRemoteData,loggerObject) => h('tr',
+    
   taskRemoteData.match({
     NotAsked: () => null,
     Loading: () => h('td.shadow-level3.m5', {
       style: 'font-size: 0.25em; text-align: center;', colspan: 7
     }, pageLoading()),
-    Success: (data) => h('td', {colspan: 7}, showTableItem(data)),
+    Success: (data) => h('td', {colspan: 7}, 
+
+      showTableItem(data, loggerObject),
+    ),
     Failure: (_error) => h('td.shadow-level3.m5',
       {style: 'text-align: center;', colspan: 7, title: 'Could not load arguments'},
       [iconCircleX(), ' ', _error]),

--- a/Control/public/common/task/tasksPerHostPanel.js
+++ b/Control/public/common/task/tasksPerHostPanel.js
@@ -57,10 +57,7 @@ export const tasksPerHostPanel = (
   
   const infoLoggerButtonTitle = source === FLP ? 'InfoLogger FLP' : 'InfoLogger EPN';
   const infoLoggerButtonUrl = source === FLP ? COG.ILG_URL : COG.ILG_EPN_URL;
-  const loggerObject = { run, 
-    partition, 
-    title: infoLoggerButtonTitle, url: infoLoggerButtonUrl, 
-  }
+
   return h('.flex-column.g2', [
     h('.flex-row.g1', [
       h('.flex-row.g1', [
@@ -91,7 +88,14 @@ export const tasksPerHostPanel = (
           if (source === EPN) {
             [hostnameToIlg] = hostname.split('.');
           }
-          loggerObject.hostname = hostnameToIlg;
+          const infoLoggerConfig = {
+            fields: {
+              run,
+              partition,
+              hostname: hostnameToIlg,
+            },
+            url: infoLoggerButtonUrl,
+          };
           return h('', [
             h('.p2.flex-row.bg-primary.white', [
               h('h5.flex-grow-3', hostname),
@@ -110,11 +114,8 @@ export const tasksPerHostPanel = (
               ]),
             ]),
             source === FLP
-              ? flpTasksTable(tasksByHosts[hostname].list, 
-                taskTableModel, 
-                loggerObject)
-              : epnTasksTable(tasksByHosts[hostname].list,
-                loggerObject),
+              ? flpTasksTable(tasksByHosts[hostname].list, taskTableModel, infoLoggerConfig)
+              : epnTasksTable(tasksByHosts[hostname].list),
           ]);
         })
   ]);

--- a/Control/public/common/task/tasksPerHostPanel.js
+++ b/Control/public/common/task/tasksPerHostPanel.js
@@ -57,7 +57,10 @@ export const tasksPerHostPanel = (
   
   const infoLoggerButtonTitle = source === FLP ? 'InfoLogger FLP' : 'InfoLogger EPN';
   const infoLoggerButtonUrl = source === FLP ? COG.ILG_URL : COG.ILG_EPN_URL;
-
+  const loggerObject = { run, 
+    partition, 
+    title: infoLoggerButtonTitle, url: infoLoggerButtonUrl, 
+  }
   return h('.flex-column.g2', [
     h('.flex-row.g1', [
       h('.flex-row.g1', [
@@ -88,6 +91,7 @@ export const tasksPerHostPanel = (
           if (source === EPN) {
             [hostnameToIlg] = hostname.split('.');
           }
+          loggerObject.hostname = hostnameToIlg;
           return h('', [
             h('.p2.flex-row.bg-primary.white', [
               h('h5.flex-grow-3', hostname),
@@ -106,8 +110,11 @@ export const tasksPerHostPanel = (
               ]),
             ]),
             source === FLP
-              ? flpTasksTable(tasksByHosts[hostname].list, taskTableModel)
-              : epnTasksTable(tasksByHosts[hostname].list),
+              ? flpTasksTable(tasksByHosts[hostname].list, 
+                taskTableModel, 
+                loggerObject)
+              : epnTasksTable(tasksByHosts[hostname].list,
+                loggerObject),
           ]);
         })
   ]);


### PR DESCRIPTION
The request of this ticket is to add another button (and such create a btn-group out of the two buttons). This new button should be labeled "ILG" and work in a similar fashion to existing infologgerbutton which opens infologger. But extra, it should add one more parameter, that is pid with the value of the pid of the task that it is in line with. (PID can be seen in ECS GUI table as well)

#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful
