### PR TITLE
[OGUI-1587] Remove force transparent background in JSROOT objects

### DIFF
--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -33,9 +33,6 @@
 
 .status-bar { border-top: 1px solid var(--color-gray-dark); }
 
-/* Force jsroot's background to be transparent */
-.canvas_fillrect { fill: transparent !important; }
-
 /* Show plots gradually */
 .jsroot { animation-name: appearance; animation-duration: 0.2s; }
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

The PR addressed an issue with JSROOT plots, where the background was being forced to be transparent, overriding any background settings applied by users:
- The forced transparent background has been removed
