### PR TITLE
[OGUI-1677] Fix CCDB version retrieval

### DIFF
--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -89,8 +89,10 @@ export class CcdbService {
       throw new Error(`Unable to connect to CCDB due to: ${error}`);
     }
     try {
-      const monitorData = serviceInfo?.[CCDB_MONITOR]?.[this._hostname] ?? [];
-      const version = monitorData[0]?.value ?? 'unknown version';
+      const monitorData = serviceInfo?.[CCDB_MONITOR] ?? {};
+      const [firstKey] = monitorData ? Object.keys(monitorData) : [];
+
+      const version = monitorData[firstKey]?.[0]?.value ?? 'unknown version';
       return { version };
     } catch (error) {
       throw new Error(`Unable to read version of CCDB due to: ${error}`);


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR fixes how we get the CCDB version. Before, it depended on a key that changed between environments, which caused issues. Now it just grabs the first value from `/ccdb_version` , so it works consistently no matter what the key is.