### PR TITLE
[OGUI-1784] Update sidebar layout name locally after save

### DIFF
--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -258,6 +258,7 @@ export default class Layout extends BaseViewModel {
     }
     const result = await this.model.services.layout.saveLayout(this.item);
     if (result.isSuccess()) {
+      await this.model.services.layout.getLayoutsByUserId(this.model.session.personid);
       this.model.notification.show(`Layout "${this.item.name}" has been saved successfully.`, 'success');
     } else {
       this.item = this.editOriginalClone;

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -435,6 +435,49 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
     const location2 = await page.evaluate(() => window.location);
     strictEqual(location2.search, `?page=layoutShow&layoutId=${LAYOUT_ID}&tab=test`);
   });
+
+  await testParent.test(
+    'should update layout name in sidebar when name is changed and saved via JSON editor',
+    { timeout },
+    async () => {
+      const originalSidebarName = await page.evaluate(() => {
+        const sidebarLayoutLink = document.querySelector('nav a.menu-item.w-wrapped.selected span:nth-child(2)');
+        return sidebarLayoutLink ? sidebarLayoutLink.textContent.trim() : null;
+      });
+
+      const editDropdownButtonPath = '.btn-group > div > button';
+      await page.locator(editDropdownButtonPath).click();
+      await delay(100);
+
+      const editViaJSONButtonPath = '#editByJson';
+      await page.locator(editViaJSONButtonPath).click();
+      await delay(100);
+
+      const currentJSON = await page.evaluate(() => {
+        const textareaPath = 'body > div > div > div > div > textarea';
+        return document.querySelector(textareaPath).value;
+      });
+
+      const layoutData = JSON.parse(currentJSON);
+      const newLayoutName = 'Updated Layout Name Test';
+      layoutData.name = newLayoutName;
+
+      const textareaPath = '#layout-json-editor';
+      await page.locator(textareaPath).fill(JSON.stringify(layoutData));
+
+      const updateButtonPath = '#updateLayoutButton';
+      await page.locator(updateButtonPath).click();
+      await delay(200);
+
+      const updatedSidebarName = await page.evaluate(() => {
+        const sidebarLayoutLink = document.querySelector('nav a.menu-item.w-wrapped.selected span:nth-child(2)');
+        return sidebarLayoutLink ? sidebarLayoutLink.textContent.trim() : null;
+      });
+
+      strictEqual(updatedSidebarName, newLayoutName);
+      ok(originalSidebarName !== updatedSidebarName, 'Sidebar name should have changed from original');
+    },
+  );
 };
 
 const checkInvalidJSON = async (page, mockedJSON, errorMessage) => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR fixes sync error in which the sidebar showing 'My layouts' was not being updated accordingly after changing the name of a layout in edit mode. With this change, the sidebar refreshes correctly and the new name of the layout is shown after saving (via JSON or via GUI)