### PR TITLE
[OGUI-1232] Use consul UI param rather than host and port

### DIFF
--- a/Control/public/configuration/ConfigByCru.js
+++ b/Control/public/configuration/ConfigByCru.js
@@ -263,7 +263,7 @@ export default class Config extends Observable {
    */
   getConsulConfigURL() {
     const consul = COG.CONSUL;
-    return `${consul.protocol}://${consul.hostname}:${consul.port}/${consul.kVPrefix}/${consul.readoutCardPath}`;
+    return `${consul.protocol}://${consul.ui}/${consul.kVPrefix}/${consul.readoutCardPath}`;
   }
 
   /**


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* uses the `consul.ui` public config parameter instead of hostname and port. 
* on the back-end the parameter is built depending on the current deployment, thus if UI is not defined (such as dedicated nginx server), the parameter `ui` will be built based on known hostname and port as before