### PR TITLE
[OGUI-1706] Fix layout list sync after isOfficial update between 'My layouts' and 'All layouts'

### DIFF
--- a/QualityControl/public/folder/model/FolderModel.js
+++ b/QualityControl/public/folder/model/FolderModel.js
@@ -81,16 +81,22 @@ export default class FolderModel extends Observable {
   }
 
   /**
-   * Adds a new item to the folder's list if it's in a success state
-   * @param {object} item - The item to add to the folder
+   * Adds or updates an item in the folder's list if it's in a success state.
+   * If an equivalent item exists (based on equals() method), it will be replaced.
+   * @param {object} item - The item to add/update in the folder
    * @returns {undefined}
    */
-  push(item) {
+  set(item) {
     this._list.match({
       Success: (list) => {
-        list.push(item);
-        this.notify();
+        const index = list.findIndex((listItem) => listItem.equals(item)); // equals based on id
+        if (index >= 0) {
+          list[index] = item;
+        } else {
+          list.push(item);
+        }
         item.bubbleTo(this);
+        this.notify();
       },
       Other: () => {},
     });

--- a/QualityControl/public/pages/layoutListView/model/LayoutCardModel.js
+++ b/QualityControl/public/pages/layoutListView/model/LayoutCardModel.js
@@ -15,7 +15,6 @@
 import { UserRole } from './../../../library/userRole.enum.js';
 import { hasMinimumRoleAccess } from '../../../common/utils.js';
 import { Observable } from '/js/src/index.js';
-import { RequestFields } from '../../../common/RequestFields.enum.js';
 
 /**
  * Model namespace for LayoutCardModel
@@ -51,8 +50,12 @@ export default class LayoutCardModel extends Observable {
    */
   async toggleOfficial() {
     const layoutService = this.model.services.layout;
-    await layoutService.patchLayout(this.id, { isOfficial: !this.isOfficial });
-    await this.model.services.layout.getLayouts(RequestFields.LAYOUT_CARD);
+
+    const response = await layoutService.patchLayout(this.id, { isOfficial: !this.isOfficial });
+    response.match({
+      Success: () => this._handleOfficialToggle(),
+      Other: () => {},
+    });
   };
 
   /**
@@ -71,5 +74,24 @@ export default class LayoutCardModel extends Observable {
    */
   equals(other) {
     return other instanceof LayoutCardModel && this.id === other.id;
+  }
+
+  /**
+   * Private method to handle the toggling of the layout's official status.
+   * Updates the local state of the layout's official flag and notifies observers.
+   * Also updates the parent layout list model by moving this layout to/from the "Official" category.
+   * @private
+   */
+  _handleOfficialToggle() {
+    this.isOfficial = !this.isOfficial;
+    this.notify();
+
+    const { layoutListModel } = this.model;
+    if (this.isOfficial) {
+      layoutListModel.setLayout(this).in('Official');
+    } else {
+      layoutListModel.removeLayout(this).from('Official');
+    }
+    layoutListModel.setLayout(this).in('All Layouts');
   }
 }

--- a/QualityControl/public/pages/layoutListView/model/LayoutCardModel.js
+++ b/QualityControl/public/pages/layoutListView/model/LayoutCardModel.js
@@ -15,6 +15,7 @@
 import { UserRole } from './../../../library/userRole.enum.js';
 import { hasMinimumRoleAccess } from '../../../common/utils.js';
 import { Observable } from '/js/src/index.js';
+import { RequestFields } from '../../../common/RequestFields.enum.js';
 
 /**
  * Model namespace for LayoutCardModel
@@ -50,12 +51,8 @@ export default class LayoutCardModel extends Observable {
    */
   async toggleOfficial() {
     const layoutService = this.model.services.layout;
-
-    const response = await layoutService.patchLayout(this.id, { isOfficial: !this.isOfficial });
-    response.match({
-      Success: () => this._handleOfficialToggle(),
-      Other: () => {},
-    });
+    await layoutService.patchLayout(this.id, { isOfficial: !this.isOfficial });
+    await this.model.services.layout.getLayouts(RequestFields.LAYOUT_CARD);
   };
 
   /**
@@ -74,23 +71,5 @@ export default class LayoutCardModel extends Observable {
    */
   equals(other) {
     return other instanceof LayoutCardModel && this.id === other.id;
-  }
-
-  /**
-   * Private method to handle the toggling of the layout's official status.
-   * Updates the local state of the layout's official flag and notifies observers.
-   * Also updates the parent layout list model by moving this layout to/from the "Official" category.
-   * @private
-   */
-  _handleOfficialToggle() {
-    this.isOfficial = !this.isOfficial;
-    this.notify();
-
-    const { layoutListModel } = this.model;
-    if (this.isOfficial) {
-      layoutListModel.addLayout(this).to('Official');
-    } else {
-      layoutListModel.removeLayout(this).from('Official');
-    }
   }
 }

