### PR TITLE
[OGUI-1791] Fix coverage pipeline failure when database isn’t fully initialized

### DIFF
--- a/QualityControl/docker-compose.coverage-ci.yml
+++ b/QualityControl/docker-compose.coverage-ci.yml
@@ -1,5 +1,8 @@
 services:
   test_app:
+    depends_on:
+      database:
+        condition: service_healthy
     build:
       context: .
       target: coverage-ci

--- a/QualityControl/docker-compose.coverage-local.yml
+++ b/QualityControl/docker-compose.coverage-local.yml
@@ -1,5 +1,8 @@
 services:
   test_app:
+    depends_on:
+      database:
+        condition: service_healthy
     build:
       context: .
       target: coverage-local

--- a/QualityControl/docker-compose.dev.yml
+++ b/QualityControl/docker-compose.dev.yml
@@ -1,5 +1,8 @@
 services:
   application:
+    depends_on:
+      database:
+        condition: service_healthy
     build:
       context: .
       target: development

--- a/QualityControl/docker-compose.test.yml
+++ b/QualityControl/docker-compose.test.yml
@@ -1,5 +1,8 @@
 services:
   test_app:
+    depends_on:
+      database:
+        condition: service_healthy
     build:
       context: .
       target: test

--- a/QualityControl/docker-compose.yml
+++ b/QualityControl/docker-compose.yml
@@ -20,6 +20,13 @@ services:
         read_only: true
         source: ./docker/database/populate
         target: /docker-entrypoint-initdb.d
+    # Max total time for the container to start 2 mins (20s + 5*20s)
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 20s
+      timeout: 20s
+      retries: 5
+      start_period: 20s
 
 volumes:
   database-data:


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

This PR makes app and test containers wait for the database to be ready.

- Adds `depends_on: service_healthy` and a DB `healthcheck` for CI jobs.