### PR TITLE
[OGUI-1679] Improve docs and use of statusComponent from environment readiness

### DIFF
--- a/Control/public/common/environment/environmentReadinessStatus.js
+++ b/Control/public/common/environment/environmentReadinessStatus.js
@@ -74,7 +74,7 @@ export const environmentReadinessStatus = (item, model) => {
   }
 
   return {
-    statusComponent,
+    statusComponent: typeof statusComponent === 'string' ? () => h('', statusComponent) : statusComponent,
     statusMessage,
     styleClasses: classes
   };

--- a/Control/public/common/environment/environmentReadinessStatus.js
+++ b/Control/public/common/environment/environmentReadinessStatus.js
@@ -25,7 +25,7 @@ import { parseOdcStatusPerEnv } from './../utils.js';
  * * ECS finished transitioning and is CONFIGURED
  * @param {EnvironmentInfo} item - Environment to be checked
  * @param {Model} model - Model to be used
- * @returns {{status: {vnode, string}, style: string}}
+ * @returns {{statusComponent: {vnode, string}, styleClasses: string, statusMessage: string|undefined}}
  */
 export const environmentReadinessStatus = (item, model) => {
   const {currentRunNumber, currentTransition, state, userVars} = item;

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -195,7 +195,7 @@ const environmentsTable = (model, list) => {
 const runColumn = (item, model) => {
   const {statusComponent, styleClasses} = environmentReadinessStatus(item, model);
   return h('td', {style: 'text-align: center;'},
-    h('.badge.f4', {class: styleClasses}, statusComponent)
+    h('.badge.f4', { class: styleClasses }, typeof statusComponent === 'function' ? statusComponent() : statusComponent)
   );
 }
 

--- a/Control/public/environment/environmentsPage.js
+++ b/Control/public/environment/environmentsPage.js
@@ -195,7 +195,7 @@ const environmentsTable = (model, list) => {
 const runColumn = (item, model) => {
   const {statusComponent, styleClasses} = environmentReadinessStatus(item, model);
   return h('td', {style: 'text-align: center;'},
-    h('.badge.f4', { class: styleClasses }, typeof statusComponent === 'function' ? statusComponent() : statusComponent)
+    h('.badge.f4', { class: styleClasses }, statusComponent())
   );
 }
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* fixes a bug in which statusComponent was returned as function but the client was not calling it, thus being displayed as arrow function
* documentation for usage of statusComponent has been udpated