### PR TITLE
[OGUI-1672] Add support for NewEnvironmentAsync

### DIFF
--- a/Control/lib/services/Environment.service.js
+++ b/Control/lib/services/Environment.service.js
@@ -175,6 +175,49 @@ class EnvironmentService {
   }
 
   /**
+   * Method to create a NewEnvironmentAsync request using the gRPC client. 
+   * Service is considered low-level. It is assumed that the caller has already checked the validity of the parameters.
+   * @param {NewEnvironmentRequest - o2control.proto} request - partial request object with information needed to create the environment
+   * @param {string} request.workflowTemplate - name in format `repository/revision/template`
+   * @param {Object<string, string>} request.userVars - KV string pairs to define environment configuration
+   * @param {User} request.user - user that requested the environment creation
+   * @returns {Promise.<{EnvironmentInfo}, Error>} - if operation was a success ECS will return a partialEnvironmentInfo object
+   * @throws {Error} - if the operation failed
+   */
+  async newEnvironmentAsync({ workflowTemplate, userVars, user }) {
+    let environment = undefined;
+    try {
+      ({ environment } = await this._coreGrpc.NewEnvironmentAsync({
+        workflowTemplate,
+        vars: userVars,
+        autoTransition: false,
+        requestUser: user.toEcsFormat()
+      })
+      );
+    } catch (grpcError) {
+      throw grpcErrorToNativeError(grpcError);
+    }
+
+    try {
+      const detectorsAll = this._apricotGrpc.detectors ?? [];
+      const hostsByDetector = this._apricotGrpc.hostsByDetector ?? {};
+      const environmentInfo = EnvironmentInfoAdapter.toEntity(environment, '', detectorsAll, hostsByDetector);
+      /**
+       * Transition is not yet started as per ECS, but we set the state to DEPLOYING to ensure that the UI
+       * is updated accordingly. The state will be updated once the environment is created and the transition
+       * is finished.
+       * @type {EnvironmentInfo}
+       * @property {string} currentTransition - the current transition of the environment
+       */
+      environmentInfo.currentTransition = environmentInfo.currentTransition || 'DEPLOY';
+      this._environmentCacheService.addOrUpdateEnvironment(environmentInfo, true);
+      return environmentInfo;
+    } catch (error) {
+      throw new Error(`Unable to process payload from NewEnvironmentAsync response from ECS ${error}`);
+    }
+  }
+
+  /**
    * Given the workflowTemplate and variables configuration, it will generate a unique string and send all to AliECS to create a
    * new auto transitioning environment
    * @param {String} workflowTemplate - name in format `repository/revision/template`

--- a/Control/lib/services/Environment.service.js
+++ b/Control/lib/services/Environment.service.js
@@ -84,7 +84,7 @@ class EnvironmentService {
           // Issue reported: OCTRL-1012
           environment = await this.getEnvironment(id, '', false);
         } catch (error) {
-          this._logger.error(`Failed to retrieve environment ${id}: ${error}`);
+          this._logger.errorMessage(`Failed to retrieve environment ${id}: ${error}`);
         }
         if (environment) {
           if (shouldUpdateCache) {
@@ -103,7 +103,6 @@ class EnvironmentService {
       this._broadcastService.broadcast(ENVIRONMENTS_OVERVIEW, [...this._environmentCacheService.environments.values()]);
       return environmentList;
     } catch (error) {
-      console.log(error);
       this._logger.errorMessage(error);
     }
   }
@@ -198,23 +197,19 @@ class EnvironmentService {
       throw grpcErrorToNativeError(grpcError);
     }
 
-    try {
-      const detectorsAll = this._apricotGrpc.detectors ?? [];
-      const hostsByDetector = this._apricotGrpc.hostsByDetector ?? {};
-      const environmentInfo = EnvironmentInfoAdapter.toEntity(environment, '', detectorsAll, hostsByDetector);
-      /**
-       * Transition is not yet started as per ECS, but we set the state to DEPLOYING to ensure that the UI
-       * is updated accordingly. The state will be updated once the environment is created and the transition
-       * is finished.
-       * @type {EnvironmentInfo}
-       * @property {string} currentTransition - the current transition of the environment
-       */
-      environmentInfo.currentTransition = environmentInfo.currentTransition || 'DEPLOY';
-      this._environmentCacheService.addOrUpdateEnvironment(environmentInfo, true);
-      return environmentInfo;
-    } catch (error) {
-      throw new Error(`Unable to process payload from NewEnvironmentAsync response from ECS ${error}`);
-    }
+    const detectorsAll = this._apricotGrpc.detectors ?? [];
+    const hostsByDetector = this._apricotGrpc.hostsByDetector ?? {};
+    const environmentInfo = EnvironmentInfoAdapter.toEntity(environment, '', detectorsAll, hostsByDetector);
+    /**
+     * Transition is not yet started as per ECS, but we set the state to DEPLOYING to ensure that the UI
+     * is updated accordingly. The state will be updated once the environment is created and the transition
+     * is finished.
+     * @type {EnvironmentInfo}
+     * @property {string} currentTransition - the current transition of the environment
+     */
+    environmentInfo.currentTransition = environmentInfo.currentTransition || 'DEPLOY';
+    this._environmentCacheService.addOrUpdateEnvironment(environmentInfo, true);
+    return environmentInfo;
   }
 
   /**

--- a/Control/test/lib/services/mocha-environment.service.test.js
+++ b/Control/test/lib/services/mocha-environment.service.test.js
@@ -195,13 +195,6 @@ describe('EnvironmentService test suite', () => {
       );
     });
 
-    it('should throw error due to issue encountered during conversion to environment info of response', async () => {
-      await assert.rejects(
-        envService.newEnvironmentAsync({ workflowTemplate: 'MISSING_ID_CASE', user }),
-        new InvalidInputError(`Unable to process payload from NewEnvironmentAsync response from ECS TypeError: Cannot destructure property 'id' of 'environment' as it is undefined.`)
-      );
-    });
-
     it('should successfully return environment id if successfully created', async () => {
       const environmentTransitioned = await envService.newEnvironmentAsync({ workflowTemplate: 'github/template/1.1.0', userVars: {keyA: 'keyA'}, user });
       assert.strictEqual(environmentTransitioned.id, ENVIRONMENT_VALID);

--- a/Control/test/lib/services/mocha-environment.service.test.js
+++ b/Control/test/lib/services/mocha-environment.service.test.js
@@ -15,7 +15,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-const { NotFoundError, GrpcErrorCodes, UnauthorizedAccessError } = require('@aliceo2/web-ui');
+const { NotFoundError, GrpcErrorCodes, UnauthorizedAccessError, InvalidInputError } = require('@aliceo2/web-ui');
 
 const { EnvironmentService } = require('./../../../lib/services/Environment.service.js');
 const { User } = require('./../../../lib/dtos/User.js');
@@ -62,6 +62,17 @@ describe('EnvironmentService test suite', () => {
   }).resolves({ id: ENVIRONMENT_VALID });
   DestroyEnvironmentStub.rejects({code: 1, details: 'Wrong arguments, using default stub reject'});
 
+  const NewEnvironmentAsyncStub = sinon.stub();
+  NewEnvironmentAsyncStub.withArgs(
+    { workflowTemplate: 'BAD', vars: undefined, autoTransition: false, requestUser: user.toEcsFormat() }
+  ).rejects({ code: 3, details: 'Cannot create environment with this template' });
+  NewEnvironmentAsyncStub.withArgs(
+    { workflowTemplate: 'MISSING_ID_CASE', vars: undefined, autoTransition: false, requestUser: user.toEcsFormat() }
+  ).resolves({ id: undefined, state: 'RUNNING', currentRunNumber: 1 });
+  NewEnvironmentAsyncStub.withArgs(
+    { workflowTemplate: 'github/template/1.1.0', vars: {keyA: 'keyA'}, autoTransition: false, requestUser: user.toEcsFormat() }
+  ).resolves({ environment: { id: ENVIRONMENT_VALID, state: 'RUNNING', currentRunNumber: 1 } });
+
   const environmentCacheServiceMock = {
     environments: new Map(),
   };
@@ -71,6 +82,7 @@ describe('EnvironmentService test suite', () => {
       GetEnvironment: GetEnvironmentStub,
       ControlEnvironment: ControlEnvironmentStub,
       DestroyEnvironment: DestroyEnvironmentStub,
+      NewEnvironmentAsync: NewEnvironmentAsyncStub,
     }, { detectors: [], includedDetectors: [] }, {}, {}, environmentCacheServiceMock,
   );
 
@@ -173,5 +185,34 @@ describe('EnvironmentService test suite', () => {
       const environmentTransitioned = await envService.destroyEnvironment(ENVIRONMENT_VALID, { keepTasks: true }, user);
       assert.deepStrictEqual(environmentTransitioned, {id: ENVIRONMENT_VALID})
     });
+  });
+
+  describe(`'newEnvironmentAsync' test suite`, async () => {
+    it('should catch gRPC error and throw native error due to issue encountered when trying to create environment', async () => {
+      await assert.rejects(
+        envService.newEnvironmentAsync({ workflowTemplate: 'BAD', user }, ),
+        new InvalidInputError('Cannot create environment with this template')
+      );
+    });
+
+    it('should throw error due to issue encountered during conversion to environment info of response', async () => {
+      await assert.rejects(
+        envService.newEnvironmentAsync({ workflowTemplate: 'MISSING_ID_CASE', user }),
+        new InvalidInputError(`Unable to process payload from NewEnvironmentAsync response from ECS TypeError: Cannot destructure property 'id' of 'environment' as it is undefined.`)
+      );
+    });
+
+    it('should successfully return environment id if successfully created', async () => {
+      const environmentTransitioned = await envService.newEnvironmentAsync({ workflowTemplate: 'github/template/1.1.0', userVars: {keyA: 'keyA'}, user });
+      assert.strictEqual(environmentTransitioned.id, ENVIRONMENT_VALID);
+      assert.strictEqual(environmentTransitioned.currentTransition, 'DEPLOY');
+    });
+
+    it('should add environment to cache when successfully deployed', async () => {
+      envService._environmentCacheService.addOrUpdateEnvironment = sinon.stub().returns();
+      const environmentTransitioned = await envService.newEnvironmentAsync({ workflowTemplate: 'github/template/1.1.0', userVars: { keyA: 'keyA' }, user });
+      assert.strictEqual(environmentTransitioned.id, ENVIRONMENT_VALID);
+      assert.ok(envService._environmentCacheService.addOrUpdateEnvironment.calledOnce);
+    })
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
- Adds to the environment service the option to call `NewEnvironmentAsync` with the gRPC. 
- The method will also need to convert the received payload to EnvironmentInfo and add to cache due to the fact that ECS is not recognizing the created environment until later in the workflow
- The method also adds a `currentTransition` value as ECS is not defining one
- Adds tests for the newly added method