--- a/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
+++ b/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
@@ -79,40 +79,4 @@ export default class LayoutListModel extends Observable {
     });
     this.notify();
   }
-
-  /**
-   * Fluent interface for removing layouts
-   * @param {LayoutCardModel} layout - Layout to remove
-   * @returns {object} Object with .from() method
-   */
-  removeLayout(layout) {
-    return {
-
-      /**
-       * Specifies source folder for removal
-       * @param {string} folderName - Folder name
-       */
-      from: (folderName) => {
-        this.folders.get(folderName)?.removeItem(layout);
-      },
-    };
-  }
-
-  /**
-   * Begins the process of adding a layout by returning an intermediate object with .to() method
-   * @param {LayoutCardModel} layout - Layout instance to add
-   * @returns {object} Intermediate object with .to() method
-   */
-  addLayout(layout) {
-    return {
-
-      /**
-       * Completes the add operation by specifying the target folder
-       * @param {string} folderName - Name of the folder to add to
-       */
-      to: (folderName) => {
-        this.folders.get(folderName)?.push(layout);
-      },
-    };
-  }
 }

--- a/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
+++ b/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
@@ -111,7 +111,7 @@ export default class LayoutListModel extends Observable {
        * @param {string} folderName - Name of the folder to add to
        */
       in: (folderName) => {
-        this.folders.get(folderName)?.push(layout);
+        this.folders.get(folderName)?.set(layout);
       },
     };
   }

--- a/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
+++ b/QualityControl/public/pages/layoutListView/model/LayoutListModel.js
@@ -79,4 +79,40 @@ export default class LayoutListModel extends Observable {
     });
     this.notify();
   }
+
+  /**
+   * Fluent interface for removing layouts
+   * @param {LayoutCardModel} layout - Layout to remove
+   * @returns {object} Object with .from() method
+   */
+  removeLayout(layout) {
+    return {
+
+      /**
+       * Specifies source folder for removal
+       * @param {string} folderName - Folder name
+       */
+      from: (folderName) => {
+        this.folders.get(folderName)?.removeItem(layout);
+      },
+    };
+  }
+
+  /**
+   * Begins the process of adding a layout by returning an intermediate object with .to() method
+   * @param {LayoutCardModel} layout - Layout instance to add
+   * @returns {object} Intermediate object with .to() method
+   */
+  setLayout(layout) {
+    return {
+
+      /**
+       * Completes the add operation by specifying the target folder
+       * @param {string} folderName - Name of the folder to add to
+       */
+      in: (folderName) => {
+        this.folders.get(folderName)?.push(layout);
+      },
+    };
+  }
 }


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Pr that fixes an issue where the 'All layouts' list was not updating after changing the isOfficial state from the 'My layouts' section. This issue was introduced in [PR #2836](https://github.com/AliceO2Group/WebUi/pull/2836), which refactored layout handling logic but missed updating the synchronization between the two layout views.

* The fix replaces the relevant layouts in the All layouts folder after a layout is toggled as official.