### PR TITLE
[OGUI-1796] Reduce the restriction on regex for PeriodName

### DIFF
--- a/QualityControl/lib/dtos/ObjectGetDto.js
+++ b/QualityControl/lib/dtos/ObjectGetDto.js
@@ -15,7 +15,7 @@
 import Joi from 'joi';
 import { RunNumberDto } from './filters/RunNumberDto.js';
 
-const periodNamePattern = /^LHC\d{1,2}[a-z]+$/i;
+const periodNamePattern = /^LHC\d{1,2}[a-z0-9]+$/i;
 
 /**
  * Creates and returns a filters schema for object DTOs

--- a/QualityControl/test/lib/middlewares/objects/objectGetByContentsValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectGetByContentsValidation.middleware.test.js
@@ -145,7 +145,7 @@ export const objectGetContentsValidationMiddlewareTest = () => {
         ok(res.status.calledWith(400), 'Should return 400 status');
         ok(res.json.calledWithMatch({
           message: 'Invalid query parameters: "filters.PeriodName" with value "invalid-period"' +
-          ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+          ' fails to match the required pattern: /^LHC\\d{1,2}[a-z0-9]+$/i',
           status: 400,
           title: 'Invalid Input',
         }), 'Should return validation error');

--- a/QualityControl/test/lib/middlewares/objects/objectGetByIdValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectGetByIdValidation.middleware.test.js
@@ -121,7 +121,7 @@ export const objectGetByIdValidationMiddlewareTest = () => {
       ok(res.status.calledWith(400), 'Should return 400 status');
       ok(res.json.calledWithMatch({
         message: 'Invalid query parameters: "filters.PeriodName" with value "invalid-period"' +
-        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z0-9]+$/i',
         status: 400,
         title: 'Invalid Input',
       }), 'Should return validation error');

--- a/QualityControl/test/lib/middlewares/objects/objectsGetValidation.middleware.test.js
+++ b/QualityControl/test/lib/middlewares/objects/objectsGetValidation.middleware.test.js
@@ -127,7 +127,7 @@ export const objectsGetValidationMiddlewareTest = () => {
       ok(res.status.calledWith(400), 'Should return 400 status');
       ok(res.json.calledWithMatch({
         message: 'Invalid query parameters: "filters.PeriodName" with value "INVALID_PERIOD"' +
-        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z]+$/i',
+        ' fails to match the required pattern: /^LHC\\d{1,2}[a-z0-9]+$/i',
         status: 400,
         title: 'Invalid Input',
       }), 'Should return validation error');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* following user requests for QCG-MC instance, the PeriodName needs to be slightly relaxed for expected values