### PR TITLE
[OGUI-1612] Keep grpc call in workflowtemplate.service independently and pass informative message to user

### DIFF
--- a/Control/lib/services/WorkflowTemplate.service.js
+++ b/Control/lib/services/WorkflowTemplate.service.js
@@ -38,8 +38,18 @@ class WorkflowTemplateService {
    * @throws
    */
   async getDefaultTemplateSource() {
-    const {repos: repositories} = await this._coreGrpc['ListRepos']();
-    const defaultRepository = repositories.find((repository) => repository.default);
+    /**
+     * @type {grpc.core.ListReposReply}
+     */
+    let repositoriesReply = {};
+    try {
+      repositoriesReply = await this._coreGrpc['ListRepos']();
+      
+    } catch (error) {
+      throw grpcErrorToNativeError(error);
+    }
+    const { repos = [] } = repositoriesReply;
+    const defaultRepository = repos.find((repository) => repository.default);
 
     if (!defaultRepository) {
       throw new NotFoundError(`Unable to find a default repository`);
@@ -59,34 +69,36 @@ class WorkflowTemplateService {
   /**
    * Retrieve a list of mappings for simplified creation of environments based on workflow saved configurations
    * @return {Array<{label: String, configuration: String}>} - list of mappings to be displayed
+   * @throws
    */
   async retrieveWorkflowMappings() {
+    let mappingsString = '';
     try {
-      const mappingsString = await this._apricotGrpc.getRuntimeEntryByComponent(RUNTIME_COMPONENT, RUNTIME_KEY);
-      const mappings = JSON.parse(mappingsString);
-      if (Array.isArray(mappings)) {
-        return mappings.sort(({label: labelA}, {label: labelB}) => labelA < labelB ? -1 : 1);
-      }
-
-      return [];
+      mappingsString = await this._apricotGrpc.getRuntimeEntryByComponent(RUNTIME_COMPONENT, RUNTIME_KEY);
     } catch (error) {
       throw grpcErrorToNativeError(error);
     }
+    const mappings = JSON.parse(mappingsString);
+    if (Array.isArray(mappings)) {
+      return mappings.sort(({ label: labelA }, { label: labelB }) => labelA < labelB ? -1 : 1);
+    }
+    return [];
   }
 
   /**
    * Using apricot service, retrieve the content of a saved configuration by name
    * @param {String} name - configuration that needs to be retrieved
    * @return {Object} - object with saved configuration
+   * @throws
    */
   async retrieveWorkflowSavedConfiguration(name) {
+    let configurationString = '';
     try {
-      const configurationString = await this._apricotGrpc.getRuntimeEntryByComponent(RUNTIME_CONFIGURATION, name);
-      const configuration = JSON.parse(configurationString);
-      return configuration
+      configurationString = await this._apricotGrpc.getRuntimeEntryByComponent(RUNTIME_CONFIGURATION, name);
     } catch (error) {
       throw grpcErrorToNativeError(error);
     }
+    return JSON.parse(configurationString);
   }
 }
 

--- a/Control/lib/services/WorkflowTemplate.service.js
+++ b/Control/lib/services/WorkflowTemplate.service.js
@@ -79,10 +79,10 @@ class WorkflowTemplateService {
       throw grpcErrorToNativeError(error);
     }
     const mappings = JSON.parse(mappingsString);
-    if (Array.isArray(mappings)) {
-      return mappings.sort(({ label: labelA }, { label: labelB }) => labelA.localCompare(labelB));
+    if (!Array.isArray(mappings)) {
+      throw new Error('WorkflowMappings returned from data store are not an array');
     }
-    return [];
+    return mappings.sort(({ label: labelA }, { label: labelB }) => labelA.localeCompare(labelB));
   }
 
   /**

--- a/Control/lib/services/WorkflowTemplate.service.js
+++ b/Control/lib/services/WorkflowTemplate.service.js
@@ -80,7 +80,7 @@ class WorkflowTemplateService {
     }
     const mappings = JSON.parse(mappingsString);
     if (Array.isArray(mappings)) {
-      return mappings.sort(({ label: labelA }, { label: labelB }) => labelA < labelB ? -1 : 1);
+      return mappings.sort(({ label: labelA }, { label: labelB }) => labelA.localCompare(labelB));
     }
     return [];
   }

--- a/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
+++ b/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
@@ -63,7 +63,7 @@ export class EnvironmentCreationModel extends Observable {
     this._workflowMappings = RemoteData.loading();
     this.notify();
 
-    const {result: mappingResult, ok: isMappingOk} = await this._model.loader.get('/api/workflow/template/mappings');
+    const { result: mappingResult, ok: isMappingOk } = await this._model.loader.get('/api/workflow/template/mappings', {}, true);
     this._workflowMappings = isMappingOk
       ? RemoteData.success(mappingResult) : RemoteData.failure(mappingResult.message);
 

--- a/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
+++ b/Control/public/pages/EnvironmentCreation/EnvironmentCreation.model.js
@@ -63,7 +63,9 @@ export class EnvironmentCreationModel extends Observable {
     this._workflowMappings = RemoteData.loading();
     this.notify();
 
-    const { result: mappingResult, ok: isMappingOk } = await this._model.loader.get('/api/workflow/template/mappings', {}, true);
+    const { result: mappingResult, ok: isMappingOk } = await this._model.loader.get(
+      '/api/workflow/template/mappings', {}, true
+    );
     this._workflowMappings = isMappingOk
       ? RemoteData.success(mappingResult) : RemoteData.failure(mappingResult.message);
 

--- a/Control/public/pages/EnvironmentCreation/components/workflowMappings.component.js
+++ b/Control/public/pages/EnvironmentCreation/components/workflowMappings.component.js
@@ -36,7 +36,7 @@ export const workflowMappingsComponent = (mapping, selected = '', callbackSelect
               selectConfigurationButton(label, configuration === selected, configuration, callbackSelection)
             )]
           ),
-      Failure: () => errorMapping('No saved configurations, use advanced creation')
+      Failure: (error) => errorMapping(error ?? 'No saved configurations, use advanced creation')
     }),
     ),
     h('.flex-row.justify-center', workflowLoaded.match({
@@ -53,7 +53,7 @@ export const workflowMappingsComponent = (mapping, selected = '', callbackSelect
           }))
         ]),
       ]),
-      Failure: () => errorMapping(`Unable to retrieve configuration`)
+      Failure: (error) => errorMapping(error ?? `Unable to retrieve configuration`)
     })
     )
   ]);

--- a/Control/test/lib/services/mocha-workflowTemplate.service.test.js
+++ b/Control/test/lib/services/mocha-workflowTemplate.service.test.js
@@ -48,7 +48,7 @@ describe('WorkflowTemplateService test suite', () => {
     });
 
     it('should throw error due to no default repository being identified', async () => {
-      const stub = sinon.stub().resolves({repos: [mockRepoList[0]]}); // first element has no default
+      const stub = sinon.stub().resolves({repos: [mockRepoList[0]]}); // first element has no default repository but a default revision
       const workflowTemplate = new WorkflowTemplateService({ListRepos: stub});
       await assert.rejects(() => workflowTemplate.getDefaultTemplateSource(), new NotFoundError('Unable to find a default repository'));
     });
@@ -59,8 +59,18 @@ describe('WorkflowTemplateService test suite', () => {
         name: 'optimal-workflow',
         default: true,
       }]});
-      const workflowTemplate = new WorkflowTemplateService({ListRepos: stub});
+      const workflowTemplate = new WorkflowTemplateService({ListRepos: stub}); // first element has no default repository and no default revision
       await assert.rejects(() => workflowTemplate.getDefaultTemplateSource(), new NotFoundError('Unable to find a default revision'));
+    });
+
+    it('should throw NotFoundError due to apricot service throwing gRPC code 5', async () => {
+      const stub = sinon.stub().rejects({
+        code: 5,
+        details: 'Could not be found',
+        message: 'Could not be found',
+      });
+      const workflowTemplate = new WorkflowTemplateService({ListRepos: stub}); // first element has no default repository and no default revision
+      await assert.rejects(() => workflowTemplate.getDefaultTemplateSource(), new NotFoundError('Could not be found'));
     });
   });
 
@@ -94,6 +104,14 @@ describe('WorkflowTemplateService test suite', () => {
       const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
       await assert.rejects(() => workflowTemplate.retrieveWorkflowMappings(), new Error());
     });
+
+    it('should throw error due to incorrect JSON returned by apricot service', async () => {
+      const getRuntimeEntryByComponent = sinon.stub().resolves(
+        `template: 'some config', detectors: ['TPC', 'FSA']}`
+      );
+      const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
+      await assert.rejects(() => workflowTemplate.retrieveWorkflowMappings(), new SyntaxError(`Unexpected token 'e', "template: '"... is not valid JSON`));
+    });
   });
 
   describe(`'retrieveWorkflowSavedConfiguration' test suite`, async () => {
@@ -104,6 +122,14 @@ describe('WorkflowTemplateService test suite', () => {
       const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
       const mappings = await workflowTemplate.retrieveWorkflowSavedConfiguration();
       assert.deepStrictEqual(mappings, {template: 'some config', detectors: ['TPC', 'FSA']});
+    });
+
+    it('should throw error due to incorrect JSON returned by apricot service', async () => {
+      const getRuntimeEntryByComponent = sinon.stub().resolves(
+        `template: 'some config', detectors: ['TPC', 'FSA']}`
+      );
+      const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
+      await assert.rejects(() => workflowTemplate.retrieveWorkflowSavedConfiguration(), new SyntaxError(`Unexpected token 'e', "template: '"... is not valid JSON`));
     });
   });
 });

--- a/Control/test/lib/services/mocha-workflowTemplate.service.test.js
+++ b/Control/test/lib/services/mocha-workflowTemplate.service.test.js
@@ -84,13 +84,20 @@ describe('WorkflowTemplateService test suite', () => {
       assert.deepStrictEqual(mappings, [{label: 'Aconfig1', component: 'Config_1'}, {label: 'config1', component: 'Config_1'}]);
     });
 
-    it('should successfully return empty array if Apricot returned empty object', async () => {
+    it('should throw an error if Apricot returned an empty object', async () => {
       const getRuntimeEntryByComponent = sinon.stub().resolves(
         JSON.stringify('{}')
       );
       const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
-      const mappings = await workflowTemplate.retrieveWorkflowMappings();
-      assert.deepStrictEqual(mappings, []);
+      await assert.rejects(() => workflowTemplate.retrieveWorkflowMappings(), new Error('WorkflowMappings returned from data store are not an array'));
+    });
+
+    it('should throw an error if Apricot returned object that is not array for mappings', async () => {
+      const getRuntimeEntryByComponent = sinon.stub().resolves(
+        JSON.stringify('{mappings: {someMapping: {}}}')
+      );
+      const workflowTemplate = new WorkflowTemplateService({}, {getRuntimeEntryByComponent});
+      await assert.rejects(() => workflowTemplate.retrieveWorkflowMappings(), new Error('WorkflowMappings returned from data store are not an array'));
     });
 
     it('should throw NotFoundError due to apricot service throwing gRPC code 5', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates front-end so that informative error message in case of failure to retrieve workflow information is displayed to the user rather than a hardcoded one
* updates the backend service of WorkflowTemplate to keep the gRPC call independently from other potential errors