### PR TITLE
[OGUI-1678] Set task attribute `isCritical` to `false` by default to protect against lack of optional

### DIFF
--- a/Control/lib/adapters/ShortTaskInfoAdapter.js
+++ b/Control/lib/adapters/ShortTaskInfoAdapter.js
@@ -39,7 +39,7 @@ class ShortTaskInfoAdapter {
       deploymentInfo,
       pid,
       sandboxStdout,
-      critical = true,
+      critical = false, // set to false by default to workaround the lack of optional usage in proto
     } = task;
 
     /**

--- a/Control/test/lib/adapters/mocha-short-task-info.adapter.test.js
+++ b/Control/test/lib/adapters/mocha-short-task-info.adapter.test.js
@@ -13,25 +13,95 @@
 */
 /* eslint-disable max-len */
 
-const assert = require('assert');
+const { strictEqual } = require('assert');
 const { ShortTaskInfoAdapter } = require('../../../lib/adapters/ShortTaskInfoAdapter');
+const { TaskState } = require('../../../lib/common/taskState.enum.js');
 
 describe('ShortTaskInfoAdapter test suite', () => {
   describe('_getShortName() - tests', async () => {
     it('should successfully replace task name if regex is matched', async () => {
       const tagModified = ShortTaskInfoAdapter._getShortName('github.com/AliceO2Group/ControlWorkflows/tasks/readout@4726d80d4bf43fe65133d20d83831752049c8dbe#54c7c9b0-ffbe-11e9-97fb-02163e018d4a');
-      assert.strictEqual(tagModified, 'readout');
+      strictEqual(tagModified, 'readout');
     });
 
     it('should not replace task name due to regex not matching the name (missing tasks/ group)', async () => {
       const nameNotModified = ShortTaskInfoAdapter._getShortName('github.com/AliceO2Group/ControlWorkflows/readout@4726d80d4bf43fe65133d20d83831752049c8dbe#54c7c9b0-ffbe-11e9-97fb-02163e018d4a');
-      assert.strictEqual(nameNotModified, 'github.com/AliceO2Group/ControlWorkflows/readout@4726d80d4bf43fe65133d20d83831752049c8dbe#54c7c9b0-ffbe-11e9-97fb-02163e018d4a');
+      strictEqual(nameNotModified, 'github.com/AliceO2Group/ControlWorkflows/readout@4726d80d4bf43fe65133d20d83831752049c8dbe#54c7c9b0-ffbe-11e9-97fb-02163e018d4a');
     });
 
     it('should not replace task name due to regex not matching the name (missing @ character)', async () => {
       const taskFullName = 'github.com/AliceO2Group/ControlWorkflows/tasks/readout4726d80d4bf43fe65133d20d83831752049c8dbe#54c7c9b0-ffbe-11e9-97fb-02163e018d4a';
       const nameNotModified = ShortTaskInfoAdapter._getShortName(taskFullName);
-      assert.strictEqual(nameNotModified, taskFullName);
+      strictEqual(nameNotModified, taskFullName);
+    });
+  });
+
+  describe('toEntity() - tests', () => {
+    it('should map all fields correctly from a typical task object', function () {
+      const task = {
+        name: 'tasks/MyTask@host',
+        locked: true,
+        taskId: 42,
+        status: 'RUNNING',
+        state: TaskState.RUNNING,
+        className: 'SomeClass',
+        deploymentInfo: { hostname: 'host' },
+        pid: 1234,
+        sandboxStdout: '/tmp/stdout',
+        critical: true
+      };
+      const entity = ShortTaskInfoAdapter.toEntity(task);
+      strictEqual(entity.id, 42);
+      strictEqual(entity.taskId, 42);
+      strictEqual(entity.name, 'MyTask');
+      strictEqual(entity.locked, true);
+      strictEqual(entity.hostname, 'host');
+      strictEqual(entity.status, 'RUNNING');
+      strictEqual(entity.state, TaskState.RUNNING);
+      strictEqual(entity.className, 'SomeClass');
+      strictEqual(entity.pid, 1234);
+      strictEqual(entity.sandboxStdout, '/tmp/stdout');
+      strictEqual(entity.isCritical, true);
+    });
+
+    it('should default missing fields', function () {
+      const task = {
+        name: 'tasks/OtherTask@host',
+        locked: false,
+        taskId: 7,
+        deploymentInfo: undefined,
+        pid: undefined,
+        sandboxStdout: undefined
+      };
+      const entity = ShortTaskInfoAdapter.toEntity(task);
+      strictEqual(entity.status, 'UNKNOWN');
+      strictEqual(entity.state, TaskState.UNKNOWN);
+      strictEqual(entity.hostname, '');
+      strictEqual(entity.isCritical, false);
+    });
+
+    it('should set state to ERROR_CRITICAL if state is ERROR and critical is true', function () {
+      const task = {
+        name: 'tasks/FailTask@host',
+        locked: false,
+        taskId: 99,
+        state: TaskState.ERROR,
+        critical: true
+      };
+      const entity = ShortTaskInfoAdapter.toEntity(task);
+      strictEqual(entity.state, TaskState.ERROR_CRITICAL);
+    });
+
+    it('should not set state to ERROR_CRITICAL if state is ERROR and critical is false', function () {
+      const task = {
+        name: 'tasks/FailTask@host',
+        locked: false,
+        taskId: 99,
+        state: TaskState.ERROR,
+        critical: false
+      };
+      const entity = ShortTaskInfoAdapter.toEntity(task);
+      strictEqual(entity.state, TaskState.ERROR);
     });
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the default value of `critical` that comes via proto with `false` as to protect against ECS not adding it and lack of optioanl