### PR TITLE
[OGUI-1740] Exclude test files from QualityControl coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -60,5 +60,5 @@ ignore:
   - docs/*
   - node_modules/*
   - Control/protobuf/*
-  - QualityControl/test/setup/testServerSetup.js
+  - QualityControl/test/*
 comment: false


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Updated `codecov` configuration to ignore test files when calculating coverage metrics for QCG.