### PR TITLE
Potential fix for code scanning alert no. 223: Semicolon insertion

### DIFF
--- a/Control/lib/controllers/Deployment.controller.js
+++ b/Control/lib/controllers/Deployment.controller.js
@@ -62,7 +62,7 @@ class DeploymentController {
       updateAndSendExpressResponseFromNativeError(
         res,
         new InvalidInputError('Invalid input: workflowTemplate or selectedConfiguration must be provided')
-      )
+      );
       return;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/AliceO2Group/WebUi/security/code-scanning/223](https://github.com/AliceO2Group/WebUi/security/code-scanning/223)

To fix the problem, we should add an explicit semicolon after the function call to `updateAndSendExpressResponseFromNativeError` on line 65. This change should be made directly in the file Control/lib/controllers/Deployment.controller.js, at the end of the statement on line 65. No other changes, imports, or definitions are required, as this is purely a stylistic fix to ensure consistency and avoid relying on JavaScript's automatic semicolon insertion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
