### PR TITLE
[OGUI-1688] Update API endpoint to retrieve list of objects based on filter v2

### DIFF
--- a/QualityControl/lib/QCModel.js
+++ b/QualityControl/lib/QCModel.js
@@ -38,6 +38,11 @@ import { UserRepository } from './repositories/UserRepository.js';
 import { ChartRepository } from './repositories/ChartRepository.js';
 import { initDatabase } from './database/index.js';
 import { SequelizeDatabase } from './database/SequelizeDatabase.js';
+import { objectGetByIdValidationMiddlewareFactory }
+  from './middleware/objects/objectGetByIdValidationMiddlewareFactory.js';
+import { objectsGetValidationMiddlewareFactory } from './middleware/objects/objectsGetValidationMiddlewareFactory.js';
+import { objectGetContentsValidationMiddlewareFactory }
+  from './middleware/objects/objectGetContentsValidationMiddlewareFactory.js';
 
 /**
  * Model initialization for the QCG application
@@ -77,6 +82,10 @@ export const setupQcModel = () => {
 
   const filterController = new FilterController(filterService);
 
+  const objectGetByIdValidation = objectGetByIdValidationMiddlewareFactory(filterService);
+  const objectsGetValidation = objectsGetValidationMiddlewareFactory(filterService);
+  const objectGetContentsValidation = objectGetContentsValidationMiddlewareFactory(filterService);
+
   initializeIntervals(intervalsService, qcObjectService, filterService);
 
   return {
@@ -89,6 +98,9 @@ export const setupQcModel = () => {
     filterController,
     layoutRepository,
     jsonFileService,
+    objectGetByIdValidation,
+    objectsGetValidation,
+    objectGetContentsValidation,
   };
 };
 

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -19,7 +19,6 @@ import { layoutOwnerMiddleware } from './middleware/layouts/layoutOwner.middlewa
 import { layoutIdMiddleware } from './middleware/layouts/layoutId.middleware.js';
 import { layoutServiceMiddleware } from './middleware/layouts/layoutService.middleware.js';
 import { statusComponentMiddleware } from './middleware/status/statusComponent.middleware.js';
-// import { getObjectsValidationMiddleware } from './middleware/objects/ObjectGet.middleWare.js';
 
 /**
  * Adds paths and binds websocket to instance of HttpServer passed

--- a/QualityControl/lib/api.js
+++ b/QualityControl/lib/api.js
@@ -19,6 +19,7 @@ import { layoutOwnerMiddleware } from './middleware/layouts/layoutOwner.middlewa
 import { layoutIdMiddleware } from './middleware/layouts/layoutId.middleware.js';
 import { layoutServiceMiddleware } from './middleware/layouts/layoutService.middleware.js';
 import { statusComponentMiddleware } from './middleware/status/statusComponent.middleware.js';
+// import { getObjectsValidationMiddleware } from './middleware/objects/ObjectGet.middleWare.js';
 
 /**
  * Adds paths and binds websocket to instance of HttpServer passed
@@ -46,11 +47,16 @@ export const setup = (http, ws) => {
     layoutRepository,
     jsonFileService,
     filterController,
+    objectGetByIdValidation,
+    objectsGetValidation,
+    objectGetContentsValidation,
   } = setupQcModel();
   statusService.ws = ws;
-  http.get('/object/:id', objectController.getObjectById.bind(objectController));
-  http.get('/object', objectController.getObjectContent.bind(objectController));
-  http.get('/objects', objectController.getObjects.bind(objectController), { public: true });
+
+  http.get('/object/:id', objectGetByIdValidation, objectController.getObjectById.bind(objectController));
+  http.get('/object', objectGetContentsValidation, objectController.getObjectContent.bind(objectController));
+
+  http.get('/objects', objectsGetValidation, objectController.getObjects.bind(objectController), { public: true });
 
   http.get('/layouts', layoutController.getLayoutsHandler.bind(layoutController));
   http.get('/layout/:id', layoutController.getLayoutHandler.bind(layoutController));

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -31,7 +31,6 @@ export class ObjectController {
      * @type {QCObjectService}
      */
     this._objService = objService;
