### PR TITLE
[OGUI-1741] Remove filters layout list about page

### DIFF
--- a/QualityControl/public/common/header.js
+++ b/QualityControl/public/common/header.js
@@ -63,14 +63,12 @@ const headerSpecific = (model) => {
  * @returns {vnode} - virtual node element
  */
 const filterSpecific = (model) => {
-  const { page, filterModel, layout, object, objectViewModel, aboutViewModel, layoutListModel } = model;
+  const { page, filterModel, layout, object, objectViewModel } = model;
 
   switch (page) {
-    case 'layoutList': return filtersPanel(filterModel, layoutListModel);
     case 'layoutShow': return filtersPanel(filterModel, layout);
     case 'objectTree': return filterModel.inRunMode ? null : filtersPanel(filterModel, object);
     case 'objectView': return filtersPanel(filterModel, objectViewModel);
-    case 'about': return filtersPanel(filterModel, aboutViewModel);
     default: return null;
   }
 };

--- a/QualityControl/public/pages/aboutView/components/aboutViewHeader.js
+++ b/QualityControl/public/pages/aboutView/components/aboutViewHeader.js
@@ -12,7 +12,6 @@
  * or submit itself to any jurisdiction.
  */
 
-import { filterPanelToggleButton } from '../../../common/filters/filterViews.js';
 import { h } from '/js/src/index.js';
 
 /**
@@ -20,11 +19,10 @@ import { h } from '/js/src/index.js';
  * @param {FilterModel} filterModel - model that controlls the filter state
  * @returns {vnode} - virtual node element
  */
-export default (filterModel) => [
+export default () => [
   h(
     '.w-50.flex-row.justify-center',
     h('b.f4.ph2', 'About'),
   ),
   h('.flex-grow'),
-  filterPanelToggleButton(filterModel),
 ];

--- a/QualityControl/public/pages/aboutView/components/aboutViewHeader.js
+++ b/QualityControl/public/pages/aboutView/components/aboutViewHeader.js
@@ -16,7 +16,6 @@ import { h } from '/js/src/index.js';
 
 /**
  * Shows header of Framework Information
- * @param {FilterModel} filterModel - model that controlls the filter state
  * @returns {vnode} - virtual node element
  */
 export default () => [

--- a/QualityControl/public/pages/layoutListView/components/LayoutListHeader.js
+++ b/QualityControl/public/pages/layoutListView/components/LayoutListHeader.js
@@ -12,7 +12,6 @@
  * or submit itself to any jurisdiction.
  */
 
-import { filterPanelToggleButton } from '../../../common/filters/filterViews.js';
 import { h } from '/js/src/index.js';
 
 /**
@@ -21,10 +20,9 @@ import { h } from '/js/src/index.js';
  * @param {FilterModel} filterModel - The model handeling the filter state
  * @returns {vnode} - virtual node element
  */
-export default (layoutListModel, filterModel) => [
+export default (layoutListModel) => [
   h('.w-50.text-center', [h('b.f4', 'Layouts')]),
   h('.flex-grow.text-right', [
-    filterPanelToggleButton(filterModel),
     h('input.form-control.form-inline.mh1.w-33', {
       placeholder: 'Search',
       type: 'text',

--- a/QualityControl/public/pages/layoutListView/components/LayoutListHeader.js
+++ b/QualityControl/public/pages/layoutListView/components/LayoutListHeader.js
@@ -17,7 +17,6 @@ import { h } from '/js/src/index.js';
 /**
  * Shows header of list of layouts with one search input to filter them
  * @param {LayoutListModel} layoutListModel - The model handeling the state of the LayoutListPage
- * @param {FilterModel} filterModel - The model handeling the filter state
  * @returns {vnode} - virtual node element
  */
 export default (layoutListModel) => [

--- a/QualityControl/test/public/features/filterTest.test.js
+++ b/QualityControl/test/public/features/filterTest.test.js
@@ -11,55 +11,43 @@
  * or submit itself to any jurisdiction.
  */
 
-import { strictEqual, ok, deepStrictEqual } from 'node:assert';
-
-const LAYOUT_LIST_PAGE_PARAM = '?page=layoutList';
-const FILTER_SELECTOR = 'header #filterElement';
+import { strictEqual } from 'node:assert';
 
 export const filterTests = async (url, page, timeout = 5000, testParent) => {
-  await testParent.test('should successfully load filter element on layoutListPage', { timeout }, async () => {
-    await page.goto(`${url}${LAYOUT_LIST_PAGE_PARAM}`, { waitUntil: 'networkidle0' });
-    await page.waitForSelector(FILTER_SELECTOR);
-
-    const element = await page.$(FILTER_SELECTOR);
-    ok(element !== null, 'Filter element does not exist, or is not inside the header');
-
-    const location = await page.evaluate(() => window.location);
-    deepStrictEqual(location.search, '?page=layoutList');
-  });
-
   await testParent.test('filter should persist between pages', { timeout }, async () => {
     const runNumber = '0';
+
+    await page.locator('.sidebar > a:nth-of-type(2)').click(); // navigate to ObjectTreePage
+    await page.waitForSelector('#runNumberFilter', { visible: true });
+
     await page.locator('#runNumberFilter').fill(runNumber);
-    await page.locator('#filterElement #triggerFilterButton').click();
 
-    let value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
-    strictEqual(value, runNumber, 'RunNumber is no longer set');
+    await page.locator('#triggerFilterButton').click();
+    await page.locator('#updateOnlyButton').click();
 
-    await page.locator('.sidebar > a:nth-of-type(3)').click(); // navigate to aboutPage.
-
-    value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
-    strictEqual(value, runNumber, 'RunNumber is no longer set');
-
-    await page.locator('.sidebar > a:nth-of-type(2)').click(); // navigate to ObjectTreePage.
-
-    value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
-    strictEqual(value, runNumber, 'RunNumber is no longer set');
+    // Check that URL contains RunNumber=0
+    const location = await page.evaluate(() => window.location);
+    strictEqual(location.href.includes('RunNumber=0'), true, 'URL should contain RunNumber=0');
     await page.waitForSelector('tr:last-of-type td');
 
     await extendTree(3, 5);
     await page.locator('tr:last-of-type td').click(); // This will select an object
     await page.waitForSelector('.resize-button a');
     await page.locator('.resize-button a').click(); // This would navigate to the objectViewPage
+    await page.waitForSelector('#runNumberFilter', { visible: true });
 
-    value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
-    strictEqual(value, runNumber, 'RunNumber is no longer set');
+    // Check that filter is still set to 0
+    let value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
+    strictEqual(value, runNumber, 'RunNumber filter should still be set to 0 on objectView page');
 
+    // Navigate to layout show
     await page.waitForSelector('.sidebar > div:nth-of-type(3) a:nth-child(1)', { visible: true, stable: true });
     await page.locator('.sidebar > div:nth-of-type(3) a:nth-child(1)').click(); // navigate to layout show
+    await page.waitForSelector('#runNumberFilter', { visible: true });
 
+    // Check that filter is still set to 0
     value = await page.evaluate(() => document.querySelector('#runNumberFilter').value);
-    strictEqual(value, runNumber, 'RunNumber is no longer set');
+    strictEqual(value, runNumber, 'RunNumber filter should still be set to 0 on layout show page');
   });
 
   await testParent.test('should list all objects when disabling objectFilters', { timeout }, async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR removes the filter components from the About page and Layout List page as they are not relevant for these pages and were causing confusion in the user experience.

- About page: Removed filter panel from `aboutViewHeader.js` (filters don't apply to static information content)
- Layout List page: Removed filter panel from `LayoutListHeader.js` (layout search functionality is sufficient for this page)
- Updated filter persistence test to only validate filter state between relevant pages

