### PR TITLE
[OGUI-1782] Bug in safari: error using filter property by an iterator

### DIFF
--- a/QualityControl/package-lock.json
+++ b/QualityControl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/qc",
-      "version": "3.15.1",
+      "version": "3.15.2",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "jsroot",

--- a/QualityControl/package.json
+++ b/QualityControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/qc",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "O2 Quality Control Web User Interface",
   "author": "George Raduta",
   "contributors": [

--- a/QualityControl/public/pages/layoutListView/model/SearchFilterModel.js
+++ b/QualityControl/public/pages/layoutListView/model/SearchFilterModel.js
@@ -117,7 +117,7 @@ export class SearchFilterModel extends BaseViewModel {
    * @returns {Array<Filter>} all active filters
    */
   getAllActive() {
-    return this.filters.values().filter((filter) => filter.isActive()).toArray();
+    return [...this.filters.values()].filter((f) => f.isActive());
   }
 
   /**


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR addresses a Safari-specific bug that prevented users from accessing the Layout View page. The issue was caused by calling .filter() directly on an iterator returned by Map.values().

While browsers like Firefox and Chrome allow this usage, Safari follows the JavaScript specification more strictly and throws an error. Solution: We now convert the iterator into an array before applying .filter() to ensure consistent behavior across all browsers.