-    this._logger = LogManager.getLogger('object/controller');
   }
 
   /**

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -44,7 +44,7 @@ export class ObjectController {
     try {
       const { prefix, fields, filters } = req.query;
 
-      const list = await this._objService.retrieveLatestVersionOfObjects(prefix, fields, true, filters);
+      const list = await this._objService.retrieveLatestVersionOfObjects({ prefix, fields, filters });
       res.status(200).json(list);
     } catch (error) {
       const responseError = new Error('Failed to retrieve list of objects latest version');

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -78,6 +78,17 @@ export class ObjectController {
     }
   }
 
+  /**
+   * Using `browse` option, request a list of `last-modified` and `valid-from` for a specified path for an object
+   * Use the first `validFrom` option to make a head request to CCDB; Request which will in turn return object
+   * information and download it locally on CCDB if it is not already done so;
+   * From the information retrieved above, use the location with JSROOT to get a JSON object
+   * Use JSROOT to decompress a ROOT object content and convert it to JSON to be sent back to the client for
+   * interpretation with JSROOT.draw
+   * @param {Request} req - HTTP request object with "query" information
+   * @param {Response} res - HTTP response object to provide information on request
+   * @returns {void}
+   */
   async getObjectById(req, res) {
     try {
       const qcgId = req.params?.id;

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -48,7 +48,7 @@ export class ObjectController {
     } catch (error) {
       const responseError = new Error('Failed to retrieve list of objects latest version');
 
-      logger.errorMessage(`Error validating query parameters: ${error}`);
+      logger.errorMessage(`Error whilst retrieving objects: ${error}`);
       updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
@@ -73,7 +73,7 @@ export class ObjectController {
     } catch (error) {
       const responseError = new Error('Failed to retrieve object content');
 
-      logger.errorMessage(`Error validating query parameters: ${error}`);
+      logger.errorMessage(`Error whilst retrieving object content: ${error}`);
       updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
@@ -99,7 +99,7 @@ export class ObjectController {
     } catch (error) {
       const responseError = new Error('Unable to identify object or read it by qcg id');
 
-      logger.errorMessage(`Error validating query parameters: ${error}`);
+      logger.errorMessage(`Error whilst retrieving object: ${error}`);
       updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -91,10 +91,10 @@ export class ObjectController {
    */
   async getObjectById(req, res) {
     try {
-      const qcgId = req.params?.id;
+      const qcObjectId = req.params.id;
       const { validFrom, filters, id } = req.query;
 
-      const object = await this._objService.retrieveQcObjectByQcgId(qcgId, id, validFrom, filters);
+      const object = await this._objService.retrieveQcObjectByQcgId(qcObjectId, id, validFrom, filters);
       res.status(200).json(object);
     } catch (error) {
       const responseError = new Error('Unable to identify object or read it by qcg id');

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -12,8 +12,9 @@
  * or submit itself to any jurisdiction.
  */
 'use strict';
-import { InvalidInputError, NotFoundError, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
-import { LogManager } from '@aliceo2/web-ui';
+import { LogManager, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
+
+const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/object-ctrl`);
 
 /**
  * Gateway for all QC Objects requests
@@ -40,30 +41,16 @@ export class ObjectController {
    * @returns {void}
    */
   async getObjects(req, res) {
-    const { prefix, fields = [] } = req.query;
-    if (prefix && typeof prefix !== 'string') {
-      updateAndSendExpressResponseFromNativeError(
-        res,
-        new InvalidInputError('Invalid parameters provided: prefix must be of type string'),
-      );
-      return;
-    } else if (!Array.isArray(fields)) {
-      updateAndSendExpressResponseFromNativeError(
-        res,
-        new InvalidInputError('Invalid parameters provided: fields must be of type Array'),
-      );
-      return;
-    } else {
-      try {
-        const list = await this._objService.retrieveLatestVersionOfObjects(prefix, fields);
-        res.status(200).json(list);
-      } catch (error) {
-        updateAndSendExpressResponseFromNativeError(
-          res,
-          new Error('Failed to retrieve list of objects latest version'),
-        );
-        this._logger.errorMessage(error);
-      }
+    try {
+      const { prefix, fields, filters } = req.query;
+
+      const list = await this._objService.retrieveLatestVersionOfObjects(prefix, fields, true, filters);
+      res.status(200).json(list);
+    } catch (error) {
+      const responseError = new Error('Failed to retrieve list of objects latest version');
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
 
@@ -79,57 +66,31 @@ export class ObjectController {
    * @returns {void}
    */
   async getObjectContent(req, res) {
-    const { path, validFrom, id, filters } = req.query;
-    if (!path) {
-      updateAndSendExpressResponseFromNativeError(
-        res,
-        new InvalidInputError('Invalid URL parameters: missing object path'),
-      );
-    } else {
-      try {
-        const object = await this._objService.retrieveQcObject(path, Number(validFrom), id, filters);
-        res.status(200).json(object);
-      } catch (error) {
-        updateAndSendExpressResponseFromNativeError(
-          res,
-          new Error('Unable to identify object or read it'),
-        );
-        this._logger.errorMessage(error);
-      }
+    try {
+      const { path, validFrom, filters, id } = req.query;
+
+      const object = await this._objService.retrieveQcObject(path, validFrom, id, filters);
+      res.status(200).json(object);
+    } catch (error) {
+      const responseError = new Error('Failed to retrieve object content');
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
 
-  /**
-   * Using `browse` option, request a list of `last-modified` and `valid-from` for a specified path for an object
-   * Use the first `validFrom` option to make a head request to CCDB; Request which will in turn return object
-   * information and download it locally on CCDB if it is not already done so;
-   * From the information retrieved above, use the location with JSROOT to get a JSON object
-   * Use JSROOT to decompress a ROOT object content and convert it to JSON to be sent back to the client for
-   * interpretation with JSROOT.draw
-   * @param {Request} req - HTTP request object with "query" information
-   * @param {Response} res - HTTP response object to provide information on request
-   * @returns {void}
-   */
   async getObjectById(req, res) {
-    const qcgId = req.params?.id;
-    const { validFrom, filters, id } = req.query;
-    if (!qcgId) {
-      updateAndSendExpressResponseFromNativeError(
-        res,
-        new InvalidInputError('Invalid URL parameters: missing object ID'),
-      );
-      return;
-    } else {
-      try {
-        const object = await this._objService.retrieveQcObjectByQcgId(qcgId, id, validFrom, filters);
-        res.status(200).json(object);
-      } catch (error) {
-        updateAndSendExpressResponseFromNativeError(
-          res,
-          new NotFoundError('Unable to identify object or read it by qcg id'),
-        );
-        this._logger.errorMessage(error);
-      }
+    try {
+      const qcgId = req.params?.id;
+      const { validFrom, filters, id } = req.query;
+
+      const object = await this._objService.retrieveQcObjectByQcgId(qcgId, id, validFrom, filters);
+      res.status(200).json(object);
+    } catch (error) {
+      const responseError = new Error('Unable to identify object or read it by qcg id');
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
 }

--- a/QualityControl/lib/dtos/ObjectGetDto.js
+++ b/QualityControl/lib/dtos/ObjectGetDto.js
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import Joi from 'joi';
+
+const periodNamePattern = /^LHC\d{1,2}[a-z]+$/i;
+
+/**
+ * Creates and returns a filters schema for object DTOs
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for filters
+ */
+function createFiltersSchema(runTypes) {
+  return Joi.object({
+    RunNumber: Joi.number().integer().min(0).max(999999).optional(),
+    RunType: runTypes.length > 0
+      ? Joi.string().valid(...runTypes).optional()
+      : Joi.string().optional(),
+    PeriodName: Joi.string().pattern(periodNamePattern).optional(),
+    PassName: Joi.string().optional(),
+  }).optional();
+}
+
+/**
+ * Creates and returns the base object get schema
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for base object get
+ */
+function createBaseObjectGetDto({ runTypes }) {
+  return Joi.object({
+    token: Joi.string().required(),
+    id: Joi.string().optional(),
+    validFrom: Joi.number().optional().min(0),
+    filters: createFiltersSchema(runTypes),
+  }).options({ allowUnknown: false });
+}
+
+/**
+ * Creates and returns the base objects get schema
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for base objects get
+ */
+function createBaseObjectsGetDto({ runTypes }) {
+  return Joi.object({
+    token: Joi.string().required(),
+    fields: Joi.array().default([]).items(Joi.string()),
+    filters: createFiltersSchema(runTypes),
+  }).options({ allowUnknown: false });
+}
+
+/**
+ * Creates and returns the ObjectsGetDto schema
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for getting multiple objects
+ */
+export function createObjectsGetDto({ runTypes }) {
+  return createBaseObjectsGetDto({ runTypes }).keys({
+    prefix: Joi.string(),
+  });
+}
+
+/**
+ * Creates and returns the ObjectContentsGetDto schema
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for getting object contents
+ */
+export function createObjectContentsGetDto({ runTypes }) {
+  return createBaseObjectGetDto({ runTypes }).keys({
+    path: Joi.string().required(),
+  });
+}
+
+/**
+ * Creates and returns the ObjectGetByIdDto schema
+ * @param {Array<string>} runTypes - Array of valid run types
+ * @returns {Joi.ObjectSchema} Joi validation schema for getting an object by ID
+ */
+export function createObjectGetByIdDto({ runTypes }) {
+  return createBaseObjectGetDto({ runTypes }); // doesn't require any alterations.
+}
+
+/**
+ * Joi validation schema for object ID in URL
+ */
+export const qcgIdDto = Joi.string().required().trim().min(1).messages({ 'string.empty': 'Missing object ID in URL' });

--- a/QualityControl/lib/dtos/ObjectGetDto.js
+++ b/QualityControl/lib/dtos/ObjectGetDto.js
@@ -93,4 +93,5 @@ export function createObjectGetByIdDto({ runTypes }) {
 /**
  * Joi validation schema for object ID in URL
  */
-export const qcgIdDto = Joi.string().required().trim().min(1).messages({ 'string.empty': 'Missing object ID in URL' });
+export const qcObjectIdDto =
+  Joi.string().required().trim().min(1).messages({ 'string.empty': 'Missing object ID in URL' });

--- a/QualityControl/lib/middleware/objects/objectGetByIdValidationMiddlewareFactory.js
+++ b/QualityControl/lib/middleware/objects/objectGetByIdValidationMiddlewareFactory.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { InvalidInputError, LogManager, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
+import { createObjectGetByIdDto, qcgIdDto } from '../../dtos/ObjectGetDto.js';
+
+const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/object-middleware`);
+
+/**
+ * Factory function to create object validation middleware with dynamic RUN_TYPES
+ * @param {FilterService} filterService - Service providing run types
+ * @returns {function(req, res, next): undefined} - Express middleware function
+ */
+export function objectGetByIdValidationMiddlewareFactory(filterService) {
+  const { runTypes } = filterService;
+  const ObjectGetByIdDto = createObjectGetByIdDto({ runTypes });
+
+  return async (req, res, next) => {
+    try {
+      req.params.id = await qcgIdDto.validateAsync(req.params?.id);
+      req.query = await ObjectGetByIdDto.validateAsync(req.query);
+      return next();
+    } catch (error) {
+      const responseError = new InvalidInputError(`Invalid query parameters: ${error.details[0].message}`);
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
+    }
+  };
+}

--- a/QualityControl/lib/middleware/objects/objectGetByIdValidationMiddlewareFactory.js
+++ b/QualityControl/lib/middleware/objects/objectGetByIdValidationMiddlewareFactory.js
@@ -13,7 +13,7 @@
  */
 
 import { InvalidInputError, LogManager, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
-import { createObjectGetByIdDto, qcgIdDto } from '../../dtos/ObjectGetDto.js';
+import { createObjectGetByIdDto, qcObjectIdDto } from '../../dtos/ObjectGetDto.js';
 
 const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/object-middleware`);
 
@@ -28,7 +28,7 @@ export function objectGetByIdValidationMiddlewareFactory(filterService) {
 
   return async (req, res, next) => {
     try {
-      req.params.id = await qcgIdDto.validateAsync(req.params?.id);
+      req.params.id = await qcObjectIdDto.validateAsync(req.params?.id);
       req.query = await ObjectGetByIdDto.validateAsync(req.query);
       return next();
     } catch (error) {

--- a/QualityControl/lib/middleware/objects/objectGetContentsValidationMiddlewareFactory.js
+++ b/QualityControl/lib/middleware/objects/objectGetContentsValidationMiddlewareFactory.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { InvalidInputError, LogManager, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
+import { createObjectContentsGetDto } from '../../dtos/ObjectGetDto.js';
+
+const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/object-middleware`);
+
+/**
+ * Factory function to create object validation middleware with dynamic RUN_TYPES
+ * @param {FilterService} filterService - Service providing run types
+ * @returns {function(req, res, next): undefined} - Express middleware function
+ */
+export function objectGetContentsValidationMiddlewareFactory(filterService) {
+  const { runTypes } = filterService;
+  const ObjectContentsGetDto = createObjectContentsGetDto({ runTypes });
+
+  return async (req, res, next) => {
+    try {
+      req.query = await ObjectContentsGetDto.validateAsync(req.query);
+      return next();
+    } catch (error) {
+      const responseError = new InvalidInputError(`Invalid query parameters: ${error.details[0].message}`);
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
+    }
+  };
+}

--- a/QualityControl/lib/middleware/objects/objectsGetValidationMiddlewareFactory.js
+++ b/QualityControl/lib/middleware/objects/objectsGetValidationMiddlewareFactory.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { InvalidInputError, LogManager, updateAndSendExpressResponseFromNativeError } from '@aliceo2/web-ui';
+import { createObjectsGetDto } from '../../dtos/ObjectGetDto.js';
+
+const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/object-middleware`);
+
+/**
+ * Factory function to create object validation middleware with dynamic RUN_TYPES
+ * @param {FilterService} filterService - Service providing run types
+ * @returns {function(req, res, next): undefined} - Express middleware function
+ */
+export function objectsGetValidationMiddlewareFactory(filterService) {
+  const { runTypes } = filterService;
+  const ObjectsGetDto = createObjectsGetDto({ runTypes });
+
+  return async (req, res, next) => {
+    try {
+      req.query = await ObjectsGetDto.validateAsync(req.query);
+      return next();
+    } catch (error) {
+      const responseError = new InvalidInputError(`Invalid query parameters: ${error.details[0].message}`);
+
+      logger.errorMessage(`Error validating query parameters: ${error}`);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
+    }
+  };
+}

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -90,18 +90,31 @@ export class QcObjectService {
    * * make a new request and get data directly from data service
    * * @example Equivalent of URL request: `/latest/qc/TPC/object.*`
    * @param {string|Regex} prefix - Prefix for which CCDB should search for objects.
-   * @param {Array<string>} [fields = []] - List of fields that should be requested for each object
+   * @param {Array<string>} [fields] - List of fields that should be requested for each object
    * @param {boolean} [useCache = true] - if the list should be the cached version or not
+   * @param {Array<string>} [filters = undefined] - Run number by which the objects are filtered.
    * @returns {Promise.<Array<QcObjectLeaf>>} - results of objects with required fields
    * @rejects {Error}
    */
-  async retrieveLatestVersionOfObjects(prefix = this._dbService.PREFIX, useCache = true) {
-    if (useCache && this._cache?.objects) {
+  async retrieveLatestVersionOfObjects(
+    prefix = this._dbService.PREFIX,
+    fields,
+    useCache = true,
+    filters = undefined,
+  ) {
+    const hasFilters = filters !== undefined;
+
+    if (!hasFilters && useCache && this._cache.objects?.length) {
       return this._cache.objects.filter((object) => object.name.startsWith(prefix));
-    } else {
-      const objects = await this._dbService.getObjectsTreeList(prefix); // TreeList links to the latest
-      return this._parseObjects(objects);
     }
+
+    let objects = [];
+    if (!hasFilters) {
+      objects = await this._dbService.getObjectsTreeList(prefix);
+    } else {
+      objects = await this._dbService.getObjectsLatestVersionList(prefix, filters, fields);
+    }
+    return this._parseObjects(objects);
   }
 
   /**

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -93,7 +93,7 @@ export class QcObjectService {
    * @param {string|Regex} options.prefix - Prefix for which CCDB should search for objects.
    * @param {Array<string>} options.fields - List of fields that should be requested for each object
    * @param {boolean} options.useCache - if the list should be the cached version or not
-   * @param {Array<string>} options.filters - Run number by which the objects are filtered.
+   * @param {Array<string>} options.filters - Filter object by which the objects from ccdb are filtered.
    * @returns {Promise.<Array<QcObjectLeaf>>} - results of objects with required fields
    * @rejects {Error}
    */

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -108,7 +108,7 @@ export class QcObjectService {
     if (!hasFilters) {
       objects = await this._dbService.getObjectsTreeList(prefix);
     } else {
-      objects = await this._dbService.getObjectsLatestVersionList(prefix, filters, fields);
+      objects = await this._dbService.getObjectsLatestVersionList({ prefix, filters, fields });
     }
     return this._parseObjects(objects);
   }

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -89,19 +89,15 @@ export class QcObjectService {
    * * from cache if it is requested by the client and the system is configured to use a cache;
    * * make a new request and get data directly from data service
    * * @example Equivalent of URL request: `/latest/qc/TPC/object.*`
-   * @param {string|Regex} prefix - Prefix for which CCDB should search for objects.
-   * @param {Array<string>} [fields] - List of fields that should be requested for each object
-   * @param {boolean} [useCache = true] - if the list should be the cached version or not
-   * @param {Array<string>} [filters = undefined] - Run number by which the objects are filtered.
+   * @param {object} options - An object that contains query parameters among other arguments
+   * @param {string|Regex} options.prefix - Prefix for which CCDB should search for objects.
+   * @param {Array<string>} options.fields - List of fields that should be requested for each object
+   * @param {boolean} options.useCache - if the list should be the cached version or not
+   * @param {Array<string>} options.filters - Run number by which the objects are filtered.
    * @returns {Promise.<Array<QcObjectLeaf>>} - results of objects with required fields
    * @rejects {Error}
    */
-  async retrieveLatestVersionOfObjects(
-    prefix = this._dbService.PREFIX,
-    fields,
-    useCache = true,
-    filters = undefined,
-  ) {
+  async retrieveLatestVersionOfObjects({ prefix = this._dbService.PREFIX, fields, useCache = true, filters }) {
     const hasFilters = filters !== undefined;
 
     if (!hasFilters && useCache && this._cache.objects?.length) {

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -98,7 +98,7 @@ export class QcObjectService {
    * @rejects {Error}
    */
   async retrieveLatestVersionOfObjects({ prefix = this._dbService.PREFIX, fields, useCache = true, filters }) {
-    const hasFilters = filters !== undefined;
+    const hasFilters = typeof filters === 'object' && Object.keys(filters).length;
 
     if (!hasFilters && useCache && this._cache.objects?.length) {
       return this._cache.objects.filter((object) => object.name.startsWith(prefix));

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -112,7 +112,6 @@ export class CcdbService {
     if (!Array.isArray(subfolders)) {
       throw new FailedDependencyError('Invalid response format from server - expected subfolders array');
     }
-    // console.log(await this.getObjectsLatestVersionList(prefix));
 
     return subfolders.map((folder) => ({ path: folder }));
   }
@@ -126,18 +125,24 @@ export class CcdbService {
    *
    * Attributes of objects wished to be requested for each object can be passed through the fields parameter;
    * If attributes list is missing, a default minimal list will be used: PATH, CREATED, LAST_MODIFIED
-   * @example Equivalent of URL request: `/latest/qc/TPC/object.*`
+   * @example Equivalent of URL request: `/latest/qc/TPC/object.* /RunNumber=42`
    * @param {string} [prefix] - Prefix for which CCDB should search for objects
+   * @param {object} [filters] - Object metadata that will be used to construct a endpoint path.
    * @param {Array<string>} [fields] - List of fields that should be requested for each object
    * @returns {Promise.<Array<{PATH, CREATED, LAST_MODIFIED}>>} - results of objects query or error
-   * @rejects {Error}
    */
-  async getObjectsLatestVersionList(prefix = this._PREFIX, fields = []) {
-    const headers = {
-      accept: 'application/json',
-      'x-filter-fields': fields.length > 0 ? fields.join(',') : `${PATH},${CREATED},${LAST_MODIFIED}`,
-    };
-    const { objects } = await httpGetJson(this._hostname, this._port, `/latest/${prefix}.*`, { headers });
+  async getObjectsLatestVersionList(
+    prefix = this._PREFIX,
+    filters,
+    fields,
+  ) {
+    fields = fields?.length ? fields : [PATH, CREATED, LAST_MODIFIED];
+    const identification = { path: `${prefix}.*`, filters };
+
+    const headers = { accept: 'application/json', 'x-filter-fields': fields.join(',') };
+
+    const path = `/latest${this._buildCcdbUrlPath(identification)}`;
+    const { objects } = await httpGetJson(this._hostname, this._port, path, { headers });
     return objects;
   }
 

--- a/QualityControl/lib/services/ccdb/CcdbService.js
+++ b/QualityControl/lib/services/ccdb/CcdbService.js
@@ -126,16 +126,13 @@ export class CcdbService {
    * Attributes of objects wished to be requested for each object can be passed through the fields parameter;
    * If attributes list is missing, a default minimal list will be used: PATH, CREATED, LAST_MODIFIED
    * @example Equivalent of URL request: `/latest/qc/TPC/object.* /RunNumber=42`
-   * @param {string} [prefix] - Prefix for which CCDB should search for objects
-   * @param {object} [filters] - Object metadata that will be used to construct a endpoint path.
-   * @param {Array<string>} [fields] - List of fields that should be requested for each object
+   * @param {object} options - An object that contains the arguments
+   * @param {string} options.prefix - Prefix for which CCDB should search for objects
+   * @param {object} options.filters - Object metadata that will be used to construct a endpoint path.
+   * @param {Array<string>} options.fields - List of fields that should be requested for each object
    * @returns {Promise.<Array<{PATH, CREATED, LAST_MODIFIED}>>} - results of objects query or error
    */
-  async getObjectsLatestVersionList(
-    prefix = this._PREFIX,
-    filters,
-    fields,
-  ) {
+  async getObjectsLatestVersionList({ prefix = this._PREFIX, filters, fields } = {}) {
     fields = fields?.length ? fields : [PATH, CREATED, LAST_MODIFIED];
     const identification = { path: `${prefix}.*`, filters };
 

--- a/QualityControl/test/api/objects/api-get-object.test.js
+++ b/QualityControl/test/api/objects/api-get-object.test.js
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { suite, test } from 'node:test';
+import { OWNER_TEST_TOKEN, URL_ADDRESS } from '../config.js';
+import request from 'supertest';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { MOCK_OBJECT_BY_ID_RESULT, OBJECT_BY_PATH_RESULT, OBJECT_LATEST_FILTERED_BY_RUN_NUMBER, OBJECT_VERSIONS,
+  OBJECT_VERSIONS_FILTERED_BY_RUN_NUMBER, TREE_API_OBJECTS } from '../../setup/seeders/ccdbObjects.js';
+
+export const apiGetObjectsTests = () => {
+  suite('GET /object', () => {
+    test('should return QCObject details with all versions', async () => {
+      const url = `${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}&path=qc/test/object/1`;
+      await testResult(url, 200, OBJECT_BY_PATH_RESULT, OBJECT_VERSIONS);
+    });
+
+    test('should return QCObject versions if a filter is added', async () => {
+      const url = `${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}&path=qc/test/object/1&filters[RunNumber]=0`;
+      await testResult(url, 200, OBJECT_BY_PATH_RESULT, OBJECT_VERSIONS_FILTERED_BY_RUN_NUMBER);
+    });
+
+    test('should return 400 if path parameter is missing', async () => {
+      await testResult(`${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}`, 400, {
+        message: 'Invalid query parameters: "path" is required', status: 400, title: 'Invalid Input' });
+    });
+
+    test('should return 400 if path parameter is not a string', async () => {
+      await testResult(`${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}&path[]=array`, 400, {
+        message: 'Invalid query parameters: "path" must be a string', status: 400, title: 'Invalid Input' });
+    });
+
+    test('should return 500 if service fails to retrieve object', async () => {
+      const url = `${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}&path=invalid/path`;
+      await testResult(url, 500, { message: 'Failed to retrieve object content', status: 500, title: 'Unknown Error' });
+    });
+  });
+
+  suite('GET /object/:id', () => {
+    const objectId = '6724a6bd1b2bad3d713cc4ee';
+
+    test('should return QCObject details with all versions', async () => {
+      const url = `${URL_ADDRESS}/api/object/${objectId}?token=${OWNER_TEST_TOKEN}`;
+      await testResult(url, 200, MOCK_OBJECT_BY_ID_RESULT, OBJECT_VERSIONS);
+    });
+
+    test('should return QCObject versions if a filter is added', async () => {
+      const url = `${URL_ADDRESS}/api/object/${objectId}?token=${OWNER_TEST_TOKEN}&filters[RunNumber]=0`;
+      await testResult(url, 200, MOCK_OBJECT_BY_ID_RESULT, OBJECT_VERSIONS_FILTERED_BY_RUN_NUMBER);
+    });
+
+    test('should return error when filter is a string', async () => {
+      await testResult(`${URL_ADDRESS}/api/object/${objectId}?token=${OWNER_TEST_TOKEN}&filters=RunNumber=0`, 400, {
+        message: 'Invalid query parameters: "filters" must be of type object', status: 400, title: 'Invalid Input' });
+    });
+
+    test('should return 400 if ID parameter is missing', async () => {
+      await testResult(`${URL_ADDRESS}/api/object/%20?token=${OWNER_TEST_TOKEN}`, 400, {
+        message: 'Invalid query parameters: Missing object ID in URL', status: 400, title: 'Invalid Input' });
+    });
+
+    test('should return 500 if service fails to retrieve object by ID', async () => {
+      await testResult(`${URL_ADDRESS}/api/object/invalid_id?token=${OWNER_TEST_TOKEN}`, 500, {
+        message: 'Unable to identify object or read it by qcg id', status: 500, title: 'Unknown Error' });
+    });
+  });
+
+  suite('GET /objects', () => {
+    test('should return object names when no filter is provided', async () => {
+      await testResult(`${URL_ADDRESS}/api/objects?token=${OWNER_TEST_TOKEN}`, 200, TREE_API_OBJECTS);
+    });
+
+    test('should return detailed objects when filter is provided', async () => {
+      const url = `${URL_ADDRESS}/api/objects?token=${OWNER_TEST_TOKEN}&filters[RunNumber]=0`;
+      await testResult(url, 200, OBJECT_LATEST_FILTERED_BY_RUN_NUMBER);
+    });
+
+    test('should return 400 if prefix is not a string', async () => {
+      await testResult(`${URL_ADDRESS}/api/objects?token=${OWNER_TEST_TOKEN}&prefix[]=array`, 400, {
+        message: 'Invalid query parameters: "prefix" must be a string', status: 400, title: 'Invalid Input' });
+    });
+
+    test('should return 400 if fields is not an array', async () => {
+      await testResult(`${URL_ADDRESS}/api/objects?token=${OWNER_TEST_TOKEN}&fields=not_an_array`, 400, {
+        message: 'Invalid query parameters: "fields" must be an array', status: 400, title: 'Invalid Input' });
+    });
+  });
+};
+
+/**
+ * Unified test helper function
+ * @param {string} url - Full URL to test
+ * @param {number} expectedStatus - Expected HTTP status code
+ * @param {object} expectedBody - Expected response body
+ * @param {Array<Objects>} [expectedVersions] - Optional expected versions array (for object tests)
+ */
+async function testResult(url, expectedStatus, expectedBody, expectedVersions = undefined) {
+  const response = await request(url).get('');
+  const { versions } = response.body;
+  delete response.body.versions;
+  delete response.body.root;
+
+  if (expectedVersions) {
+    deepStrictEqual(versions, expectedVersions, 'Versions do not match up');
+  }
+
+  deepStrictEqual(response.body, expectedBody, 'Unexpected response body');
+  strictEqual(response.status, expectedStatus, 'Unexpected status code');
+}

--- a/QualityControl/test/lib/controllers/ObjectController.test.js
+++ b/QualityControl/test/lib/controllers/ObjectController.test.js
@@ -1,194 +1,184 @@
-import { strict as assert } from 'assert';
-import { suite, test, beforeEach } from 'node:test';
-import { ObjectController } from '../../../lib/controllers/ObjectController.js';
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import test, { afterEach, beforeEach, suite } from 'node:test';
+import { ok } from 'node:assert';
 import sinon from 'sinon';
+import { ObjectController } from '../../../lib/controllers/ObjectController.js';
+import { QcObjectService } from '../../../lib/services/QcObject.service.js';
+import { NotFoundError } from '@aliceo2/web-ui';
 
 export const objectControllerTestSuite = async () => {
-  suite('ObjectController test suite', () => {
-    let res = null;
-    let req = null;
-    let qcObjectServiceStub = null;
-    let objectController = null;
+  let QcObjectServiceMock = null;
+  let reqMock = null;
+  let resMock = null;
+  let objectController = null;
 
-    beforeEach(() => {
-      res = {
-        status: sinon.stub().returnsThis(),
-        json: sinon.stub(),
-      };
-      req = {
-        params: {},
-        query: {},
-      };
-      qcObjectServiceStub = {
-        retrieveLatestVersionOfObjects: sinon.stub(),
-        retrieveQcObjectByQcgId: sinon.stub(),
-        retrieveQcObject: sinon.stub(),
-      };
-      objectController = new ObjectController(qcObjectServiceStub);
+  beforeEach(() => {
+    resMock = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.spy(),
+      json: sinon.spy(),
+    };
+    reqMock = {
+      query: { token: 'someToken' },
+      params: {},
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  suite('getObjects() tests', () => {
+    const mockObjectsList = [
+      { objectName: 'object1', path: 'qc/path/object1' },
+      { objectName: 'object2', path: 'qc/path/object2' },
+    ];
+
+    test('should successfully retrieve objects list without prefix', async () => {
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveLatestVersionOfObjects: sinon.stub().resolves(mockObjectsList),
+      });
+
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjects(reqMock, resMock);
+
+      ok(resMock.status.calledWith(200));
+      ok(resMock.json.calledWith(mockObjectsList));
+      ok(QcObjectServiceMock.retrieveLatestVersionOfObjects.calledWith(undefined, undefined, true, undefined));
     });
 
-    suite('`getObjects()` tests', () => {
-      test('should return 400 if prefix is not a string', async () => {
-        const req = {
-          query: { prefix: 123, fields: [] },
-        };
+    test('should successfully retrieve objects list with prefix and fields', async () => {
+      reqMock.query.prefix = 'qc/path';
+      reqMock.query.fields = ['objectName', 'path'];
 
-        await objectController.getObjects(req, res);
-
-        assert.ok(res.status.calledWith(400));
-        assert.ok(res.json.calledWith({
-          message: 'Invalid parameters provided: prefix must be of type string',
-          title: 'Invalid Input',
-          status: 400,
-        }));
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveLatestVersionOfObjects: sinon.stub().resolves(mockObjectsList),
       });
 
-      test('should return 400 if fields is not an array', async () => {
-        const req = {
-          query: { prefix: 'some/path', fields: 'not-an-array' },
-        };
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjects(reqMock, resMock);
 
-        await objectController.getObjects(req, res);
-
-        assert.ok(res.status.calledWith(400));
-        assert.ok(res.json.calledWith({
-          message: 'Invalid parameters provided: fields must be of type Array',
-          title: 'Invalid Input',
-          status: 400,
-        }));
-      });
-
-      test('should return 200 and list of objects if parameters are valid', async () => {
-        const mockList = [{ name: 'object1' }, { name: 'object2' }];
-        qcObjectServiceStub.retrieveLatestVersionOfObjects.resolves(mockList);
-
-        const req = {
-          query: { prefix: 'valid/path', fields: ['field1', 'field2'] },
-        };
-
-        await objectController.getObjects(req, res);
-
-        assert.ok(res.status.calledWith(200));
-        assert.ok(res.json.calledWith(mockList));
-      });
-
-      test('should return 500 if service throws error', async () => {
-        qcObjectServiceStub.retrieveLatestVersionOfObjects.rejects(new Error('Service failed'));
-
-        const req = {
-          query: { prefix: 'valid/path', fields: ['f'] },
-        };
-
-        await objectController.getObjects(req, res);
-
-        assert.ok(res.status.calledWith(500));
-        assert.ok(res.json.calledWith({
-          message: 'Failed to retrieve list of objects latest version',
-          title: 'Unknown Error',
-          status: 500,
-        }));
-      });
+      ok(resMock.status.calledWith(200));
+      ok(QcObjectServiceMock.retrieveLatestVersionOfObjects
+        .calledWith('qc/path', ['objectName', 'path'], true, undefined));
     });
 
-    suite('`getObjectsContent()` test suite', () => {
-      test('should return a 400 error if URL is invalid', async () => {
-        await objectController.getObjectContent(req, res);
-        assert.ok(res.json.calledWith({
-          message: 'Invalid URL parameters: missing object path',
-          title: 'Invalid Input',
-          status: 400,
-        }));
+    test('should handle service errors when retrieving objects', async () => {
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveLatestVersionOfObjects: sinon.stub().rejects(new NotFoundError('Object not found')),
       });
-      test('should return 200 with the QcObject', async () => {
-        const mockObject = { id: 'obj1', name: 'Test Object' };
 
-        req.query = {
-          path: 'valid/path.json',
-          validFrom: '1700000000',
-          id: 'id123',
-          filters: JSON.stringify({ a: 'b', empty: '' }),
-        };
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjects(reqMock, resMock);
 
-        qcObjectServiceStub.retrieveQcObject.resolves(mockObject);
+      ok(resMock.status.calledWith(500));
+      ok(resMock.json.calledWithMatch({
+        message: 'Failed to retrieve list of objects latest version',
+        status: 500,
+        title: 'Unknown Error',
+      }));
+    });
+  });
 
-        await objectController.getObjectContent(req, res);
+  suite('getObjectContent() tests', () => {
+    const stubObject = {
+      path: 'qc/path',
+      versions: [
+        {
+          validFrom: 1736424299423,
+          id: '4f9917a2-ce82-11ef-936c-c0a80209250c',
+          createdAt: 1736424454827,
+        },
+        {
+          validFrom: 1736420279131,
+          id: '21a6de32-ce79-11ef-936b-c0a80209250c',
+          createdAt: 1736420512272,
+        },
+      ],
+    };
 
-        assert.ok(res.status.calledWith(200));
-        assert.ok(res.json.calledWith(mockObject));
+    test('should successfully retrieve object content', async () => {
+      reqMock.query.path = stubObject.path;
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveQcObject: sinon.stub().resolves(stubObject),
       });
-      test('should return a 500 error if service fails', async () => {
-        const error = new Error('Service failure');
 
-        req.query = {
-          path: 'valid/path.json',
-          validFrom: '1700000000',
-          id: 'id123',
-          filters: JSON.stringify({ key: 'value' }),
-        };
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjectContent(reqMock, resMock);
 
-        qcObjectServiceStub.retrieveQcObject.rejects(error);
-
-        objectController.updateAndSendExpressResponseFromNativeError = (res, err) => {
-          res.status(500).json({
-            message: err.message,
-            title: 'Unknown error',
-            status: 500,
-          });
-        };
-
-        await objectController.getObjectContent(req, res);
-
-        assert.ok(res.status.calledWith(500));
-        assert.ok(res.json.calledWith({
-          message: 'Unable to identify object or read it',
-          title: 'Unknown Error',
-          status: 500,
-        }));
-      });
+      ok(resMock.status.calledWith(200));
+      ok(resMock.json.calledWith(stubObject));
+      ok(QcObjectServiceMock.retrieveQcObject.calledWith(stubObject.path, undefined, undefined, undefined));
     });
 
-    suite('`getObjectById()` tests', () => {
-      test('should return 400 if ID param is missing', async () => {
-        await objectController.getObjectById(req, res);
-
-        assert.ok(res.status.calledWith(400));
-        assert.ok(res.json.calledWith({
-          message: 'Invalid URL parameters: missing object ID',
-          title: 'Invalid Input',
-          status: 400,
-        }));
+    test('should handle service errors when retrieving object content', async () => {
+      reqMock.query.path = 'qc/test';
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveQcObject: sinon.stub().rejects(new NotFoundError('Object not found')),
       });
 
-      test('should return 200 and the object if retrieval is successful', async () => {
-        const mockObject = { name: 'ObjectName' };
-        req.params.id = 'abc123';
-        req.query = { id: 'sub-id', validFrom: '2024-01-01', filters: { foo: 'bar' } };
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjectContent(reqMock, resMock);
 
-        qcObjectServiceStub.retrieveQcObjectByQcgId.resolves(mockObject);
+      ok(resMock.status.calledWith(500));
+      ok(resMock.json.calledWithMatch({
+        message: 'Failed to retrieve object content',
+        status: 500,
+        title: 'Unknown Error',
+      }));
+    });
+  });
 
-        await objectController.getObjectById(req, res);
+  suite('getObjectById() tests', () => {
+    const mockObject = {
+      id: '21a6de32-ce79-11ef-936b-c0a80209250c',
+      path: 'qc/path/object',
+      validFrom: 1736420279131,
+    };
 
-        assert.ok(qcObjectServiceStub.retrieveQcObjectByQcgId
-          .calledWith('abc123', 'sub-id', '2024-01-01', { foo: 'bar' }));
-        assert.ok(res.status.calledWith(200));
-        assert.ok(res.json.calledWith(mockObject));
+    test('should successfully retrieve object by QCG ID', async () => {
+      reqMock.params.id = mockObject.id;
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveQcObjectByQcgId: sinon.stub().resolves(mockObject),
       });
 
-      test('should call errorHandler with 404 if service throws error', async () => {
-        req.params.id = 'abc123';
-        req.query = { id: 'some-id' };
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjectById(reqMock, resMock);
 
-        const error = new Error('Service failure');
-        qcObjectServiceStub.retrieveQcObjectByQcgId.rejects(error);
+      ok(resMock.status.calledWith(200));
+      ok(resMock.json.calledWith(mockObject));
+      ok(QcObjectServiceMock.retrieveQcObjectByQcgId.calledWith(mockObject.id, undefined, undefined, undefined));
+    });
 
-        await objectController.getObjectById(req, res);
-        assert.ok(res.json.calledWith({
-          message: 'Unable to identify object or read it by qcg id',
-          title: 'Not Found',
-          status: 404,
-        }));
-        assert.ok(res.status.calledWith(404));
+    test('should handle service errors when retrieving object by ID', async () => {
+      reqMock.params.id = 'some-id';
+      QcObjectServiceMock = sinon.createStubInstance(QcObjectService, {
+        retrieveQcObjectByQcgId: sinon.stub().rejects(new NotFoundError('Object not found')),
       });
+
+      objectController = new ObjectController(QcObjectServiceMock);
+      await objectController.getObjectById(reqMock, resMock);
+
+      ok(resMock.status.calledWith(500));
+      ok(resMock.json.calledWithMatch({
+        message: 'Unable to identify object or read it by qcg id',
+        status: 500,
+        title: 'Unknown Error',
+      }));
+      ok(QcObjectServiceMock.retrieveQcObjectByQcgId.calledWith('some-id', undefined, undefined, undefined));
     });
   });
 };

--- a/QualityControl/test/lib/controllers/ObjectController.test.js
+++ b/QualityControl/test/lib/controllers/ObjectController.test.js
@@ -57,7 +57,9 @@ export const objectControllerTestSuite = async () => {
 
       ok(resMock.status.calledWith(200));
       ok(resMock.json.calledWith(mockObjectsList));
-      ok(QcObjectServiceMock.retrieveLatestVersionOfObjects.calledWith(undefined, undefined, true, undefined));
+
+      ok(QcObjectServiceMock.retrieveLatestVersionOfObjects.calledWith({
+        prefix: undefined, fields: undefined, filters: undefined }));
     });
 
     test('should successfully retrieve objects list with prefix and fields', async () => {
@@ -73,7 +75,7 @@ export const objectControllerTestSuite = async () => {
 
       ok(resMock.status.calledWith(200));
       ok(QcObjectServiceMock.retrieveLatestVersionOfObjects
-        .calledWith('qc/path', ['objectName', 'path'], true, undefined));
+        .calledWith({ prefix: 'qc/path', fields: ['objectName', 'path'], filters: undefined }));
     });
 
     test('should handle service errors when retrieving objects', async () => {

--- a/QualityControl/test/lib/middlewares/objects/objectGetByContentsValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectGetByContentsValidation.middleware.test.js
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { beforeEach, suite, test } from 'node:test';
+import { ok } from 'node:assert';
+import sinon from 'sinon';
+import { objectGetContentsValidationMiddlewareFactory }
+  from '../../../../lib/middleware/objects/objectGetContentsValidationMiddlewareFactory.js';
+
+/**
+ * Test suite for the middleware that validates query parameters
+ */
+
+export const objectGetContentsValidationMiddlewareTest = () => {
+  suite('Object get contents validation Middleware', () => {
+    let req = {};
+    let res = {};
+    let next = {};
+    let middleWare = {};
+
+    let mockFilterService = {};
+    let runTypes = [];
+
+    beforeEach(() => {
+      runTypes = ['PHYSICS', 'PROTON-PROTON', '0', '1', '2'];
+      mockFilterService = { runTypes };
+
+      req = {
+        query: {
+          token: 'valid-token',
+        },
+      };
+      res = {
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub(),
+      };
+      next = sinon.stub();
+
+      middleWare = objectGetContentsValidationMiddlewareFactory(mockFilterService);
+    });
+    suite('getObjectContent() tests', () => {
+      test('should successfully validate a request with token and path', async () => {
+        req.query.path = 'valid/path';
+        await middleWare(req, res, next);
+        ok(next.calledOnce, 'Should call next() on successful validation');
+        ok(res.status.notCalled, 'Should not set status on success');
+        ok(res.json.notCalled, 'Should not send response on success');
+      });
+
+      test('should reject request without token', async () => {
+        delete req.query.token;
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "token" is required',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with a non-string path', async () => {
+        req.query.path = 1;
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "path" must be a string',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with empty path', async () => {
+        req.query.path = '';
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "path" is not allowed to be empty',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should successfully validate request with valid filters', async () => {
+        req.query.path = 'valid/path';
+        req.query.filters = {
+          RunNumber: '12345',
+          RunType: 'PHYSICS',
+          PeriodName: 'LHC22a',
+          PassName: 'pass1',
+        };
+        await middleWare(req, res, next);
+        ok(next.calledOnce, 'Should call next() when filters are valid');
+      });
+
+      test('should reject non-object filters', async () => {
+        req.query.filters = 'PassName=100';
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "filters" must be of type object',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with invalid RunNumber filter', async () => {
+        req.query.path = 'valid/path';
+        req.query.filters = { RunNumber: 'abc' };
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "filters.RunNumber" must be a number',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with invalid RunType filter', async () => {
+        req.query.path = 'valid/path';
+        req.query.filters = { RunType: 'INVALID_TYPE' };
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "filters.RunType" must be one of [PHYSICS, PROTON-PROTON, 0, 1, 2]',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with invalid PeriodName filter', async () => {
+        req.query.path = 'valid/path';
+        req.query.filters = { PeriodName: 'invalid-period' };
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "filters.PeriodName" with value "invalid-period"' +
+          ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with unknown filter field', async () => {
+        req.query.path = 'valid/path';
+        req.query.filters = { UnknownField: 'value' };
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "filters.UnknownField" is not allowed',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should successfully validate request with validFrom timestamp', async () => {
+        req.query.path = 'valid/path';
+        req.query.validFrom = '1234567890';
+        await middleWare(req, res, next);
+        ok(next.calledOnce, 'Should call next() when validFrom is valid');
+      });
+
+      test('should reject request with negative validFrom timestamp', async () => {
+        req.query.path = 'valid/path';
+        req.query.validFrom = '-1';
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "validFrom" must be greater than or equal to 0',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+
+      test('should reject request with non-numeric validFrom', async () => {
+        req.query.path = 'valid/path';
+        req.query.validFrom = 'not-a-number';
+        await middleWare(req, res, next);
+        ok(res.status.calledWith(400), 'Should return 400 status');
+        ok(res.json.calledWithMatch({
+          message: 'Invalid query parameters: "validFrom" must be a number',
+          status: 400,
+          title: 'Invalid Input',
+        }), 'Should return validation error');
+      });
+    });
+  });
+};

--- a/QualityControl/test/lib/middlewares/objects/objectGetByIdValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectGetByIdValidation.middleware.test.js
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { beforeEach, suite, test } from 'node:test';
+import { ok } from 'node:assert';
+import sinon from 'sinon';
+import { objectGetByIdValidationMiddlewareFactory }
+  from '../../../../lib/middleware/objects/objectGetByIdValidationMiddlewareFactory.js';
+
+/**
+ * Test suite for the middleware that validates query parameters
+ */
+
+export const objectGetByIdValidationMiddlewareTest = () => {
+  suite('Object get by id validation Middleware', () => {
+    let req = {};
+    let res = {};
+    let next = {};
+    let middleWare = {};
+
+    let mockFilterService = {};
+    let runTypes = [];
+
+    beforeEach(() => {
+      runTypes = ['PHYSICS', 'PROTON-PROTON', '0', '1', '2'];
+      mockFilterService = { runTypes };
+
+      req = {
+        query: {
+          token: 'valid-token',
+        },
+        params: {
+          id: 'valid-id',
+        },
+      };
+      res = {
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub(),
+      };
+      next = sinon.stub();
+
+      middleWare = objectGetByIdValidationMiddlewareFactory(mockFilterService);
+    });
+
+    test('should successfully validate a request with valid query parameters', async () => {
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Should call next() on successful validation');
+    });
+
+    test('should reject request without token', async () => {
+      delete req.query.token;
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "token" is required',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should successfully validate request with valid filters', async () => {
+      req.query.filters = {
+        RunNumber: '12345',
+        RunType: 'PHYSICS',
+        PeriodName: 'LHC22a',
+        PassName: 'pass1',
+      };
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Should call next() when filters are valid');
+    });
+    test('should reject non-object filters', async () => {
+      req.query.filters = 'PassName=100';
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters" must be of type object',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject request with invalid RunNumber filter', async () => {
+      req.query.path = 'valid/path';
+      req.query.filters = { RunNumber: 'abc' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.RunNumber" must be a number',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject request with invalid RunType filter', async () => {
+      req.query.path = 'valid/path';
+      req.query.filters = { RunType: 'INVALID_TYPE' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.RunType" must be one of [PHYSICS, PROTON-PROTON, 0, 1, 2]',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject request with invalid PeriodName filter', async () => {
+      req.query.path = 'valid/path';
+      req.query.filters = { PeriodName: 'invalid-period' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.PeriodName" with value "invalid-period"' +
+        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject request with unknown filter field', async () => {
+      req.query.path = 'valid/path';
+      req.query.filters = { UnknownField: 'value' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.UnknownField" is not allowed',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should successfully validate request with validFrom timestamp', async () => {
+      req.query.validFrom = '1234567890';
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Should call next() when validFrom is valid');
+    });
+
+    test('should reject request with negative validFrom timestamp', async () => {
+      req.query.path = 'valid/path';
+      req.query.validFrom = '-1';
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "validFrom" must be greater than or equal to 0',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject request with non-numeric validFrom', async () => {
+      req.query.path = 'valid/path';
+      req.query.validFrom = 'not-a-number';
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "validFrom" must be a number',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+  });
+};

--- a/QualityControl/test/lib/middlewares/objects/objectsGetValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectsGetValidation.middleware.test.js
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { beforeEach, suite, test } from 'node:test';
+import { ok } from 'node:assert';
+import sinon from 'sinon';
+import { objectsGetValidationMiddlewareFactory } from
+  '../../../../lib/middleware/objects/objectsGetValidationMiddlewareFactory.js';
+
+/**
+ * Test suite for the middleware that validates query parameters
+ */
+
+export const objectsGetValidationMiddlewareTest = () => {
+  suite('Objects get validation Middleware', () => {
+    let req = {};
+    let res = {};
+    let next = {};
+    let middleWare = {};
+
+    let mockFilterService = {};
+    let runTypes = [];
+
+    beforeEach(() => {
+      runTypes = ['PHYSICS', 'PROTON-PROTON', '0', '1', '2'];
+      mockFilterService = { runTypes };
+
+      req = {
+        query: {
+          token: 'valid-token',
+        },
+      };
+      res = {
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub(),
+      };
+      next = sinon.stub();
+
+      middleWare = objectsGetValidationMiddlewareFactory(mockFilterService);
+    });
+
+    test('should pass validation with minimal required fields', async () => {
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Next should be called');
+      ok(res.status.notCalled, 'Status should not be called');
+    });
+
+    test('should reject request without token', async () => {
+      delete req.query.token;
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "token" is required',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should accept valid RunNumber filter', async () => {
+      req.query.filters = { RunNumber: 123456 };
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Next should be called');
+    });
+
+    test('should reject invalid RunNumber (too high)', async () => {
+      req.query.filters = { RunNumber: 1000000 };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.RunNumber" must be less than or equal to 999999',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject invalid RunNumber (negative)', async () => {
+      req.query.filters = { RunNumber: -1 };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.RunNumber" must be greater than or equal to 0',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should accept valid RunType filter', async () => {
+      req.query.filters = { RunType: 'PHYSICS' };
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Next should be called');
+    });
+
+    test('should reject invalid RunType filter', async () => {
+      req.query.filters = { RunType: 'INVALID_TYPE' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.RunType" must be one of [PHYSICS, PROTON-PROTON, 0, 1, 2]',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should accept valid PeriodName filter', async () => {
+      req.query.filters = { PeriodName: 'LHC22a' };
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Next should be called');
+    });
+
+    test('should reject invalid PeriodName filter (wrong format)', async () => {
+      req.query.filters = { PeriodName: 'INVALID_PERIOD' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.PeriodName" with value "INVALID_PERIOD"' +
+        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should accept valid PassName filter', async () => {
+      req.query.filters = { PassName: 'apass1' };
+      await middleWare(req, res, next);
+      ok(next.calledOnce, 'Next should be called');
+    });
+
+    test('should reject non-object filters', async () => {
+      req.query.filters = 'PassName=100';
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters" must be of type object',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject empty PassName filter', async () => {
+      req.query.filters = { PassName: 100 }; // not a string
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.PassName" must be a string',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+
+    test('should reject unknown filter field', async () => {
+      req.query.filters = { UnknownField: 'value' };
+      await middleWare(req, res, next);
+      ok(res.status.calledWith(400), 'Should return 400 status');
+
+      ok(res.json.calledWithMatch({
+        message: 'Invalid query parameters: "filters.UnknownField" is not allowed',
+        status: 400,
+        title: 'Invalid Input',
+      }), 'Should return validation error');
+    });
+  });
+};

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -121,7 +121,7 @@ export const ccdbServiceTestSuite = async () => {
       test('should reject with error for fields parameter not being a list', async () => {
         const ccdb = new CcdbService(ccdbConfig);
         await rejects(
-          async () => await ccdb.getObjectsLatestVersionList('/qc', undefined, 'bad-fields'),
+          async () => ccdb.getObjectsLatestVersionList({ prefix: '/qc', fields: 'bad-fields' }),
           new TypeError('fields.join is not a function'),
         );
       });
@@ -160,7 +160,8 @@ export const ccdbServiceTestSuite = async () => {
         })
           .get('/latest/.*')
           .reply(200, { objects: objects, subfolders: [] });
-        const objectsRetrieved = await ccdb.getObjectsLatestVersionList('', undefined, [ID, CREATED, PATH]);
+        const objectsRetrieved = await ccdb.getObjectsLatestVersionList({
+          prefix: '', filters: undefined, fields: [ID, CREATED, PATH] });
         deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
       });
 
@@ -186,7 +187,8 @@ export const ccdbServiceTestSuite = async () => {
           .reply(200, { objects: objects, subfolders: [] });
 
         const objectsRetrieved =
-          await ccdb.getObjectsLatestVersionList('', { RunNumber: 535, RunType: 'PHYSICS' }, [ID]);
+          await ccdb.getObjectsLatestVersionList({
+            prefix: '', filters: { RunNumber: 535, RunType: 'PHYSICS' }, fields: [ID] });
 
         deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
       });

--- a/QualityControl/test/lib/services/CcdbService.test.js
+++ b/QualityControl/test/lib/services/CcdbService.test.js
@@ -19,7 +19,7 @@ import { suite, test, before } from 'node:test';
 import nock from 'nock';
 
 import { CcdbService } from '../../../lib/services/ccdb/CcdbService.js';
-import { CCDB_MONITOR, CCDB_VERSION_KEY } from '../../../lib/services/ccdb/CcdbConstants.js';
+import { CCDB_FILTER_FIELDS, CCDB_MONITOR, CCDB_VERSION_KEY } from '../../../lib/services/ccdb/CcdbConstants.js';
 
 const ccdbConfig = {
   hostname: 'ccdb-local',
@@ -27,6 +27,7 @@ const ccdbConfig = {
   protocol: 'https',
   prefix: 'qc-test',
 };
+const { ID, CREATED, PATH } = CCDB_FILTER_FIELDS;
 
 export const ccdbServiceTestSuite = async () => {
   suite('CCDB Test Suite - ', () => {
@@ -120,7 +121,7 @@ export const ccdbServiceTestSuite = async () => {
       test('should reject with error for fields parameter not being a list', async () => {
         const ccdb = new CcdbService(ccdbConfig);
         await rejects(
-          async () => await ccdb.getObjectsLatestVersionList('/qc', 'bad-fields'),
+          async () => await ccdb.getObjectsLatestVersionList('/qc', undefined, 'bad-fields'),
           new TypeError('fields.join is not a function'),
         );
       });
@@ -147,19 +148,19 @@ export const ccdbServiceTestSuite = async () => {
       test('should successfully return a list of the objects with specified headers', async () => {
         const ccdb = new CcdbService(ccdbConfig);
         const objects = [
-          { path: 'object/one', Created: '101', 'Last-Modified': '102', Id: 1 },
-          { path: 'object/two', Created: '101', 'Last-Modified': '102', Id: 2 },
-          { path: 'object/three', Created: '101', 'Last-Modified': '102', Id: 3 },
+          { [PATH]: 'object/one', [CREATED]: '101', [ID]: 1 },
+          { [PATH]: 'object/two', [CREATED]: '101', [ID]: 2 },
+          { [PATH]: 'object/three', [CREATED]: '101', [ID]: 3 },
         ];
         nock('http://ccdb-local:8083', {
           reqheaders: {
             Accept: 'application/json',
-            'X-Filter-Fields': 'Id',
+            'X-Filter-Fields': [ID, CREATED, PATH].join(','),
           },
         })
           .get('/latest/.*')
           .reply(200, { objects: objects, subfolders: [] });
-        const objectsRetrieved = await ccdb.getObjectsLatestVersionList('', ['Id']);
+        const objectsRetrieved = await ccdb.getObjectsLatestVersionList('', undefined, [ID, CREATED, PATH]);
         deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
       });
 
@@ -170,6 +171,24 @@ export const ccdbServiceTestSuite = async () => {
           .get(`/latest/${ccdbConfig.prefix}.*`)
           .replyWithError(error);
         await rejects(async () => await ccdb.getObjectsLatestVersionList(), new Error(`${error.message || error}`));
+      });
+
+      test('should send HTTP request with filters', async () => {
+        const ccdb = new CcdbService(ccdbConfig);
+        const objects = [{ [ID]: 1 }, { [ID]: 2 }, { [ID]: 3 }];
+        nock('http://ccdb-local:8083', {
+          reqheaders: {
+            Accept: 'application/json',
+            'X-Filter-Fields': ID,
+          },
+        })
+          .get('/latest/.*/RunNumber=535/RunType=PHYSICS')
+          .reply(200, { objects: objects, subfolders: [] });
+
+        const objectsRetrieved =
+          await ccdb.getObjectsLatestVersionList('', { RunNumber: 535, RunType: 'PHYSICS' }, [ID]);
+
+        deepStrictEqual(objectsRetrieved, objects, 'Received objects are not alike');
       });
     });
 

--- a/QualityControl/test/setup/seeders/ccdbObjects.js
+++ b/QualityControl/test/setup/seeders/ccdbObjects.js
@@ -47,3 +47,86 @@ export const subfolders = [
   'qc/test/object/2',
   'qc/test/object/11',
 ];
+
+export const MOCK_OBJECT_BY_ID_RESULT = {
+  id: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  path: 'qc/test/object/1',
+  name: 'qc/test/object/1',
+  validFrom: 1656072357492,
+  validUntil: 1971432357492,
+  createdAt: 1656072357533,
+  lastModified: 1656072357000,
+  drawOptions: [],
+  displayHints: [],
+  etag: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  runNumber: '0',
+  runType: '0',
+  partName: 'send',
+  qcCheckName: 'Pedestals/mPedestalChannelFECHG',
+  qcQuality: '3',
+  qcDetectorName: 'TPC',
+  qcVersion: '1.64.0',
+  objectType: 'o2::quality_control::core::QualityObject',
+  location: '/download/016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  layoutDisplayOptions: [],
+  layoutName: 'a-test',
+  tabName: 'main',
+  ignoreDefaults: false,
+};
+
+export const OBJECT_VERSIONS = [
+  {
+    validFrom: 1656072357492,
+    createdAt: 1656072357533,
+    id: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  },
+  {
+    validFrom: 1655916321231,
+    createdAt: 1655916321276,
+    id: 'b4944c1d-f24a-11ec-a509-c0a80209250c',
+  },
+];
+
+export const OBJECT_VERSIONS_FILTERED_BY_RUN_NUMBER = [
+  {
+    createdAt: 1656072357533,
+    id: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+    validFrom: 1656072357492,
+  },
+];
+
+export const OBJECT_BY_PATH_RESULT = {
+  id: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  path: 'qc/test/object/1',
+  name: 'qc/test/object/1',
+  validFrom: 1656072357492,
+  validUntil: 1971432357492,
+  createdAt: 1656072357533,
+  lastModified: 1656072357000,
+  drawOptions: [],
+  displayHints: [],
+  etag: '016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+  runNumber: '0',
+  runType: '0',
+  partName: 'send',
+  qcCheckName: 'Pedestals/mPedestalChannelFECHG',
+  qcQuality: '3',
+  qcDetectorName: 'TPC',
+  qcVersion: '1.64.0',
+  objectType: 'o2::quality_control::core::QualityObject',
+  location: '/download/016fa8ac-f3b6-11ec-b9a9-c0a80209250c',
+};
+
+export const TREE_API_OBJECTS = [
+  { name: 'qc/test/object/1' },
+  { name: 'qc/test/object/2' },
+  { name: 'qc/test/object/11' },
+];
+
+export const OBJECT_LATEST_FILTERED_BY_RUN_NUMBER = [
+  {
+    [PATH]: 'qc/test/object/1',
+    createdAt: 1656072357533,
+    name: 'qc/test/object/1',
+  },
+];

--- a/QualityControl/test/setup/seeders/object-view/mock-object-view.js
+++ b/QualityControl/test/setup/seeders/object-view/mock-object-view.js
@@ -1,6 +1,7 @@
-import { CCDB_RESPONSE_BODY_KEYS } from '../../../../lib/services/ccdb/CcdbConstants.js';
+import { CCDB_RESPONSE_BODY_KEYS, CCDB_FILTER_FIELDS } from '../../../../lib/services/ccdb/CcdbConstants.js';
 
 const { ID, PATH, VALID_FROM, VALID_UNTIL, CREATED } = CCDB_RESPONSE_BODY_KEYS;
+const { LAST_MODIFIED } = CCDB_FILTER_FIELDS;
 
 export const MOCK_OBJECT_IDENTIFICATION_RESPONSE = {
   path: 'qc/test/object/1',
@@ -62,6 +63,26 @@ export const MOCK_OBJECT_VERSIONS_RESPONSE = {
       [VALID_FROM]: 1655916321231,
       [CREATED]: 1655916321276,
       [ID]: '"b4944c1d-f24a-11ec-a509-c0a80209250c"',
+    },
+  ],
+};
+
+export const MOCK_OBJECT_VERSIONS_RESPONSE_RUN_NUMBER_FILTER = {
+  objects: [
+    {
+      [VALID_FROM]: 1656072357492,
+      [CREATED]: 1656072357533,
+      [ID]: '"016fa8ac-f3b6-11ec-b9a9-c0a80209250c"',
+    },
+  ],
+};
+
+export const MOCK_LATEST_OBJECT_FILTERED_BY_RUN_NUMBER = {
+  objects: [
+    {
+      [PATH]: 'qc/test/object/1',
+      [CREATED]: 1656072357533,
+      [LAST_MODIFIED]: 1656072357492,
     },
   ],
 };

--- a/QualityControl/test/setup/testSetupForCcdb.js
+++ b/QualityControl/test/setup/testSetupForCcdb.js
@@ -17,7 +17,9 @@ import { readFileSync } from 'fs';
 import { CCDB_FILTER_FIELDS, CCDB_MONITOR, CCDB_VERSION_KEY } from './../../lib/services/ccdb/CcdbConstants.js';
 import { config } from './../config.js';
 import { objects, subfolders } from './seeders/ccdbObjects.js';
-import { MOCK_OBJECT_DETAILS_RESPONSE, MOCK_OBJECT_IDENTIFICATION_RESPONSE, MOCK_OBJECT_VERSIONS_RESPONSE }
+import { MOCK_LATEST_OBJECT_FILTERED_BY_RUN_NUMBER,
+  MOCK_OBJECT_DETAILS_RESPONSE, MOCK_OBJECT_IDENTIFICATION_RESPONSE,
+  MOCK_OBJECT_VERSIONS_RESPONSE, MOCK_OBJECT_VERSIONS_RESPONSE_RUN_NUMBER_FILTER }
   from './seeders/object-view/mock-object-view.js';
 import { CCDB_MOCK_VERSION } from './seeders/ccdbVersion.js';
 
@@ -40,82 +42,68 @@ const versionResponse = {};
 versionResponse[CCDB_MONITOR] = {};
 versionResponse[CCDB_MONITOR][config.ccdb.hostname] = [CCDB_MOCK_VERSION];
 const fileContent = readFileSync(CCDB_API_DOWNLOAD_ROOT_OBJECT.objectPath);
+const acceptHeader = { reqheaders: { Accept: 'application/json' } };
+const xFieldHeader1 = {
+  reqheaders: { Accept: 'application/json', 'X-Filter-Fields': `${PATH},${CREATED},${LAST_MODIFIED}` },
+};
+const xFieldHeader2 = {
+  reqheaders: { Accept: 'application/json', 'X-Filter-Fields': `${PATH},${ID},${VALID_FROM},${VALID_UNTIL}` },
+};
+const xFieldHeader3 = {
+  reqheaders: { Accept: 'application/json', 'X-Filter-Fields': `${VALID_FROM},${ID},${CREATED}` },
+};
 
 /**
  * Setup nock environment for ccdb which is to intercept all CCDB requests used in the Frontend test suites
  * Requests will have to persist as tests might run multiple times and we want to intercept all
  */
 export const initializeNockForCcdb = () => {
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-    },
-  }).persist()
+  nock(CCDB_URL, acceptHeader).persist()
     .get(CCDB_API_MONITOR)
     .reply(200, versionResponse);
 
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-      'X-Filter-Fields': `${PATH},${CREATED},${LAST_MODIFIED}`,
-    },
-  }).persist()
+  nock(CCDB_URL, xFieldHeader1).persist()
     .get(`${CCDB_API_PATH_LATEST}.*`)
-    .reply(200, {
-      objects,
-    });
+    .reply(200, { objects })
+    .get(`${CCDB_API_PATH_LATEST}.*/RunNumber=0`)
+    .reply(200, MOCK_LATEST_OBJECT_FILTERED_BY_RUN_NUMBER);
 
-  nock(CCDB_URL, {
-    reqheaders: { Accept: 'application/json' },
-  }).persist()
+  nock(CCDB_URL, acceptHeader).persist()
     .get(`${CCDB_API_PATH_TREE}.*`)
-    .reply(200, {
-      subfolders,
-    });
+    .reply(200, { subfolders })
 
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-      'X-Filter-Fields': `${PATH},${ID},${VALID_FROM},${VALID_UNTIL}`,
-    },
-  }).persist()
+    .head('/qc/test/object/1/1656072357492/1971432357492/016fa8ac-f3b6-11ec-b9a9-c0a80209250c')
+    .reply(200, null, MOCK_OBJECT_DETAILS_RESPONSE.headers)
+
+    .head(CCDB_API_PATH_OBJECT_DETAILS)
+    .reply(200, null, MOCK_OBJECT_DETAILS_RESPONSE.headers)
+
+    .head('/qc/test/object/1/1656072357492/1971432357492/016fa8ac-f3b6-11ec-b9a9-c0a80209250c/RunNumber=0')
+    .reply(200, null, MOCK_OBJECT_DETAILS_RESPONSE.headers);
+
+  nock(CCDB_URL, xFieldHeader2).persist()
     .get(CCDB_API_PATH_OBJECT_IDENTIFICATION)
     .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
-    .get(`${CCDB_API_PATH_LATEST}/object/1`)
-    .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE);
 
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-      'X-Filter-Fields': `${PATH},${ID},${VALID_FROM},${VALID_UNTIL}`,
-    },
-  }).persist()
+    .get(`${CCDB_API_PATH_LATEST}/object/1`)
+    .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
+
+    .get(`${CCDB_API_PATH_LATEST}/object/1/RunNumber=0`)
+    .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
+
     .get(CCDB_API_PATH_TREE_OBJECT_IDENTIFICATION)
     .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE)
+
     .get(`${CCDB_API_PATH_TREE}/object/1`)
     .reply(200, MOCK_OBJECT_IDENTIFICATION_RESPONSE);
 
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-    },
-  }).persist()
-    .head(CCDB_API_PATH_OBJECT_DETAILS)
-    .reply(200, null, MOCK_OBJECT_DETAILS_RESPONSE.headers)
-    .head('/qc/test/object/1/1656072357492/1971432357492/016fa8ac-f3b6-11ec-b9a9-c0a80209250c')
-    .reply(200, null, MOCK_OBJECT_DETAILS_RESPONSE.headers);
-
-  nock(CCDB_URL, {
-    reqheaders: {
-      Accept: 'application/json',
-      'X-Filter-Fields': `${VALID_FROM},${ID},${CREATED}`,
-    },
-  })
+  nock(CCDB_URL, xFieldHeader3)
     .persist()
-    // .get('/browse/qc/EMC/MO/Pedestals/mPedestalChannelFECHG')
-    // .reply(200, MOCK_OBJECT_VERSIONS_RESPONSE)
     .get('/browse/qc/test/object/1')
-    .reply(200, MOCK_OBJECT_VERSIONS_RESPONSE);
+    .reply(200, MOCK_OBJECT_VERSIONS_RESPONSE)
+
+    .get('/browse/qc/test/object/1/RunNumber=0')
+    .reply(200, MOCK_OBJECT_VERSIONS_RESPONSE_RUN_NUMBER_FILTER);
 
   nock(CCDB_URL)
     .persist()

--- a/QualityControl/test/test-index.js
+++ b/QualityControl/test/test-index.js
@@ -73,6 +73,12 @@ import { userControllerTestSuite } from './lib/controllers/UserController.test.j
 import { chartRepositoryTest } from './lib/repositories/ChartRepository.test.js';
 import { filterServiceTestSuite } from './lib/services/FilterService.test.js';
 import { apiGetLayoutsTests } from './api/layouts/api-get-layout.test.js';
+import { apiGetObjectsTests } from './api/objects/api-get-object.test.js';
+import { objectsGetValidationMiddlewareTest } from './lib/middlewares/objects/objectsGetValidation.middleware.test.js';
+import { objectGetContentsValidationMiddlewareTest }
+  from './lib/middlewares/objects/objectGetByContentsValidation.middleware.test.js';
+import { objectGetByIdValidationMiddlewareTest }
+  from './lib/middlewares/objects/objectGetByIdValidation.middleware.test.js';
 
 const FRONT_END_PER_TEST_TIMEOUT = 5000; // each front-end test is allowed this timeout
 // remaining tests are based on the number of individual tests in each suite
@@ -174,6 +180,7 @@ suite('All Tests - QCG', { timeout: FRONT_END_TIMEOUT + BACK_END_TIMEOUT }, asyn
     suite('Layout GET request test suite', async () => apiGetLayoutsTests());
     suite('Layout PUT request test suite', async () => apiPutLayoutTests());
     suite('Layout PATCH request test suite', async () => apiPatchLayoutTests());
+    suite('Object GET request test suite', async () => apiGetObjectsTests());
   });
 
   suite('Back-end test suite', { timeout: BACK_END_TIMEOUT }, async () => {
@@ -206,6 +213,10 @@ suite('All Tests - QCG', { timeout: FRONT_END_TIMEOUT + BACK_END_TIMEOUT }, asyn
       suite('LayoutOwnerMiddleware test suite', async () => layoutOwnerMiddlewareTest());
       suite('StatusComponentMiddleware test suite', async () => statusComponentMiddlewareTest());
       suite('BookkeepingServiceTest test suite', async () => await bookkeepingServiceTestSuite());
+      suite('ObjectsGetValidationMiddleware test suite', async () => objectsGetValidationMiddlewareTest());
+      suite('ObjectGetContentsValidationMiddleware test suite', async () =>
+        objectGetContentsValidationMiddlewareTest());
+      suite('ObjectGetByIdValidationMiddleware test suite', async () => objectGetByIdValidationMiddlewareTest());
     });
 
     suite('Controllers - Test Suite', async () => {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR alters the ObjectController::getObjects function and  and corresponding ObjectService functions to accept filters as an optional parameter. 

The objectService function will decide between the ccdb's tree and latest API based on the presence of the filters 

It also adds middleware for the following endpoints:
/object
/object/:id
/objects

