### PR TITLE
[OGUI-1720] Fix display logic to hide only timestamp, keep run number visible

### DIFF
--- a/QualityControl/public/layout/view/page.js
+++ b/QualityControl/public/layout/view/page.js
@@ -206,8 +206,7 @@ const drawComponent = (model, tabObject) => h('', { style: 'height:100%; display
     },
   }, draw(model, tabObject, {})),
   objectInfoResizePanel(model, tabObject),
-  model.layout.item && model.layout.item.displayTimestamp
-      && minimalObjectInfo(model, tabObject),
+  minimalObjectInfo(model, tabObject),
 ]);
 
 /**

--- a/QualityControl/public/layout/view/panels/minimalObjectInfo.js
+++ b/QualityControl/public/layout/view/panels/minimalObjectInfo.js
@@ -24,8 +24,11 @@ import { h } from '/js/src/index.js';
  */
 export const minimalObjectInfo = (model, tabObject) => {
   const { name } = tabObject;
-  const lastModified = model.object.getLastModifiedByName(name);
   const runNumber = model.object.getRunNumberByName(name);
+  const lastModified = model.layout.item?.displayTimestamp
+    ? model.object.getLastModifiedByName(name)
+    : '';
+
   return h('.gray-darker.text-center.f6.flex-row.w-100.ph2', {
     style: 'height:3em;justify-content:center;',
   }, [


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Before this change, toggling off the timestamp in layout view (edit mode) also hid the run number.
Now the component renders the run number always and conditionally shows the timestamp based on the `Display Timestamp` checkbox.