### PR TITLE
[OGUI-1461] Store in-progress adv configuration params for user-edit to prevent reset from notify of parents

### DIFF
--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -74,7 +74,7 @@ export default class Workflow extends Observable {
       textArea: {
         value: '',
       }
-    }
+    };
     this.dom = {
       keyInput: '',
       keyValueArea: ''

--- a/Control/public/workflow/Workflow.js
+++ b/Control/public/workflow/Workflow.js
@@ -66,13 +66,21 @@ export default class Workflow extends Observable {
     this.READOUT_PREFIX = PREFIX.READOUT;
     this.QC_PREFIX = PREFIX.QC;
 
+    this._advancedInputPanel = {
+      pair: {
+        key: '',
+        value: ''
+      },
+      textArea: {
+        value: '',
+      }
+    }
     this.dom = {
       keyInput: '',
       keyValueArea: ''
     };
 
     this.advErrorPanel = [];
-    this.kvPairsString = ''; // variable stored for Adv Config Panel
   }
 
   /**
@@ -301,6 +309,25 @@ export default class Workflow extends Observable {
   }
 
   /**
+   * Method to add a new KV Pair to the variables form for creating a new environment
+   * It will take the current value from the input field and add it to the variables
+   * @return {void}
+   */
+  addVariableFromInput() {
+    const keyToAdd = this.getPairInputKey();
+
+    const currentValue = this.getPairInputValue();
+    const valueWithoutNewline = currentValue?.endsWith('\n') ? currentValue.slice(0, -1) : currentValue;
+    
+    this.addVariable(keyToAdd, valueWithoutNewline, true);
+
+    this.setPairInputKey('');
+    this.setPairInputValue('');
+    
+    this.dom.keyInput.focus();
+  }
+
+  /**
    * Given a KV Pairs as a String, attempt to add
    * each key and value to the panel of KV pairs configuration
    * @param {String} kvPairs
@@ -316,7 +343,7 @@ export default class Workflow extends Observable {
       }
     });
     if (errors.length === 0) {
-      this.kvPairsString = '';
+      this._advancedInputPanel.textArea.value = '';
       this.model.notification.show(
         'Variables have been successfully imported in the configuration panels', 'success', 1000
       );
@@ -706,5 +733,56 @@ export default class Workflow extends Observable {
       delete vars['qc_config_uri_pre'];
     }
     return {variables: vars, ok: true, message: ''};
+  }
+
+  /**
+   * Get method for retrieving only the key from the advanced input panel
+   * @return {string}
+   */
+  getPairInputKey() {
+    return this._advancedInputPanel?.pair?.key ?? '';
+  }
+
+  /**
+   * Set method for updating the key of the pair input in the advanced input panel
+   * @return {void}
+   */
+  setPairInputKey(value) {
+    this._advancedInputPanel.pair.key = value;
+    this.notify();
+  }
+
+  /**
+   * Get method for retrieving only the value from the advanced input panel
+   * @return {string}
+   */
+  getPairInputValue() {
+    return this._advancedInputPanel?.pair?.value ?? '';
+  }
+
+  /**
+   * Set method for updating the value of the pair input in the advanced input panel
+   * @return {void}
+   */
+  setPairInputValue(value) {
+    this._advancedInputPanel.pair.value = value;
+    this.notify();
+  }
+
+  /**
+   * Get method for retrieving the value of the text area in the advanced input panel
+   * @return {string}
+   */
+  getTextAreaValue() {
+    return this._advancedInputPanel?.textArea?.value ?? '';
+  }
+
+  /**
+   * Set method for updating the text area value in the advanced input panel
+   * @return {void}
+   */
+  setTextAreaValue(value) {
+    this._advancedInputPanel.textArea.value = value;
+    this.notify();
   }
 }

--- a/Control/public/workflow/panels/variables/advancedPanel.js
+++ b/Control/public/workflow/panels/variables/advancedPanel.js
@@ -65,6 +65,7 @@ const addKVInputList = (workflow) =>
           type: 'text',
           value: workflow.form.variables[key],
           oninput: (e) => workflow.addVariable(key, e.target.value, true),
