### PR TITLE
[OGUI-1680] Fix bug in object drag and drop and reordering on save

### DIFF
--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -356,8 +356,8 @@ export default class Layout extends Observable {
    * @returns {undefined}
    */
   sortObjectsOfCurrentTab() {
-    this.gridList.items = this.tab.objects;
     if (this.editEnabled) {
+      this.gridList.items = this.tab.objects;
       this.gridList.resizeGrid(this.gridListSize);
     }
   }
@@ -473,13 +473,13 @@ export default class Layout extends Observable {
    * @returns {undefined}
    */
   edit() {
+    this.editEnabled = true;
     this.toggleEditMenu();
     this.model.services.object.listObjects();
     if (!this.item) {
       throw new Error('An item should be loaded before editing it');
     }
     this.setTabInterval(0);
-    this.editEnabled = true;
     this.editOriginalClone = JSON.parse(JSON.stringify(this.item));
     this.editingTabObject = null;
     window.dispatchEvent(new Event('resize'));
@@ -492,8 +492,8 @@ export default class Layout extends Observable {
    * @returns {undefined}
    */
   save() {
-    this.setTabInterval(this.item.autoTabChange);
     this.editEnabled = false;
+    this.setTabInterval(this.item.autoTabChange);
     this.editingTabObject = null;
     this.saveItem();
     this.model.services.layout.getLayoutsByUserId(this.model.session.personid);

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -734,7 +734,9 @@ export default class Layout extends Observable {
       }, time * 1000);
     } else {
       clearInterval(this.tabInterval);
-      this.selectTab(this._tabIndex);
+      if (!this.editEnabled) {
+        this.selectTab(this._tabIndex);
+      }
     }
   }
 

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -592,6 +592,8 @@ export default class Layout extends Observable {
    */
   resizeTabObject(tabObject, w, h) {
     this.gridList.resizeItem(tabObject, { w, h });
+    this.sortObjectsOfCurrentTab();
+
     this.notify();
   }
 

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -212,13 +212,8 @@ const resizeGridTabDropDown = (model, tab) =>
     style: 'cursor: pointer',
     title: 'Resize grid of the tab',
     onchange: (e) => model.layout.resizeGridByXY(e.target.value),
-  }, [
-    h('option', { selected: tab && tab.columns === 1, title: 'Resize layout to 1 columns', value: 1 }, '1 cols'),
-    h('option', { selected: tab && tab.columns === 2, title: 'Resize layout to 2 columns', value: 2 }, '2 cols'),
-    h('option', { selected: tab && tab.columns === 3, title: 'Resize layout to 3 columns', value: 3 }, '3 cols'),
-    h('option', { selected: tab && tab.columns === 4, title: 'Resize layout to 4 columns', value: 4 }, '4 cols'),
-    h('option', { selected: tab && tab.columns === 5, title: 'Resize layout to 5 columns', value: 5 }, '5 cols'),
-  ]);
+  }, [1, 2, 3, 4, 5].map((i) =>
+    h('option', { selected: tab?.columns === i, title: `Resize layout to ${i} columns`, value: 1 }, `${i} cols`)));
 
 /**
  * Single tab button


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR fixes a bug introduced in 3.12.0 where items in edit mode were misaligned when dragging/resizing, and layouts got unexpectedly reordered on save. The issue was caused by checking the editEnabled flag before it was actually set.