### PR TITLE
[OGUI-1694] Enable browser notifications for first task of an environment going into ERROR or ERROR_CRITICAL

### DIFF
--- a/Control/lib/kafka/AliEcsSynchronizer.js
+++ b/Control/lib/kafka/AliEcsSynchronizer.js
@@ -223,9 +223,9 @@ class AliEcsSynchronizer {
       );
       return;
     }
-    const { timestamp: timestampInt64, taskEvent: taskEventProto } = eventMessage;
+    const { timestamp: timestampInt64 } = eventMessage;
     const timestamp = adaptInt64ToNumber(timestampInt64);
-    const taskEvent = taskEventAdapter(taskEventProto);
+    const taskEvent = taskEventAdapter(eventMessage);
     this._eventEmitter.emit(TASKS_TRACK, {timestamp, taskEvent});
   }
 }

--- a/Control/lib/services/environment/EnvironmentCache.service.js
+++ b/Control/lib/services/environment/EnvironmentCache.service.js
@@ -13,7 +13,7 @@
 */
 
 const { LogManager } = require('@aliceo2/web-ui');
-const { BroadcastKeys: { ENVIRONMENT_EVENTS, ENVIRONMENTS_OVERVIEW } } = require('./../../common/broadcastKeys.enum');
+const { BroadcastKeys: { ENVIRONMENT_EVENTS, ENVIRONMENTS_OVERVIEW, NOTIFICATION } } = require('./../../common/broadcastKeys.enum');
 const {
   EmitterKeys: {
     ENVIRONMENTS_TRACK, INTEGRATED_SERVICES_TRACK, TASKS_TRACK
@@ -166,7 +166,7 @@ class EnvironmentCacheService {
           const environment = JSON.parse(JSON.stringify(this._environments.get(environmentId)));
           environment.firstTaskInError = taskEvent;
           this._environments.set(environmentId, environment);
-          this._broadcastService.broadcast(ENVIRONMENTS_OVERVIEW, [...this._environments.values()]);
+          this._broadcastService.broadcast(NOTIFICATION, taskEvent);
         }
       });
   }

--- a/Control/lib/services/environment/EnvironmentCache.service.js
+++ b/Control/lib/services/environment/EnvironmentCache.service.js
@@ -13,7 +13,9 @@
 */
 
 const { LogManager } = require('@aliceo2/web-ui');
-const { BroadcastKeys: { ENVIRONMENT_EVENTS, ENVIRONMENTS_OVERVIEW, NOTIFICATION } } = require('./../../common/broadcastKeys.enum');
+const { BroadcastKeys: {
+  ENVIRONMENT_EVENTS, ENVIRONMENTS_OVERVIEW, NOTIFICATION
+} } = require('./../../common/broadcastKeys.enum');
 const {
   EmitterKeys: {
     ENVIRONMENTS_TRACK, INTEGRATED_SERVICES_TRACK, TASKS_TRACK

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -166,7 +166,7 @@ export default class Model extends Observable {
       case BroadcastKeys.PADLOCK_UPDATE:
         this.lock.padlockState = message.payload;
         break;
-      case BroadcastKeys.NOTIFICATION:
+      case BroadcastKeys.NOTIFICATION: {
         const { payload: task } = message;
         if (task?.taskId) {
           // Notification is for the first task in error from an environment
@@ -176,8 +176,8 @@ export default class Model extends Observable {
             url: `?page=environment&id=${task.environmentId}`
           });
         }
-        
         break;
+      }
       case BroadcastKeys.RESOURCES_CLEANUP:
         this.task.setResourcesRequest(message.payload);
         break;

--- a/Control/public/Model.js
+++ b/Control/public/Model.js
@@ -110,7 +110,7 @@ export default class Model extends Observable {
     // General visuals
     this.accountMenuEnabled = false;
     this.sideBarMenu = true;
-
+    
     this.init();
   }
 
@@ -153,6 +153,7 @@ export default class Model extends Observable {
     if (this.detectors.selected || this.session.role == ROLES.Guest) {
       this.handleLocationChange();
     }
+    this.requestBrowserNotificationPermissions()
     this.notify();
   }
 
@@ -166,7 +167,16 @@ export default class Model extends Observable {
         this.lock.padlockState = message.payload;
         break;
       case BroadcastKeys.NOTIFICATION:
-        this.showNativeNotification(JSON.parse(message.payload));
+        const { payload: task } = message;
+        if (task?.taskId) {
+          // Notification is for the first task in error from an environment
+          this.showNativeNotification({
+            title: `TASK in ${task.state ?? 'unknown'} state`,
+            body: `Task ${task.id} in environment ${task.environmentId} is in ${task.state ?? 'unknown'} state`,
+            url: `?page=environment&id=${task.environmentId}`
+          });
+        }
+        
         break;
       case BroadcastKeys.RESOURCES_CLEANUP:
         this.task.setResourcesRequest(message.payload);
@@ -357,9 +367,9 @@ export default class Model extends Observable {
    */
   showNativeNotification(message) {
     const notification = new Notification(message.title, {body: message.body, icon: '/o2_icon.png'});
-    notification.onclick = function(event) {
+    notification.onclick = (event) => {
       event.preventDefault();
-      window.open(message.url, '_blank');
+      this.router.go(message.url, '_blank');
     }
   }
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* initializes the GUI by requesting user permissions to receive notifications if not enabled already
* displays browser notification for when a task of an environment goes first (task) into error