### PR TITLE
[release/cog/2.0.0]

### DIFF
--- a/Control/lib/common/kvStore/runtime.enum.js
+++ b/Control/lib/common/kvStore/runtime.enum.js
@@ -21,7 +21,7 @@
 const RUNTIME_COMPONENT = Object.freeze({
   PDP_VERSION: 'aliecs/defaults',
   COG: 'COG',
-  COG_V1: 'COG_V1',
+  COG_V1: 'COG-v1',
 });
 
 /**

--- a/Control/lib/kafka/enums/consumerGroups.enum.js
+++ b/Control/lib/kafka/enums/consumerGroups.enum.js
@@ -16,11 +16,11 @@
  * @returns {Object} - the object containing the consumer groups
  */
 exports.ConsumerGroups = Object.freeze({
-  ENVIRONMENT: 'cog-environment',
+  ENVIRONMENT: 'cog-environment-localo',
   INTEGRATED_SERVICE: {
-    DCS: 'cog-dcs-integrated-service',
-    ODC: 'cog-odc-integrated-service'
+    DCS: 'cog-dcs-integrated-service-local',
+    ODC: 'cog-odc-integrated-service-local',
   },
-  RUN: 'cog-run',
-  TASK: 'cog-task',
+  RUN: 'cog-run-local',
+  TASK: 'cog-task-local',
 });

--- a/Control/lib/kafka/enums/consumerGroups.enum.js
+++ b/Control/lib/kafka/enums/consumerGroups.enum.js
@@ -16,11 +16,11 @@
  * @returns {Object} - the object containing the consumer groups
  */
 exports.ConsumerGroups = Object.freeze({
-  ENVIRONMENT: 'cog-environment-localo',
+  ENVIRONMENT: 'cog-environment',
   INTEGRATED_SERVICE: {
-    DCS: 'cog-dcs-integrated-service-local',
-    ODC: 'cog-odc-integrated-service-local',
+    DCS: 'cog-dcs-integrated-service',
+    ODC: 'cog-odc-integrated-service',
   },
-  RUN: 'cog-run-local',
-  TASK: 'cog-task-local',
+  RUN: 'cog-run',
+  TASK: 'cog-task',
 });

--- a/Control/package-lock.json
+++ b/Control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.80.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/control",
-      "version": "1.80.0",
+      "version": "2.0.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/Control/package.json
+++ b/Control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/control",
-  "version": "1.80.0",
+  "version": "2.0.0",
   "description": "ALICE O2 Control GUI",
   "author": "George Raduta",
   "contributors": [

--- a/Control/public/environment/Environment.js
+++ b/Control/public/environment/Environment.js
@@ -130,7 +130,6 @@ export default class Environment extends Observable {
       this.itemNew = RemoteData.failure(result.message);
       this.notify();
     } else {
-      const { id } = result;
       this.itemNew = RemoteData.notAsked();
       // Users cannot be redirected to specific environment as it does not exist in 
       // ECS until it becomes active, thus users would get a NotFound reply from ECS

--- a/Control/public/environment/Environment.js
+++ b/Control/public/environment/Environment.js
@@ -132,7 +132,9 @@ export default class Environment extends Observable {
     } else {
       const { id } = result;
       this.itemNew = RemoteData.notAsked();
-      this.model.router.go(`?page=environment&id=${id}`);
+      // Users cannot be redirected to specific environment as it does not exist in 
+      // ECS until it becomes active, thus users would get a NotFound reply from ECS
+      this.model.router.go(`?page=environments`);
     }
   }
 

--- a/Control/test/public/page-new-environment-mocha.js
+++ b/Control/test/public/page-new-environment-mocha.js
@@ -440,7 +440,7 @@ describe('`pageNewEnvironment` test-suite', async () => {
       waitUntil: 'networkidle0',
     });
     const location = await page.evaluate(() => window.location);
-    assert.strictEqual(location.search, '?page=environment&id=6f6d6387-6577-11e8-993a-f07959157220&panel=general');
+    assert.strictEqual(location.search, '?page=environments');
     assert.ok(calls['newEnvironmentAsync']);
   });
 


### PR DESCRIPTION
Release of major version of COG/AliECS GUI to 2.0.0:
- this version starts to rely more and more until independently on Events sent by ECS via Kafka instead of the previous mechanism of gRPC streaming and polling. 