+          // the "onchange" trigger is used to update the variable same as the "oninput" but with the check that the value is not empty
           onchange: (e) => workflow.addVariable(key, e.target.value, false)
         })),
         h('.ph2.danger.actionable-icon', {

--- a/Control/public/workflow/panels/variables/advancedPanel.js
+++ b/Control/public/workflow/panels/variables/advancedPanel.js
@@ -64,7 +64,8 @@ const addKVInputList = (workflow) =>
         }, h('input.form-control', {
           type: 'text',
           value: workflow.form.variables[key],
-          onchange: (e) => workflow.addVariable(key, e.target.value, true)
+          oninput: (e) => workflow.addVariable(key, e.target.value, true),
+          onchange: (e) => workflow.addVariable(key, e.target.value, false)
         })),
         h('.ph2.danger.actionable-icon', {
           id: `removeKey${key}`,
@@ -78,17 +79,15 @@ const addKVInputList = (workflow) =>
  * @return {vnode}
  */
 const addKVInputPair = (workflow) => {
-  let keyString = '';
-  let valueString = '';
   return h('.pv2.flex-row', [
     h('.w-33.ph1', {
     }, h('input.form-control', {
       type: 'text',
       id: 'keyInputField',
       placeholder: 'key',
-      value: keyString,
+      value: workflow.getPairInputKey(),
       oncreate: ({dom}) => workflow.dom.keyInput = dom,
-      oninput: (e) => keyString = e.target.value
+      oninput: (e) => workflow.setPairInputKey(e.target.value)
     })),
     h('.ph1', {
       style: 'width:60%;',
@@ -96,23 +95,18 @@ const addKVInputPair = (workflow) => {
       placeholder: 'value',
       id: 'valueTextAreaField',
       style: 'height: 2em; resize: vertical',
-      value: valueString,
-      oninput: (e) => valueString = e.target.value,
+      value: workflow.getPairInputValue(),
+      oninput: (e) => workflow.setPairInputValue(e.target.value),
       onkeyup: (e) => {
         if (e.keyCode === 13) {
-          // last character needs removing due to new line being added by `Enter` press
-          workflow.addVariable(keyString, valueString.slice(0, -1));
-          workflow.dom.keyInput.focus();
+          workflow.addVariableFromInput();
         }
       }
     })),
     h('.ph2.actionable-icon', {
       title: 'Add (key,value) variable',
       id: 'addKVPairButton',
-      onclick: () => {
-        workflow.addVariable(keyString, valueString);
-        workflow.dom.keyInput.focus();
-      }
+      onclick: () => workflow.addVariableFromInput(),
     }, iconPlus())
   ])
 };
@@ -131,17 +125,17 @@ const addListOfKvPairs = (workflow) => {
       id: 'kvTextArea',
       rows: 7,
       style: 'resize: vertical',
-      value: workflow.kvPairsString,
+      value: workflow.getTextAreaValue(),
       placeholder: 'e.g.\n{\n\t"key1": "value1",\n\t"key2": "value2"\n}',
       oncreate: ({dom}) => workflow.dom.keyValueArea = dom,
-      oninput: (e) => workflow.kvPairsString = e.target.value
+      oninput: (e) => workflow.setTextAreaValue(e.target.value),
     })
     ),
     h('.ph2.actionable-icon', {
       title: 'Add list of (key,value) variables',
       id: 'addKVListButton',
       onclick: () => {
-        workflow.addVariableJSON(workflow.kvPairsString);
+        workflow.addVariableJSON(workflow.getTextAreaValue());
         workflow.dom.keyValueArea.focus();
       }
     }, iconPlus())

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -337,7 +337,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
 
     await page.evaluate(() => document.querySelector('#addKVListButton').click())
     const {variables, areaString} = await page.evaluate(() => {
-      return {variables: window.model.workflow.form.variables, areaString: window.model.workflow.kvPairsString};
+      return {variables: window.model.workflow.form.variables, areaString: window.model.workflow.getTextAreaValue()};
     });
     assert.deepStrictEqual(variables, currentVariables, 'diff vars');
     assert.strictEqual(areaString, toBeTyped, 'dif area')


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the KV input and text area fields to store the currently added/update user inputs in the model
* this is needed as the parent model would reset the values to empty in case of events sent from back-end that would update the page