### PR TITLE
[OGUI-1634] Add path explicitly to HEAD response from CCDB

### DIFF
--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -206,8 +206,11 @@ export class CcdbService {
       if (!location) {
         throw new Error(`No location provided by CCDB for object with path: ${path}`);
       }
-      headers.location = location;
-      return headers;
+      return {
+        ...headers,
+        location,
+        path,
+      };
     } else {
       throw new Error(`Unable to retrieve object: ${path} due to status: ${status}`);
     }

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -251,13 +251,15 @@ export const ccdbServiceTestSuite = async () => {
         await rejects(async () => ccdb.getObjectDetails({ path: null, validFrom: 213 }, null), new Error('Missing mandatory parameters: path & validFrom'));
       });
 
-      test('should successfully return content-location field on status >=200 <= 399', async () => {
+      test('should successfully return content-location field on status >=200 <= 399 and add path if missing', async () => {
+        const path = 'qc/some/test/';
         nock('http://ccdb-local:8083')
           .defaultReplyHeaders({ 'content-location': '/download/123123-123123', location: '/download/some-id' })
-          .head('/qc/some/test/123455432/id1')
+          .head(`/${path}/123455432/id1`)
           .reply(303);
-        const content = await ccdb.getObjectDetails({ path: 'qc/some/test', validFrom: 123455432, id: 'id1' });
+        const content = await ccdb.getObjectDetails({ path, validFrom: 123455432, id: 'id1' });
         strictEqual(content.location, '/download/123123-123123');
+        strictEqual(content.path, path);
       });
 
       test('should successfully return content-location field if is string as array with "alien" second item on status >=200 <= 399', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* on the HEAD response from CCDB, we explicitly add the `path`. This is needed because depending on the CCDB mode of operation (memory or local), the path may not be part of the response