### PR TITLE
[OGUI-1736] Allow detectorless envs to be destroyed

### DIFF
--- a/Control/lib/middleware/getDetectorsLockOwnershipMiddlewareFactory.js
+++ b/Control/lib/middleware/getDetectorsLockOwnershipMiddlewareFactory.js
@@ -11,7 +11,7 @@
  *  or submit itself to any jurisdiction.
  */
 
-const { LogManager, updateAndSendExpressResponseFromNativeError, InvalidInputError } = require('@aliceo2/web-ui');
+const { LogManager, updateAndSendExpressResponseFromNativeError } = require('@aliceo2/web-ui');
 const {User} = require('../dtos/User.js');
 
 const LOG_LABEL = `${process.env.npm_config_log_label ?? 'cog'}/get-det-lock-ownership`;
@@ -25,6 +25,7 @@ const LOG_LABEL = `${process.env.npm_config_log_label ?? 'cog'}/get-det-lock-own
 const getDetectorsLockOwnershipMiddlewareFactory = (lockService) => {
   /**
    * Middleware function to check that the user has ownership of the locks for the given detectors
+   * - if no detectors are present, check is by-passed as there are workflows that do not require locks
    * @param {Request} req - HTTP Request object
    * @param {@aliceo2/web-ui.Session} req.session - Session object from request
    * @param {object} req.body - Body object from request
@@ -40,12 +41,6 @@ const getDetectorsLockOwnershipMiddlewareFactory = (lockService) => {
     const { detectors = [] } = req.body;
 
     try {
-      if (!Array.isArray(detectors)) {
-        throw new InvalidInputError('Invalid input: detectors must be an array');
-      }
-      if (detectors.length === 0) {
-        throw new InvalidInputError('Invalid input: detectors array must not be empty');
-      }
       if (!lockService.hasLocks(requestor, detectors)) {
         res.status(403).json({message: `Action not allowed for user ${name} due to missing ownership of lock(s)`});
       } else {

--- a/Control/lib/middleware/setDetectorsFromEnvironmentMiddlewareFactory.js
+++ b/Control/lib/middleware/setDetectorsFromEnvironmentMiddlewareFactory.js
@@ -15,7 +15,7 @@ const {LogManager, updateAndSendExpressResponseFromNativeError, InvalidInputErro
 const LOG_LABEL = `${process.env.npm_config_log_label ?? 'cog'}/get-set-det-for-env`;
 
 /**
- * Factory function which retrieves the included detectors in an environment and add a list of them to the request body
+ * Factory function which retrieves the included detectors in an environment and add a list(can be empty) of them to the request body
  *
  * @param {EnvironmentService} environmentService - service to be used to retrieve environment information
  * @return {function(req, res, next): void} - middleware function
@@ -36,8 +36,8 @@ const setDetectorsFromEnvironmentMiddlewareFactory = (environmentService) => {
     try {
       if (!id) {
         throw new InvalidInputError('Invalid input: environment id must be provided');
-      }
-      const {includedDetectors = []} = await environmentService.getEnvironment(id);
+      } 
+      const { includedDetectors = [] } = await environmentService.getEnvironment(id);
       if (!req.body) {
         req.body = {};
       }

--- a/Control/lib/services/Lock.service.js
+++ b/Control/lib/services/Lock.service.js
@@ -131,10 +131,10 @@ class LockService {
    * Checks if the given user has the lock for the provided list of detectors
    * @param {String} userName - of user to check lock ownership
    * @param {Number} userId - person id of the user
-   * @param {Array<string>} detectors - list of detectors to check lock is owned by the user
+   * @param {Array<string>} [detectors = []] - list of detectors to check lock is owned by the user
    * @returns {boolean}
    */
-  hasLocks(user, detectors) {
+  hasLocks(user, detectors = []) {
     return detectors.every((detector) => this._locksByDetector[detector]?.isOwnedBy(user));
   }
 

--- a/Control/test/lib/middleware/mocha-getDetectorsLockOwnershipMiddlewareFactory.js
+++ b/Control/test/lib/middleware/mocha-getDetectorsLockOwnershipMiddlewareFactory.js
@@ -67,7 +67,7 @@ describe('`getDetectorsLockOwnershipMiddlewareFactory` test suite', () => {
 
   it('should call next() if the environment in request does not have detectors attribute (e.g. qc workflow)', async () => {
     lockServiceMock.hasLocks.resolves(true);
-    detectorlessReqMock = {
+    const detectorlessReqMock = {
       session: {
         name: 'Test User',
         username: 'testuser',
@@ -87,7 +87,7 @@ describe('`getDetectorsLockOwnershipMiddlewareFactory` test suite', () => {
 
   it('should call next() if the environment in request has empty detectors list (e.g. qc workflow)', async () => {
     lockServiceMock.hasLocks.resolves(true);
-    detectorlessReqMock = {
+    const detectorlessReqMock = {
       session: {
         name: 'Test User',
         username: 'testuser',

--- a/Control/test/lib/middleware/mocha-getDetectorsLockOwnershipMiddlewareFactory.js
+++ b/Control/test/lib/middleware/mocha-getDetectorsLockOwnershipMiddlewareFactory.js
@@ -65,6 +65,47 @@ describe('`getDetectorsLockOwnershipMiddlewareFactory` test suite', () => {
     assert.ok(resMock.json.notCalled);
   });
 
+  it('should call next() if the environment in request does not have detectors attribute (e.g. qc workflow)', async () => {
+    lockServiceMock.hasLocks.resolves(true);
+    detectorlessReqMock = {
+      session: {
+        name: 'Test User',
+        username: 'testuser',
+        personid: '12345',
+        access: 'admin',
+      },
+      body: {
+      },
+    };
+
+    await getDetectorsLockOwnershipMiddlewareFactory(lockServiceMock)(detectorlessReqMock, resMock, nextMock);
+
+    assert.ok(nextMock.calledOnce);
+    assert.ok(resMock.status.notCalled);
+    assert.ok(resMock.json.notCalled);
+  });
+
+  it('should call next() if the environment in request has empty detectors list (e.g. qc workflow)', async () => {
+    lockServiceMock.hasLocks.resolves(true);
+    detectorlessReqMock = {
+      session: {
+        name: 'Test User',
+        username: 'testuser',
+        personid: '12345',
+        access: 'admin',
+      },
+      body: {
+        detectors: [],
+      },
+    };
+
+    await getDetectorsLockOwnershipMiddlewareFactory(lockServiceMock)(detectorlessReqMock, resMock, nextMock);
+
+    assert.ok(nextMock.calledOnce);
+    assert.ok(resMock.status.notCalled);
+    assert.ok(resMock.json.notCalled);
+  });
+
   it('should return 403 if the user does not have ownership of the locks', async () => {
     lockServiceMock.hasLocks.returns(false);
 

--- a/Control/test/lib/services/mocha-lock.service.test.js
+++ b/Control/test/lib/services/mocha-lock.service.test.js
@@ -120,4 +120,19 @@ describe(`'LockService' test suite`, () => {
       new NotFoundError(`Detector ABCDEFG not found in the list of detectors`)
     );
   });
+
+  it('should successfully return true if list of detectors is empty/undefined', () => {
+    assert.ok(lockService.hasLocks(userA, []));
+    assert.ok(lockService.hasLocks(userA, undefined));
+    assert.ok(lockService.hasLocks(userA));
+  });
+
+  it(`should successfully return true if list of detectors is matching the user's owned locks`, () => {
+    lockService.takeLock('ABC', userA);
+    assert.ok(lockService.hasLocks(userA, ['ABC']));
+  });
+
+  it(`should successfully return false if list of detectors is not matching the user's owned locks`, () => {
+    assert.ok(!lockService.hasLocks(userA, ['DFG']));
+  });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* removes the criteria that a request for destroying an environment should always contain at least a detector
* adds default empty list for detectors if such an environment exists
* updates tests accordingly