### PR TITLE
[OGUI-1602] Remove option to save only for CRUs and rename remaining button to simple 'Configure'

### DIFF
--- a/Control/public/configuration/configPage.js
+++ b/Control/public/configuration/configPage.js
@@ -70,7 +70,6 @@ const buildPage = (model, cruMapByHost) => {
         h('h4.pv2.w-20', 'CRUs by detector:'),
         savingConfigurationMessagePanel(model),
         h('.btn-group.w-20', {style: 'justify-content: flex-end;'}, [
-          saveConfigurationButton(model),
           runRocConfigButton(model)
         ])
       ]),
@@ -401,17 +400,6 @@ const savingConfigurationMessagePanel = (model) =>
  * @param {Object} model
  * @return {vnode}
  */
-const saveConfigurationButton = (model) =>
-  h('button.btn.btn-default', {
-    onclick: () => model.configuration.saveConfiguration(),
-    disabled: model.configuration.configurationRequest.isLoading(),
-  }, model.configuration.configurationRequest.isLoading() ? loading(1.5) : 'Save');
-
-/**
- * Button to save the updated configuration
- * @param {Object} model
- * @return {vnode}
- */
 const runRocConfigButton = (model) =>
   h('button.btn.btn-primary', {
     onclick: () => {
@@ -422,4 +410,4 @@ Are you sure you would like to continue?`)
     },
     disabled: model.configuration.configurationRequest.isLoading()
     || (model.workflow.model.detectors.isSingleView() && !model.lock.isLockedByCurrentUser(model.detectors.selected)),
-  }, model.configuration.configurationRequest.isLoading() ? loading(1.5) : 'Save & Configure');
+  }, model.configuration.configurationRequest.isLoading() ? loading(1.5) : 'Configure');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which takes into consideration a user reqest:
* removes the option to `Save` only for CRUs configuration to Consul
* renames the `Save & Configure` button to `Configure` 