### PR TITLE
[OGUI-1761] Restrict Lock force ALL actions to admin users only

### DIFF
--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -260,9 +260,16 @@ module.exports.setup = (http, ws) => {
     requireDetectorOrGlobalRoleMiddleware,
     lockController.actionLockHandler.bind(lockController)
   );
+
+  http.put(`/locks/force/:action/${DetectorId.ALL}`,
+    minimumRoleMiddleware(Role.ADMIN),
+    addDetectorIdMiddleware(DetectorId.ALL),
+    lockController.actionForceLockHandler.bind(lockController)
+  );
   http.put('/locks/force/:action/:detectorId',
     minimumRoleMiddleware(Role.GLOBAL),
-    lockController.actionForceLockHandler.bind(lockController));
+    lockController.actionForceLockHandler.bind(lockController)
+  );
 
   // Status Service
   http.get('/status/consul', statusController.getConsulStatus.bind(statusController));

--- a/Control/public/lock/lockPage.js
+++ b/Control/public/lock/lockPage.js
@@ -60,9 +60,11 @@ export const content = (model) => {
         Failure: (error) => errorPage(error),
         Success: (detectorsLocksState) => h('.flex-column', [
           h('.flex-row.g2.pv2', [
-            isUserAllowedRole(ROLES.Global) && [
+            isUserAllowedRole(ROLES.Admin) && [
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.RELEASE, true, 'Force Release ALL'),
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.TAKE, true, 'Force Take ALL'),
+            ],
+            isUserAllowedRole(ROLES.Global) && [
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.RELEASE, false, 'Release ALL*'),
               detectorLockActionButton(lock, DETECTOR_ALL, {}, DetectorLockAction.TAKE, false, 'Take ALL*'),
             ],

--- a/Control/test/api/lock/api-put-locks.test.js
+++ b/Control/test/api/lock/api-put-locks.test.js
@@ -138,17 +138,18 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
       });
   });
 
-  it('should successfully FORCE take ALL available lock as Global user', async () => {
+  it('should fail to FORCE take ALL available lock as Global user', async () => {
     await request(`${TEST_URL}/api/locks`)
       .put(`/force/${DetectorLockAction.TAKE}/ALL?token=${GLOBAL_TEST_TOKEN}`)
-      .expect(200, {
-        MID: { name: 'MID', state: 'TAKEN', owner: { username: 'global', fullName: 'Global User', personid: 1 } },
-        DCS: { name: 'DCS', state: 'TAKEN', owner: { username: 'global', fullName: 'Global User', personid: 1 } },
-        ODC: { name: 'ODC', state: 'TAKEN', owner: { username: 'global', fullName: 'Global User', personid: 1 } },
+      .expect(403, {
+        message: 'Not enough permissions for this operation',
+        status: 403,
+        title: 'Unauthorized Access',
       });
   });
 
   it('should successfully FORCE take ALL available lock as Admin user', async () => {
+    console.log('herreeeeeeee')
     await request(`${TEST_URL}/api/locks`)
       .put(`/force/${DetectorLockAction.TAKE}/ALL?token=${ADMIN_TEST_TOKEN}`)
       .expect(200, {
@@ -198,7 +199,7 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
       });
   });
 
-  it('should successfully force release ALL locks from all users', async () => {
+  it('should fail to force release ALL locks from all users as global', async () => {
     // first we retake a lock to ensure we have a lock to release from different types of users
     await request(`${TEST_URL}/api/locks`)
       .put(`/${DetectorLockAction.TAKE}/DCS?token=${GLOBAL_TEST_TOKEN}`)
@@ -210,6 +211,16 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
 
     await request(`${TEST_URL}/api/locks`)
       .put(`/force/${DetectorLockAction.RELEASE}/ALL?token=${GLOBAL_TEST_TOKEN}`)
+       .expect(403, {
+        message: 'Not enough permissions for this operation',
+        status: 403,
+        title: 'Unauthorized Access',
+      });
+  });
+
+  it('should successfully force release ALL locks from all users as admin', async () => {
+    await request(`${TEST_URL}/api/locks`)
+      .put(`/force/${DetectorLockAction.RELEASE}/ALL?token=${ADMIN_TEST_TOKEN}`)
       .expect(200, {
         MID: { name: 'MID', state: 'FREE' },
         DCS: { name: 'DCS', state: 'FREE' },

--- a/Control/test/api/lock/api-put-locks.test.js
+++ b/Control/test/api/lock/api-put-locks.test.js
@@ -149,7 +149,6 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
   });
 
   it('should successfully FORCE take ALL available lock as Admin user', async () => {
-    console.log('herreeeeeeee')
     await request(`${TEST_URL}/api/locks`)
       .put(`/force/${DetectorLockAction.TAKE}/ALL?token=${ADMIN_TEST_TOKEN}`)
       .expect(200, {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the front-end to display lock buttons for 'Force Release ALL'&'Force Take ALL' to admin users only
* updates the API endpoint to restrict those actions via the middleware
* add tests for aforementioned cases

Reason:
* restriction is needed to prevent shifters from force taking all locks and attempting to start a run with detectors that should not be used. 
* in this manner the shifter has to take the locks one by one, confirming which ones are to be used with SL