### PR TITLE
[OGUI-1129] Layouts do not preserve object arrangement

### DIFF
--- a/QualityControl/public/layout/Grid.js
+++ b/QualityControl/public/layout/Grid.js
@@ -153,7 +153,7 @@ GridList.prototype = {
           position = this._getItemPosition(item);
 
       this._updateItemPosition(
-        item, this.findPositionForItem(item, {x: position.x, y: 0}));
+        item, this.findPositionForItem(item, {x: currentColumn, y: 0}));
 
       // New items should never be placed to the left of previous items
       currentColumn = Math.max(currentColumn, position.x);

--- a/QualityControl/public/layout/Grid.js
+++ b/QualityControl/public/layout/Grid.js
@@ -139,7 +139,7 @@ GridList.prototype = {
 
   resizeGrid: function(lanes) {
     var currentColumn = 0;
-    
+
     this._options.lanes = lanes;
     this._adjustSizeOfItems();
 

--- a/QualityControl/public/layout/Grid.js
+++ b/QualityControl/public/layout/Grid.js
@@ -138,7 +138,28 @@ GridList.prototype = {
   },
 
   resizeGrid: function(lanes) {
+    var currentColumn = 0;
+    
     this._options.lanes = lanes;
+    this._adjustSizeOfItems();
+
+    this._sortItemsByPosition();
+    this._resetGrid();
+
+    // The items will be sorted based on their index within the this.items array,
+    // that is their "1d position"
+    for (var i = 0; i < this.items.length; i++) {
+      var item = this.items[i],
+          position = this._getItemPosition(item);
+
+      this._updateItemPosition(
+        item, this.findPositionForItem(item, {x: position.x, y: 0}));
+
+      // New items should never be placed to the left of previous items
+      currentColumn = Math.max(currentColumn, position.x);
+    }
+
+    this._pullItemsToLeft();
   },
 
   findPositionForItem: function(item, start, fixedRow) {

--- a/QualityControl/public/layout/Grid.js
+++ b/QualityControl/public/layout/Grid.js
@@ -138,28 +138,7 @@ GridList.prototype = {
   },
 
   resizeGrid: function(lanes) {
-    var currentColumn = 0;
-
     this._options.lanes = lanes;
-    this._adjustSizeOfItems();
-
-    this._sortItemsByPosition();
-    this._resetGrid();
-
-    // The items will be sorted based on their index within the this.items array,
-    // that is their "1d position"
-    for (var i = 0; i < this.items.length; i++) {
-      var item = this.items[i],
-          position = this._getItemPosition(item);
-
-      this._updateItemPosition(
-        item, this.findPositionForItem(item, {x: currentColumn, y: 0}));
-
-      // New items should never be placed to the left of previous items
-      currentColumn = Math.max(currentColumn, position.x);
-    }
-
-    this._pullItemsToLeft();
   },
 
   findPositionForItem: function(item, start, fixedRow) {

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -355,7 +355,9 @@ export default class Layout extends Observable {
    */
   sortObjectsOfCurrentTab() {
     this.gridList.items = this.tab.objects;
-    this.gridList.resizeGrid(this.gridListSize);
+    if (this.isEditLayoutDropdownOpen) {
+      this.gridList.resizeGrid(this.gridListSize);
+    }
   }
 
   /**

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -336,7 +336,7 @@ export default class Layout extends Observable {
     this.gridListSize = parseInt(value, 10);
     this.cellHeight = 100 / this.gridListSize * 0.95; // %, put some margin at bottom to see below
     this.cellWidth = 100 / this.gridListSize; // %
-    if (this.isEditLayoutDropdownOpen) {
+    if (this.editEnabled) {
       this.gridList.resizeGrid(this.gridListSize);
     }
     this.tab.columns = this.gridListSize;
@@ -355,7 +355,7 @@ export default class Layout extends Observable {
    */
   sortObjectsOfCurrentTab() {
     this.gridList.items = this.tab.objects;
-    if (this.isEditLayoutDropdownOpen) {
+    if (this.editEnabled) {
       this.gridList.resizeGrid(this.gridListSize);
     }
   }

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -336,7 +336,9 @@ export default class Layout extends Observable {
     this.gridListSize = parseInt(value, 10);
     this.cellHeight = 100 / this.gridListSize * 0.95; // %, put some margin at bottom to see below
     this.cellWidth = 100 / this.gridListSize; // %
-    this.gridList.resizeGrid(this.gridListSize);
+    if (this.isEditLayoutDropdownOpen) {
+      this.gridList.resizeGrid(this.gridListSize);
+    }
     this.tab.columns = this.gridListSize;
     this.tab.objects.forEach((object) => {
       if (object.w > this.tab.columns) {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful


This PR aimed to fix a visual bug that would alter the LayoutView page object-layout when switching between tabs or switching to the same tab. 