### PR TITLE
[OGUI-1768] Run mode: smart refresh for object view(s)

### DIFF
--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -329,9 +329,10 @@ export default class QCObject extends BaseViewModel {
    * Set the current selected object by user
    * Search within `currentList`;
    * @param {QCObject} object - object to be selected and loaded
-   * @returns {undefined}
+   * @param {object} [preloadedData] - optional object data already fetched
+   *  @returns {undefined}
    */
-  async select(object) {
+  async select(object, preloadedData = null) {
     let foundObject = this.currentList.find((obj) => obj.name === object.name);
 
     if (foundObject && this.list && this.list.length > 0) {
@@ -340,7 +341,11 @@ export default class QCObject extends BaseViewModel {
 
     this.selected = foundObject || object;
     setBrowserTabTitle(this.selected.name);
-    await this.loadObjectByName(this.selected.name);
+    if (preloadedData) {
+      this.objects[this.selected.name] = RemoteData.success(preloadedData);
+    } else {
+      await this.loadObjectByName(this.selected.name);
+    }
     this.notify();
   }
 
@@ -568,8 +573,8 @@ export default class QCObject extends BaseViewModel {
     }
     if (this.selected && this.selected.name) {
       const { refreshNeeded, data } = await this.checkIfRefreshSelectedObject();
-      if (refreshNeeded) {
-        this.select(data?.payload ?? { name: this.selected.name });
+      if (refreshNeeded && data?.payload) {
+        this.select({ name: this.selected.name }, data.payload);
       }
     }
     this.loadList();

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -549,14 +549,28 @@ export default class QCObject extends BaseViewModel {
     restoreNodeState(this.tree);
   }
 
+  async checkIfRefreshSelectedObject() {
+    const currentId = this.objects[this.selected.name].payload.id;
+    const fetchFn = async () =>
+      await this.model.services.object.getObjectByName(this.selected.name, undefined, undefined, this);
+    const validateFn = (result) =>
+      result.isSuccess() && result.payload.id !== currentId;
+    return this.model.filterModel.refreshCheck(fetchFn, validateFn);
+  }
+
   /**
    * Function that reloads the object list with filters applied
    * @returns {undefined}
    */
   async triggerFilter() {
-    // don't clear selected object refreshing in run mode
     if (!this.model.filterModel.isRunModeActivated || !this.model.filterModel.runsModeInterval) {
       this.selected = null;
+    }
+    if (this.selected && this.selected.name) {
+      const { refreshNeeded, data } = await this.checkIfRefreshSelectedObject();
+      if (refreshNeeded) {
+        this.select(data?.payload ?? { name: this.selected.name });
+      }
     }
     this.loadList();
   }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -554,12 +554,18 @@ export default class QCObject extends BaseViewModel {
     restoreNodeState(this.tree);
   }
 
-  async checkIfRefreshSelectedObject() {
-    const currentId = this.objects[this.selected.name].payload.id;
+  /**
+   * Checks if the given object needs to be refreshed by comparing its ID
+   * @param {object} object - The object to check for refresh.
+   * @param {string} object.name - The name of the object to look up.
+   * @param {string|number} object.id - The current ID of the object being validated.
+   * @returns {Promise<boolean,RemoteData>} A promise that resolves to `true` if the object should be refreshed
+   */
+  async checkIfRefreshObject(object) {
     const fetchFn = async () =>
-      await this.model.services.object.getObjectByName(this.selected.name, undefined, undefined, this);
+      await this.model.services.object.getObjectByName(object.name, undefined, undefined, this);
     const validateFn = (result) =>
-      result.isSuccess() && result.payload.id !== currentId;
+      result.isSuccess() && result.payload.id !== object.id;
     return this.model.filterModel.refreshCheck(fetchFn, validateFn);
   }
 
@@ -572,7 +578,7 @@ export default class QCObject extends BaseViewModel {
       this.selected = null;
     }
     if (this.selected && this.selected.name) {
-      const { refreshNeeded, data } = await this.checkIfRefreshSelectedObject();
+      const { refreshNeeded, data } = await this.checkIfRefreshObject(this.objects[this.selected.name].payload);
       if (refreshNeeded && data?.payload) {
         this.select({ name: this.selected.name }, data.payload);
       }

--- a/QualityControl/public/pages/objectView/ObjectViewModel.js
+++ b/QualityControl/public/pages/objectView/ObjectViewModel.js
@@ -77,13 +77,12 @@ export default class ObjectViewModel extends BaseViewModel {
    * @returns {undefined}
    */
   async updateObjectSelection(object, validFrom = undefined, id = '') {
+    const { objectName = undefined, objectId = undefined } = object;
+    const { params } = this.model.router;
     const { refreshNeeded, data } = await this.checkIfRefreshIsNeeded(params, id, validFrom);
     if (!refreshNeeded) {
       return;
     }
-
-    const { objectName = undefined, objectId = undefined } = object;
-    const { params } = this.model.router;
 
     this._setParameters(objectName, objectId, params);
     this.selected = RemoteData.loading();

--- a/QualityControl/public/pages/objectView/ObjectViewModel.js
+++ b/QualityControl/public/pages/objectView/ObjectViewModel.js
@@ -61,14 +61,6 @@ export default class ObjectViewModel extends BaseViewModel {
     }
   }
 
-  async checkIfRefreshIsNeeded(params, id, validFrom) {
-    const fetchFn = async () => params.objectName
-      ? await this.model.services.object.getObjectByName(params.objectName, id, validFrom, this)
-      : await this.model.services.object.getObjectById(params.objectId, id, validFrom, this);
-    const validateFn = (result) => result.isSuccess() && this.selected.payload.id !== result.payload.id;
-    return await this.model.filterModel.refreshCheck(fetchFn, validateFn);
-  }
-
   /**
    * Updates the selected object from ObjectViewModel
    * @param {object} object - object with name or id to be used for content retrieval
@@ -79,7 +71,7 @@ export default class ObjectViewModel extends BaseViewModel {
   async updateObjectSelection(object, validFrom = undefined, id = '') {
     const { objectName = undefined, objectId = undefined } = object;
     const { params } = this.model.router;
-    const { refreshNeeded, data } = await this.checkIfRefreshIsNeeded(params, id, validFrom);
+    const { refreshNeeded, data } = await this.model.object.checkIfRefreshObject(this.selected.payload);
     if (!refreshNeeded) {
       return;
     }

--- a/QualityControl/public/pages/objectView/ObjectViewModel.js
+++ b/QualityControl/public/pages/objectView/ObjectViewModel.js
@@ -51,9 +51,6 @@ export default class ObjectViewModel extends BaseViewModel {
    * @returns {undefined}
    */
   async init(urlParams) {
-    this.selected = RemoteData.loading();
-    this.notify();
-
     const { objectName, layoutId, objectId, id, ts = undefined } = urlParams;
     if (objectName) {
       this.updateObjectSelection({ objectName }, ts, id);
@@ -64,6 +61,14 @@ export default class ObjectViewModel extends BaseViewModel {
     }
   }
 
+  async checkIfRefreshIsNeeded(params, id, validFrom) {
+    const fetchFn = async () => params.objectName
+      ? await this.model.services.object.getObjectByName(params.objectName, id, validFrom, this)
+      : await this.model.services.object.getObjectById(params.objectId, id, validFrom, this);
+    const validateFn = (result) => result.isSuccess() && this.selected.payload.id !== result.payload.id;
+    return await this.model.filterModel.refreshCheck(fetchFn, validateFn);
+  }
+
   /**
    * Updates the selected object from ObjectViewModel
    * @param {object} object - object with name or id to be used for content retrieval
@@ -72,18 +77,24 @@ export default class ObjectViewModel extends BaseViewModel {
    * @returns {undefined}
    */
   async updateObjectSelection(object, validFrom = undefined, id = '') {
+    const { refreshNeeded, data } = await this.checkIfRefreshIsNeeded(params, id, validFrom);
+    if (!refreshNeeded) {
+      return;
+    }
+
     const { objectName = undefined, objectId = undefined } = object;
     const { params } = this.model.router;
 
-    if (!objectName && !objectId && !params.objectId && !params.objectName && !this.selected.isSuccess()) {
-      return; // This will permanently put the page in loading mode.
-    }
     this._setParameters(objectName, objectId, params);
     this.selected = RemoteData.loading();
     this.notify();
 
+    if (!objectName && !objectId && !params.objectId && !params.objectName && !this.selected.isSuccess()) {
+      return; // This will permanently put the page in loading mode.
+    }
+
     let currentParams = '?page=objectView';
-    this.selected = params.objectName
+    this.selected = data ?? params.objectName
       ? await this.model.services.object.getObjectByName(params.objectName, id, validFrom, this)
       : await this.model.services.object.getObjectById(params.objectId, id, validFrom, this);
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR adds a new check to the object view page and the object tree visualization. When in run mode with an active run, the view will now refresh only when necessary (specifically, if the ID of the last fetch differs from the currently selected ID)