### PR TITLE
Potential fix for code scanning alert no. 169: Prototype-polluting function

### DIFF
--- a/Control/lib/services/environment/EnvironmentCache.service.js
+++ b/Control/lib/services/environment/EnvironmentCache.service.js
@@ -91,12 +91,21 @@ class EnvironmentCacheService {
       const keys = attributePath.split('.');
       for (let i = 0; i < keys.length - 1; i++) {
         const key = keys[i];
+        if (key === "__proto__" || key === "constructor") {
+          this._logger.warnMessage(`Attempt to modify restricted property '${key}' in environment with id ${id}.`);
+          return null;
+        }
         if (!current[key]) {
           current[key] = {};
-        }
-        current = current[key];
-      }
-      current[keys[keys.length - 1]] = value;
+       }
+       current = current[key];
+     }
+     const finalKey = keys[keys.length - 1];
+     if (finalKey === "__proto__" || finalKey === "constructor") {
+       this._logger.warnMessage(`Attempt to modify restricted property '${finalKey}' in environment with id ${id}.`);
+       return null;
+     }
+     current[finalKey] = value;
 
       this._environments.set(id, cachedEnvironment);
       return cachedEnvironment;


### PR DESCRIPTION
Potential fix for [https://github.com/AliceO2Group/WebUi/security/code-scanning/169](https://github.com/AliceO2Group/WebUi/security/code-scanning/169)

To fix the issue, we need to prevent prototype pollution by validating the keys in the `keys` array before assigning them to the `current` object. Specifically:
1. Block dangerous property names like `__proto__` and `constructor` from being used as keys.
2. Ensure that only safe keys are processed during the recursive assignment.

This can be achieved by adding a check inside the loop (line 93) to skip any key that matches `__proto__` or `constructor`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
