### PR TITLE
[OGUI-1657] Migrate to use tree API from CCDB

### DIFF
--- a/QualityControl/lib/dtos/QCObjectDto.js
+++ b/QualityControl/lib/dtos/QCObjectDto.js
@@ -107,16 +107,16 @@ export default class QCObjectDto {
    */
   static toQcObjectLeaf(item) {
     const objectLeaf = {
-      path: item[PATH],
       name: item[PATH],
     };
 
     if (item[VALID_FROM] !== undefined) {
-      objectLeaf.validFrom = item[VALID_FROM];
+      objectLeaf.validFrom = getDateAsTimestamp(item[VALID_FROM]);
     }
 
     if (item[CREATED] !== undefined) {
-      objectLeaf.createdAt = item[CREATED];
+      objectLeaf.createdAt = getDateAsTimestamp(item[CREATED]);
+      objectLeaf.path = item[PATH];
     }
 
     return objectLeaf;

--- a/QualityControl/lib/dtos/QCObjectDto.js
+++ b/QualityControl/lib/dtos/QCObjectDto.js
@@ -106,11 +106,19 @@ export default class QCObjectDto {
    * @returns {QcObjectLeaf} - parsed object
    */
   static toQcObjectLeaf(item) {
-    return {
+    const objectLeaf = {
       path: item[PATH],
       name: item[PATH],
-      validFrom: getDateAsTimestamp(item[VALID_FROM]),
-      createdAt: getDateAsTimestamp(item[CREATED]),
     };
+
+    if (item[VALID_FROM] !== undefined) {
+      objectLeaf.validFrom = item[VALID_FROM];
+    }
+
+    if (item[CREATED] !== undefined) {
+      objectLeaf.createdAt = item[CREATED];
+    }
+
+    return objectLeaf;
   }
 }

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -70,7 +70,7 @@ export class QcObjectService {
    */
   async refreshCache() {
     try {
-      const objects = await this._dbService.getObjectsLatestVersionList(this._dbService.CACHE_PREFIX);
+      const objects = await this._dbService.getObjectsTreeList(this._dbService.CACHE_PREFIX);
       this._cache.objects = this._parseObjects(objects);
       this._cache.lastUpdate = Date.now();
     } catch (error) {
@@ -95,11 +95,11 @@ export class QcObjectService {
    * @returns {Promise.<Array<QcObjectLeaf>>} - results of objects with required fields
    * @rejects {Error}
    */
-  async retrieveLatestVersionOfObjects(prefix = this._dbService.PREFIX, fields = [], useCache = true) {
+  async retrieveLatestVersionOfObjects(prefix = this._dbService.PREFIX, useCache = true) {
     if (useCache && this._cache?.objects) {
       return this._cache.objects.filter((object) => object.name.startsWith(prefix));
     } else {
-      const objects = await this._dbService.getObjectsLatestVersionList(prefix, fields);
+      const objects = await this._dbService.getObjectsTreeList(prefix); // TreeList links to the latest
       return this._parseObjects(objects);
     }
   }

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { LogManager } from '@aliceo2/web-ui';
+import { FailedDependencyError, LogManager } from '@aliceo2/web-ui';
 import { httpHeadJson, httpGetJson } from '../../utils/utils.js';
 import {
   CCDB_MONITOR, CCDB_VERSION_KEY, CCDB_RESPONSE_BODY_KEYS, CCDB_FILTER_FIELDS, CCDB_RESPONSE_HEADER_KEYS,
@@ -108,7 +108,7 @@ export class CcdbService {
     const { subfolders } = await httpGetJson(this._hostname, this._port, `/tree/${prefix}.*`);
 
     if (!Array.isArray(subfolders)) {
-      throw new Error('Invalid response format from server - expected subfolders array');
+      throw new FailedDependencyError('Invalid response format from server - expected subfolders array');
     }
     return subfolders.map((folder) => ({ path: folder }));
   }

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -122,6 +122,22 @@ export class CcdbService {
   }
 
   /**
+   * Returns a list of object paths using the /tree/ endpoint based on a given prefix
+   * @example Equivalent of URL request: `/tree/qc/TPC/object.*`
+   * @param {string} [prefix] - Prefix for which CCDB should search for objects
+   * @returns {Promise.<Array<{PATH}>>} - results of objects query or an empty array
+   * @rejects {Error}
+   */
+  async getObjectsTreeList(prefix = this._PREFIX) {
+    const { subfolders } = await httpGetJson(this._hostname, this._port, `/tree/${prefix}.*`);
+
+    if (!Array.isArray(subfolders)) {
+      throw new Error('Invalid response format from server - expected subfolders array');
+    }
+    return subfolders.map((folder) => ({ path: folder }));
+  }
+
+  /**
    * Retrieve a sorted list of identifications for a specified object which represent different versions of the object;
    * Number of versions defaults to a limit but it can be changed by passing a value
    * @example Equivalent of URL request: `/browse/qc/TPC/object/14324234234234234/id-id-id-id-id/RunNumber=554345`

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -110,6 +110,8 @@ export class CcdbService {
     if (!Array.isArray(subfolders)) {
       throw new FailedDependencyError('Invalid response format from server - expected subfolders array');
     }
+    // console.log(await this.getObjectsLatestVersionList(prefix));
+
     return subfolders.map((folder) => ({ path: folder }));
   }
 

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -114,6 +114,30 @@ export class CcdbService {
   }
 
   /**
+   * Returns a list of objects path (corresponding to their latest version) based on a given prefix
+   * (e.g. 'qc'; default to config file specified prefix);
+   *
+   * Due to CCDB returning sub-folders if regex is missing, service will add by default `.*` at the end to retrieve
+   * paths starting with client provided prefix.
+   *
+   * Attributes of objects wished to be requested for each object can be passed through the fields parameter;
+   * If attributes list is missing, a default minimal list will be used: PATH, CREATED, LAST_MODIFIED
+   * @example Equivalent of URL request: `/latest/qc/TPC/object.*`
+   * @param {string} [prefix] - Prefix for which CCDB should search for objects
+   * @param {Array<string>} [fields] - List of fields that should be requested for each object
+   * @returns {Promise.<Array<{PATH, CREATED, LAST_MODIFIED}>>} - results of objects query or error
+   * @rejects {Error}
+   */
+  async getObjectsLatestVersionList(prefix = this._PREFIX, fields = []) {
+    const headers = {
+      accept: 'application/json',
+      'x-filter-fields': fields.length > 0 ? fields.join(',') : `${PATH},${CREATED},${LAST_MODIFIED}`,
+    };
+    const { objects } = await httpGetJson(this._hostname, this._port, `/latest/${prefix}.*`, headers);
+    return objects;
+  }
+
+  /**
    * Retrieve a sorted list of identifications for a specified object which represent different versions of the object;
    * Number of versions defaults to a limit but it can be changed by passing a value
    * @example Equivalent of URL request: `/browse/qc/TPC/object/14324234234234234/id-id-id-id-id/RunNumber=554345`

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -98,30 +98,6 @@ export class CcdbService {
   }
 
   /**
-   * Returns a list of objects path (corresponding to their latest version) based on a given prefix
-   * (e.g. 'qc'; default to config file specified prefix);
-   *
-   * Due to CCDB returning sub-folders if regex is missing, service will add by default `.*` at the end to retrieve
-   * paths starting with client provided prefix.
-   *
-   * Attributes of objects wished to be requested for each object can be passed through the fields parameter;
-   * If attributes list is missing, a default minimal list will be used: PATH, CREATED, LAST_MODIFIED
-   * @example Equivalent of URL request: `/latest/qc/TPC/object.*`
-   * @param {string} [prefix] - Prefix for which CCDB should search for objects
-   * @param {Array<string>} [fields] - List of fields that should be requested for each object
-   * @returns {Promise.<Array<{PATH, CREATED, LAST_MODIFIED}>>} - results of objects query or error
-   * @rejects {Error}
-   */
-  async getObjectsLatestVersionList(prefix = this._PREFIX, fields = []) {
-    const headers = {
-      accept: 'application/json',
-      'x-filter-fields': fields.length > 0 ? fields.join(',') : `${PATH},${CREATED},${LAST_MODIFIED}`,
-    };
-    const { objects } = await httpGetJson(this._hostname, this._port, `/latest/${prefix}.*`, headers);
-    return objects;
-  }
-
-  /**
    * Returns a list of object paths using the /tree/ endpoint based on a given prefix
    * @example Equivalent of URL request: `/tree/qc/TPC/object.*`
    * @param {string} [prefix] - Prefix for which CCDB should search for objects

--- a/QualityControl/public/layout/view/panels/objectTreeSidebar.js
+++ b/QualityControl/public/layout/view/panels/objectTreeSidebar.js
@@ -34,7 +34,7 @@ export default (model) =>
       const { searchInput = '' } = model.object;
       if (searchInput.trim() !== '') {
         objectsToDisplay = objects.filter((qcObject) =>
-          qcObject.path.toLowerCase().includes(searchInput.toLowerCase()));
+          qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
       }
       return [
         searchForm(model),
@@ -136,7 +136,7 @@ const branchRow = (model, sideTree, level) => {
 
   const icon = sideTree.open ? iconCaretBottom() : iconCaretRight();
   const iconWrapper = h('span', { style: { paddingLeft: `${level}em` } }, icon);
-  const path = sideTree.path.join('/');
+  const path = sideTree.name;
 
   const attr = {
     key: `key-sidebar-tree-${path}`,
@@ -163,7 +163,7 @@ const branchRow = (model, sideTree, level) => {
 const leafRow = (model, sideTree, level) => {
   // UI construction
   const iconWrapper = h('span', { style: { paddingLeft: `${level}em` } }, iconBarChart());
-  const path = sideTree.path.join('/');
+  const path = sideTree.name;
   const className = sideTree.object && sideTree.object === model.object.selected ? 'table-primary' : '';
   const draggable = Boolean(sideTree.object);
 

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -124,32 +124,30 @@ export default class QCObject extends Observable {
    */
   sortListByField(listSource, field, order) {
     listSource.sort((a, b) => typeof a[field] === 'string' ?
-      this._compareStrings(a, b, field, order) :
-      this._compareNumbers(a, b, field, order));
+      this._compareStrings(a[field], b[field], order) :
+      this._compareNumbers(a[field], b[field], order));
   }
 
   /**
    * Helper method for sortListByField for sorting strings
    * @param {string} a - first string to be sorted
    * @param {string} b - second string to be sorted
-   * @param {string} field - filed by which the sort should be done
    * @param {number} order - acending (1) or decending (-1)
    * @returns {undefined}
    */
-  _compareStrings(a, b, field, order) {
-    return a[field].toUpperCase().localeCompare(b[field].toUpperCase()) * order;
+  _compareStrings(a, b, order) {
+    return a.toUpperCase().localeCompare(b.toUpperCase()) * order;
   }
 
   /**
    * Helper method for sortListByField for sorting numbers
    * @param {number} a - first number to be sorted
    * @param {number} b - second number to be sorted
-   * @param {string} field - filed by which the sort should be done
    * @param {number} order - acending (1) or decending (-1)
    * @returns {undefined}
    */
-  _compareNumbers(a, b, field, order) {
-    return (a[field] - b[field]) * order;
+  _compareNumbers(a, b, order) {
+    return (a - b) * order;
   }
 
   /**

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -119,25 +119,37 @@ export default class QCObject extends Observable {
    * Method to sort a list of JSON objects by one of its fields
    * @param {Array<JSON>} listSource - list of objects to be sorted
    * @param {string} field - filed by which the sort should be done
-   * @param {number} order - order by which it should be done
+   * @param {number} order - acending (1) or decending (-1)
    * @returns {undefined}
    */
   sortListByField(listSource, field, order) {
-    listSource.sort((a, b) => {
-      if (field === 'createTime') {
-        if (a[field] < b[field]) {
-          return -1 * order;
-        } else {
-          return Number(order);
-        }
-      } else if (field === 'name') {
-        if (a[field].toUpperCase() < b[field].toUpperCase()) {
-          return -1 * order;
-        } else {
-          return Number(order);
-        }
-      }
-    });
+    listSource.sort((a, b) => typeof a[field] === 'string' ?
+      this._compareStrings(a, b, field, order) :
+      this._compareNumbers(a, b, field, order));
+  }
+
+  /**
+   * Helper method for sortListByField for sorting strings
+   * @param {string} a - first string to be sorted
+   * @param {string} b - second string to be sorted
+   * @param {string} field - filed by which the sort should be done
+   * @param {number} order - acending (1) or decending (-1)
+   * @returns {undefined}
+   */
+  _compareStrings(a, b, field, order) {
+    return a[field].toUpperCase().localeCompare(b[field].toUpperCase()) * order;
+  }
+
+  /**
+   * Helper method for sortListByField for sorting numbers
+   * @param {number} a - first number to be sorted
+   * @param {number} b - second number to be sorted
+   * @param {string} field - filed by which the sort should be done
+   * @param {number} order - acending (1) or decending (-1)
+   * @returns {undefined}
+   */
+  _compareNumbers(a, b, field, order) {
+    return (a[field] - b[field]) * order;
   }
 
   /**

--- a/QualityControl/public/object/objectTreeHeader.js
+++ b/QualityControl/public/object/objectTreeHeader.js
@@ -45,8 +45,6 @@ export default function objectTreeHeader(model) {
           onclick: () => model.object.toggleSortDropdown(),
         }, [model.object.sortBy.title, ' ', model.object.sortBy.icon]),
         h('.dropdown-menu.text-left', [
-          sortMenuItem(model, 'Created Time', 'Sort by time of creation ASC', iconArrowTop(), 'createTime', 1),
-          sortMenuItem(model, 'Created Time', 'Sort by time of creation DESC', iconArrowBottom(), 'createTime', -1),
           sortMenuItem(model, 'Name', 'Sort by name ASC', iconArrowTop(), 'name', 1),
           sortMenuItem(model, 'Name', 'Sort by name DESC', iconArrowBottom(), 'name', -1),
 

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -40,7 +40,7 @@ export default (model) => h('.h-100.flex-column', { key: model.router.params.pag
         if (searchInput !== '') {
           const objectsLoaded = model.object.list;
           const objectsToDisplay = objectsLoaded.filter((qcObject) =>
-            qcObject.path.toLowerCase().includes(searchInput.toLowerCase()));
+            qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
           return virtualTable(model, 'main', objectsToDisplay);
         }
         return tableShow(model);
@@ -176,7 +176,7 @@ function treeRow(model, tree, level) {
   const padding = `${level}em`;
   const levelDeeper = level + 1;
   const children = tree.open ? tree.children.map((children) => treeRow(model, children, levelDeeper)) : [];
-  const path = tree.path.join('/');
+  const path = tree.name;
   const className = tree.object && tree.object === model.object.selected ? 'table-primary' : '';
 
   if (model.object.searchInput) {

--- a/QualityControl/public/services/Layout.service.js
+++ b/QualityControl/public/services/Layout.service.js
@@ -48,7 +48,7 @@ export default class LayoutService {
     const { result, ok } = await this.loader.get('/api/layouts');
 
     if (ok) {
-      const sortedLayouts = result.sort((lOne, lTwo) => lOne.name > lTwo.name ? 1 : -1);
+      const sortedLayouts = result.sort(this._compareByName);
       const officialLayouts = sortedLayouts.filter(({ isOfficial = false }) => isOfficial);
       this.list = RemoteData.success(sortedLayouts);
       this.model.folder.map.get('All Layouts').list = RemoteData.success(sortedLayouts);
@@ -76,7 +76,7 @@ export default class LayoutService {
     } else {
       const { result, ok } = await this.loader.get(`/api/layouts?owner_id=${userId}`);
       if (ok) {
-        const sortedLayouts = result.sort((lOne, lTwo) => lOne.name > lTwo.name ? 1 : -1);
+        const sortedLayouts = result.sort(this._compareByName);
         this.userList = RemoteData.success(sortedLayouts);
         this.model.folder.map.get('My Layouts').list = RemoteData.success(sortedLayouts);
       } else {
@@ -86,6 +86,20 @@ export default class LayoutService {
     }
 
     that.notify();
+  }
+
+  /**
+   * Comparator function to sort layouts alphabetically by their name property
+   * @param {Layout} layout1 - First layout object to compare
+   * @param {Layout} layout2 - Second layout object to compare
+   * @returns {number} - Returns a number indicating the sort order:
+   *   - Negative if layout1.name comes before layout2.name
+   *   - Positive if layout1.name comes after layout2.name
+   *   - Zero if names are identical
+   * @private
+   */
+  _compareByName(layout1, layout2) {
+    return layout1.name.localeCompare(layout2.name);
   }
 
   /**

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -116,63 +116,6 @@ export const ccdbServiceTestSuite = async () => {
       });
     });
 
-    suite('`getObjectsLatestVersionList()` tests', () => {
-      test('should reject with error for fields parameter not being a list', async () => {
-        const ccdb = new CcdbService(ccdbConfig);
-        await rejects(
-          async () => await ccdb.getObjectsLatestVersionList('/qc', 'bad-fields'),
-          new TypeError('fields.join is not a function'),
-        );
-      });
-
-      test('should successfully return a list of the objects with requested default headers', async () => {
-        const ccdb = new CcdbService(ccdbConfig);
-        const objects = [
-          { path: 'object/one', Created: '101', 'Last-Modified': '102' },
-          { path: 'object/two', Created: '101', 'Last-Modified': '102' },
-          { path: 'object/three', Created: '101', 'Last-Modified': '102' },
-        ];
-        nock('http://ccdb-local:8083', {
-          reqheaders: {
-            Accept: 'application/json',
-            'X-Filter-Fields': 'path,Created,Last-Modified',
-          },
-        })
-          .get(`/latest/${ccdbConfig.prefix}.*`)
-          .reply(200, { objects, subfolders: [] });
-        const objectsRetrieved = await ccdb.getObjectsLatestVersionList();
-        deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
-      });
-
-      test('should successfully return a list of the objects with specified headers', async () => {
-        const ccdb = new CcdbService(ccdbConfig);
-        const objects = [
-          { path: 'object/one', Created: '101', 'Last-Modified': '102', Id: 1 },
-          { path: 'object/two', Created: '101', 'Last-Modified': '102', Id: 2 },
-          { path: 'object/three', Created: '101', 'Last-Modified': '102', Id: 3 },
-        ];
-        nock('http://ccdb-local:8083', {
-          reqheaders: {
-            Accept: 'application/json',
-            'X-Filter-Fields': 'Id',
-          },
-        })
-          .get('/latest/.*')
-          .reply(200, { objects: objects, subfolders: [] });
-        const objectsRetrieved = await ccdb.getObjectsLatestVersionList('', ['Id']);
-        deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
-      });
-
-      test('should reject due to HTTP request error', async () => {
-        const ccdb = new CcdbService(ccdbConfig);
-        const error = new Error('Querying service is down');
-        nock('http://ccdb-local:8083')
-          .get(`/latest/${ccdbConfig.prefix}.*`)
-          .replyWithError(error);
-        await rejects(async () => await ccdb.getObjectsLatestVersionList(), new Error(`${error.message || error}`));
-      });
-    });
-
     suite('`getObjectsTreeList()` tests', () => {
       test('should successfully return a list of the object paths', async () => {
         const ccdb = new CcdbService(ccdbConfig);

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -116,6 +116,63 @@ export const ccdbServiceTestSuite = async () => {
       });
     });
 
+    suite('`getObjectsLatestVersionList()` tests', () => {
+      test('should reject with error for fields parameter not being a list', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        await rejects(
+          async () => await ccdb.getObjectsLatestVersionList('/qc', 'bad-fields'),
+          new TypeError('fields.join is not a function'),
+        );
+      });
+
+      test('should successfully return a list of the objects with requested default headers', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const objects = [
+          { path: 'object/one', Created: '101', 'Last-Modified': '102' },
+          { path: 'object/two', Created: '101', 'Last-Modified': '102' },
+          { path: 'object/three', Created: '101', 'Last-Modified': '102' },
+        ];
+        nock('http://ccdb-local:8083', {
+          reqheaders: {
+            Accept: 'application/json',
+            'X-Filter-Fields': 'path,Created,Last-Modified',
+          },
+        })
+          .get(`/latest/${ccdbConfig.prefix}.*`)
+          .reply(200, { objects, subfolders: [] });
+        const objectsRetrieved = await ccdb.getObjectsLatestVersionList();
+        deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
+      });
+
+      test('should successfully return a list of the objects with specified headers', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const objects = [
+          { path: 'object/one', Created: '101', 'Last-Modified': '102', Id: 1 },
+          { path: 'object/two', Created: '101', 'Last-Modified': '102', Id: 2 },
+          { path: 'object/three', Created: '101', 'Last-Modified': '102', Id: 3 },
+        ];
+        nock('http://ccdb-local:8083', {
+          reqheaders: {
+            Accept: 'application/json',
+            'X-Filter-Fields': 'Id',
+          },
+        })
+          .get('/latest/.*')
+          .reply(200, { objects: objects, subfolders: [] });
+        const objectsRetrieved = await ccdb.getObjectsLatestVersionList('', ['Id']);
+        deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
+      });
+
+      test('should reject due to HTTP request error', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const error = new Error('Querying service is down');
+        nock('http://ccdb-local:8083')
+          .get(`/latest/${ccdbConfig.prefix}.*`)
+          .replyWithError(error);
+        await rejects(async () => await ccdb.getObjectsLatestVersionList(), new Error(`${error.message || error}`));
+      });
+    });
+
     suite('`getObjectsTreeList()` tests', () => {
       test('should successfully return a list of the object paths', async () => {
         const ccdb = new CcdbService(ccdbConfig);

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -173,6 +173,56 @@ export const ccdbServiceTestSuite = async () => {
       });
     });
 
+    suite('`getObjectsTreeList()` tests', () => {
+      test('should successfully return a list of the object paths', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const subfolders = [
+          'object/one',
+          'object/two',
+          'object/three',
+        ];
+        const expectedObjects = [
+          { path: 'object/one' },
+          { path: 'object/two' },
+          { path: 'object/three' },
+        ];
+
+        nock('http://ccdb-local:8083', {
+          reqheaders: { Accept: 'application/json' },
+        })
+          .get(`/tree/${ccdbConfig.prefix}.*`)
+          .reply(200, { subfolders });
+        const objectsRetrieved = await ccdb.getObjectsTreeList(ccdbConfig.prefix);
+        deepStrictEqual(objectsRetrieved, expectedObjects, 'Received objects are not alike');
+      });
+
+      test('should throw error when response has invalid subfolders format', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const invalidResponse = { subfolders: 'not-an-array' };
+
+        nock('http://ccdb-local:8083', {
+          reqheaders: { Accept: 'application/json' },
+        })
+          .get(`/tree/${ccdbConfig.prefix}.*`)
+          .reply(200, invalidResponse);
+
+        await rejects(
+          async () => await ccdb.getObjectsTreeList(ccdbConfig.prefix),
+          new Error('Invalid response format from server - expected subfolders array'),
+          'Should throw error for invalid subfolders format',
+        );
+      });
+
+      test('should reject due to HTTP request error', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const error = new Error('Querying service is down');
+        nock('http://ccdb-local:8083')
+          .get(`/tree/${ccdbConfig.prefix}.*`)
+          .replyWithError(error);
+        await rejects(async () => await ccdb.getObjectsTreeList(), new Error(`${error.message || error}`));
+      });
+    });
+
     suite('`getObjectVersions()` tests', () => {
       test('should successfully return a list of versions for a specific object', async () => {
         const ccdb = new CcdbService(ccdbConfig);

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -52,7 +52,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
 
   await testParent.test('should sort list of histograms by name in descending order', async () => {
     await page.locator(SORTING_BUTTON_PATH).click();
-    const sortingByNameOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(4)';
+    const sortingByNameOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(2)';
     await page.locator(sortingByNameOptionPath).click();
 
     const sorted = await page.evaluate(() => ({
@@ -67,7 +67,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
 
   await testParent.test('should sort list of histograms by name in ascending order', async () => {
     await page.locator(SORTING_BUTTON_PATH).click();
-    const sortingByNameOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(3)';
+    const sortingByNameOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(1)';
     await page.locator(sortingByNameOptionPath).click();
     const sorted = await page.evaluate(() => ({
       list: window.model.object.currentList,
@@ -77,34 +77,6 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
     strictEqual(sorted.sort.order, 1);
     strictEqual(sorted.sort.field, 'name');
     strictEqual(sorted.list[0].name, 'qc/test/object/1');
-  });
-
-  await testParent.test('should sort list of histograms by created time in descending order', async () => {
-    await page.locator(SORTING_BUTTON_PATH).click();
-    const sortingByCreatedTimeOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(2)';
-    await page.locator(sortingByCreatedTimeOptionPath).click();
-    const sorted = await page.evaluate(() => ({
-      list: window.model.object.currentList,
-      sort: window.model.object.sortBy,
-    }));
-    strictEqual(sorted.sort.title, 'Created Time');
-    strictEqual(sorted.sort.order, -1);
-    strictEqual(sorted.sort.field, 'createTime');
-    strictEqual(sorted.list[0].name, 'qc/test/object/2');
-  });
-
-  await testParent.test('should sort list of histograms by created time in ascending order', async () => {
-    await page.locator(SORTING_BUTTON_PATH).click();
-    const sortingByCreatedTimeOptionPath = 'header > div > div:nth-child(3) > div > div > a:nth-child(1)';
-    await page.locator(sortingByCreatedTimeOptionPath).click();
-    const sorted = await page.evaluate(() => ({
-      list: window.model.object.currentList,
-      sort: window.model.object.sortBy,
-    }));
-    strictEqual(sorted.sort.title, 'Created Time');
-    strictEqual(sorted.sort.order, 1);
-    strictEqual(sorted.sort.field, 'createTime');
-    strictEqual(sorted.list[0].name, 'qc/test/object/2');
   });
 
   await testParent.test('should have filtered results on input search', async () => {

--- a/QualityControl/test/setup/seeders/ccdbObjects.js
+++ b/QualityControl/test/setup/seeders/ccdbObjects.js
@@ -41,3 +41,9 @@ export const objects = [
     [VALID_UNTIL]: new Date('2023-12-04').valueOf(),
   },
 ];
+
+export const subfolders = [
+  'qc/test/object/1',
+  'qc/test/object/2',
+  'qc/test/object/11',
+];

--- a/QualityControl/test/setup/testSetupForCcdb.js
+++ b/QualityControl/test/setup/testSetupForCcdb.js
@@ -18,7 +18,7 @@ import path from 'path';
 
 import { CCDB_FILTER_FIELDS, CCDB_MONITOR, CCDB_VERSION_KEY } from './../../lib/services/ccdb/CcdbConstants.js';
 import { config } from './../config.js';
-import { objects } from './seeders/ccdbObjects.js';
+import { objects, subfolders } from './seeders/ccdbObjects.js';
 import { MOCK_OBJECT_DETAILS_RESPONSE, MOCK_OBJECT_IDENTIFICATION_RESPONSE, MOCK_OBJECT_VERSIONS_RESPONSE }
   from './seeders/object-view/mock-object-view.js';
 import { CCDB_MOCK_VERSION } from './seeders/ccdbVersion.js';
@@ -26,6 +26,8 @@ import { CCDB_MOCK_VERSION } from './seeders/ccdbVersion.js';
 const CCDB_URL = `${config.ccdb.protocol}://${config.ccdb.hostname}:${config.ccdb.port}`;
 const CCDB_API_PATH_LATEST = `/latest/${config.ccdb.prefix}`;
 const CCDB_API_PATH_OBJECT_IDENTIFICATION = '/latest/qc/test/object/1';
+const CCDB_API_PATH_TREE = `/tree/${config.ccdb.prefix}`;
+const CCDB_API_PATH_TREE_OBJECT_IDENTIFICATION = '/tree/qc/test/object/1';
 const CCDB_API_PATH_OBJECT_DETAILS =
 '/qc/test/object/1/1656072357492/016fa8ac-f3b6-11ec-b9a9-c0a80209250c';
 const CCDB_API_DOWNLOAD_ROOT_OBJECT = {
@@ -65,6 +67,14 @@ export const initializeNockForCcdb = () => {
     });
 
   nock(CCDB_URL, {
+    reqheaders: { Accept: 'application/json' },
+  }).persist()
+    .get(`${CCDB_API_PATH_TREE}.*`)
+    .reply(200, {
+      subfolders,
+    });
+
+  nock(CCDB_URL, {
     reqheaders: {
       Accept: 'application/json',
       'X-Filter-Fields': `${PATH},${ID},${VALID_FROM},${VALID_UNTIL}`,
@@ -73,6 +83,17 @@ export const initializeNockForCcdb = () => {
     .get(CCDB_API_PATH_OBJECT_IDENTIFICATION)
     .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
     .get(`${CCDB_API_PATH_LATEST}/object/1`)
+    .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE);
+
+  nock(CCDB_URL, {
+    reqheaders: {
+      Accept: 'application/json',
+      'X-Filter-Fields': `${PATH},${ID},${VALID_FROM},${VALID_UNTIL}`,
+    },
+  }).persist()
+    .get(CCDB_API_PATH_TREE_OBJECT_IDENTIFICATION)
+    .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
+    .get(`${CCDB_API_PATH_TREE}/object/1`)
     .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE);
 
   nock(CCDB_URL, {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

In this PR, the 'latest' API from CCDB is swapped out with the /tree API. 

It removes the sort by date option from the ObjectTree page header, removes tests from the previous implementation, and adds new tests. 