### PR TITLE
[OGUI-1635] Fix show error in importModal if error occurs during importing a new …

### DIFF
--- a/QualityControl/public/layout/panels/importModal.js
+++ b/QualityControl/public/layout/panels/importModal.js
@@ -35,7 +35,7 @@ export default (model) =>
           NotAsked: () => null,
           Loading: () => h('', 'Loading...'),
           Success: (_) => null,
-          Failure: (error) => h('.danger.pv1', error.message),
+          Failure: (error) => h('.danger.pv1', error.message || String(error)),
         }),
         h('.btn-group.w-100.align-center.pv1', {
           style: 'display:flex; justify-content:center;',


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR addresses an issue encountered when importing a layout via JSON. In the current flow, errors did not provide immediate feedback to the user.
- When we attempted to access the error message again, we didn't get any output because the error was already captured and processed earlier in the flow (`parseResult` method).
-  Now the error message is captured and correctly displayed

