### PR TITLE
[OGUI-1828] Add unique errors to _getJsRootFormat and pass errors to the frontend

### DIFF
--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -72,9 +72,8 @@ export class ObjectController {
       });
       res.status(200).json(objectsData);
     } catch (error) {
-      const responseError = new Error('Failed to retrieve list of objects latest version');
       this._logger.errorMessage(`Error whilst retrieving objects: ${error}`);
-      updateAndSendExpressResponseFromNativeError(res, responseError);
+      updateAndSendExpressResponseFromNativeError(res, error);
     }
   }
 
@@ -123,10 +122,8 @@ export class ObjectController {
       const object = await this._objService.retrieveQcObject({ path, validFrom, id, filters });
       res.status(200).json(object);
     } catch (error) {
-      const responseError = new Error('Failed to retrieve object content');
-
       this._logger.errorMessage(`Error whilst retrieving object content: ${error}`);
-      updateAndSendExpressResponseFromNativeError(res, responseError);
+      updateAndSendExpressResponseFromNativeError(res, error);
     }
   }
 
@@ -149,10 +146,8 @@ export class ObjectController {
       const object = await this._objService.retrieveQcObjectByQcgId({ qcObjectId, id, validFrom, filters });
       res.status(200).json(object);
     } catch (error) {
-      const responseError = new Error('Unable to identify object or read it by qcg id');
-
       this._logger.errorMessage(`Error whilst retrieving object: ${error}`);
-      updateAndSendExpressResponseFromNativeError(res, responseError);
+      updateAndSendExpressResponseFromNativeError(res, error);
     }
   }
 }

--- a/QualityControl/lib/controllers/ObjectController.js
+++ b/QualityControl/lib/controllers/ObjectController.js
@@ -72,8 +72,9 @@ export class ObjectController {
       });
       res.status(200).json(objectsData);
     } catch (error) {
+      const responseError = new Error('Failed to retrieve list of objects latest version');
       this._logger.errorMessage(`Error whilst retrieving objects: ${error}`);
-      updateAndSendExpressResponseFromNativeError(res, error);
+      updateAndSendExpressResponseFromNativeError(res, responseError);
     }
   }
 

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -206,21 +206,48 @@ export class QcObjectService {
    * * if of ROOT type, uses jsroot.toJSON
    * @param {string} url - location of Root file to be retrieved
    * @returns {Promise<JSON.Error>} - JSON version of the object
+   * @throws {Error} When JSROOT fails to open the file
+   * @throws {Error} When JSROOT fails to read the `ccdb_object` from the file
+   * @throws {Error} When BigInt-safe serialization fails
+   * @throws {Error} When JSROOT fails to convert the object to JSON using `toJSON`
    */
   async _getJsRootFormat(url) {
-    const file = await this._rootService.openFile(`${url}+`);
-    const root = await file.readObject('ccdb_object');
+    let file = undefined;
+    try {
+      file = await this._rootService.openFile(`${url}+`);
+    } catch (error) {
+      this._logger.error(error.message || error);
+      throw new Error(`JSROOT failed to open file '${url}'`);
+    }
+
+    let root = undefined;
+    try {
+      root = await file.readObject('ccdb_object');
+    } catch (error) {
+      this._logger.error(error.message || error);
+      throw new Error(`JSROOT failed to read object 'ccdb_object' from '${url}'`);
+    }
+
     root['_typename'] = root['mTreatMeAs'] || root['_typename'];
 
     if (isObjectOfTypeChecker(root)) {
       /**
        * Due to QC Checker big ints, JSON utility has to be overridden to parse 'bigint' types and replace with string
        */
-      return JSON.parse(JSON.stringify(root, (_, value) => typeof value === 'bigint' ? value.toString() : value));
+      try {
+        return JSON.parse(JSON.stringify(root, (_, value) => typeof value === 'bigint' ? value.toString() : value));
+      } catch (error) {
+        this._logger.error(error.message || error);
+        throw new Error(`Failed to serialize ROOT object '${root['_typename']}' with BigInt-safe JSON`);
+      }
     }
 
-    const rootJson = await this._rootService.toJSON(root);
-    return rootJson;
+    try {
+      return await this._rootService.toJSON(root);
+    } catch (error) {
+      this._logger.error(error.message || error);
+      throw new Error(`JSROOT failed to convert object '${root['_typename']}' to JSON`);
+    }
   }
 
   /**

--- a/QualityControl/lib/services/QcObject.service.js
+++ b/QualityControl/lib/services/QcObject.service.js
@@ -13,7 +13,7 @@
  */
 
 import { LogManager } from '@aliceo2/web-ui';
-import { isObjectOfTypeChecker, parseObjects } from '../../common/library/qcObject/utils.js';
+import { isObjectOfTypeChecker, parseObjects, QC_CHECKER_TYPE } from '../../common/library/qcObject/utils.js';
 import QCObjectDto from '../dtos/QCObjectDto.js';
 import QcObjectIdentificationDto from '../dtos/QcObjectIdentificationDto.js';
 
@@ -238,7 +238,7 @@ export class QcObjectService {
         return JSON.parse(JSON.stringify(root, (_, value) => typeof value === 'bigint' ? value.toString() : value));
       } catch (error) {
         this._logger.error(error.message || error);
-        throw new Error(`Failed to serialize ROOT object '${root['_typename']}' with BigInt-safe JSON`);
+        throw new Error(`Failed to serialize ROOT object '${QC_CHECKER_TYPE}' with BigInt-safe JSON`);
       }
     }
 

--- a/QualityControl/test/api/objects/api-get-object.test.js
+++ b/QualityControl/test/api/objects/api-get-object.test.js
@@ -48,7 +48,7 @@ export const apiGetObjectsTests = () => {
 
     test('should return 500 if service fails to retrieve object', async () => {
       const url = `${URL_ADDRESS}/api/object?token=${OWNER_TEST_TOKEN}&path=invalid/path`;
-      await testResult(url, 500, { message: 'Failed to retrieve object content', status: 500, title: 'Unknown Error' });
+      await testResult(url, 500, { message: 'Non-2xx status code: 501', status: 500, title: 'Unknown Error' });
     });
   });
 
@@ -101,7 +101,7 @@ export const apiGetObjectsTests = () => {
 
     test('should return 500 if service fails to retrieve object by ID', async () => {
       await testResult(`${URL_ADDRESS}/api/object/invalid_id?token=${OWNER_TEST_TOKEN}`, 500, {
-        message: 'Unable to identify object or read it by qcg id', status: 500, title: 'Unknown Error' });
+        message: 'Object with invalid_id could not be found', status: 500, title: 'Unknown Error' });
     });
   });
 

--- a/QualityControl/test/lib/controllers/ObjectController.test.js
+++ b/QualityControl/test/lib/controllers/ObjectController.test.js
@@ -99,7 +99,7 @@ export const objectControllerTestSuite = async () => {
       await objectController.getObjectsHandler(reqMock, resMock);
       ok(resMock.status.calledWith(500));
       ok(resMock.json.calledWithMatch({
-        message: 'Failed to retrieve list of objects latest version',
+        message: 'Service error',
         status: 500,
         title: 'Unknown Error',
       }));
@@ -146,7 +146,7 @@ export const objectControllerTestSuite = async () => {
 
       ok(resMock.status.calledWith(500));
       ok(resMock.json.calledWithMatch({
-        message: 'Failed to retrieve object content',
+        message: 'Service error',
         status: 500,
         title: 'Unknown Error',
       }));
@@ -182,7 +182,7 @@ export const objectControllerTestSuite = async () => {
 
       ok(resMock.status.calledWith(500));
       ok(resMock.json.calledWithMatch({
-        message: 'Unable to identify object or read it by qcg id',
+        message: 'Service error',
         status: 500,
         title: 'Unknown Error',
       }));

--- a/QualityControl/test/lib/controllers/ObjectController.test.js
+++ b/QualityControl/test/lib/controllers/ObjectController.test.js
@@ -99,7 +99,7 @@ export const objectControllerTestSuite = async () => {
       await objectController.getObjectsHandler(reqMock, resMock);
       ok(resMock.status.calledWith(500));
       ok(resMock.json.calledWithMatch({
-        message: 'Service error',
+        message: 'Failed to retrieve list of objects latest version',
         status: 500,
         title: 'Unknown Error',
       }));

--- a/QualityControl/test/lib/services/QcObjectService.test.js
+++ b/QualityControl/test/lib/services/QcObjectService.test.js
@@ -1,8 +1,9 @@
-import { deepStrictEqual, strictEqual } from 'node:assert';
+import { deepStrictEqual, rejects, strictEqual } from 'node:assert';
 import { suite, test, before, beforeEach } from 'node:test';
 import nock from 'nock';
 import { QcObjectService } from '../../../lib/services/QcObject.service.js';
 import { stub } from 'sinon';
+import { OBJECT_TYPE_KEY, QC_CHECKER_TYPE } from "../../../common/library/qcObject/utils.js";
 
 export const qcObjectServiceTestSuite = async () => {
   suite('QC Object Service Test Suite -', () => {
@@ -155,5 +156,90 @@ export const qcObjectServiceTestSuite = async () => {
     });
     suite('retrieveQcObject', async () => { });
     suite('retrieveQcObjectByQcId', async () => { });
+
+    suite('retrieveQcObject', async () => {
+      let rootServiceMock = null;
+
+      beforeEach(() => {
+        // Inject rootService into the service instance
+        rootServiceMock = {
+          openFile: stub(),
+          toJSON: stub(),
+        };
+        qcObjectService._rootService = rootServiceMock;
+      });
+
+      test('should throw if openFile fails', async () => {
+        const url = 'http://localhost:1234/test.root';
+        rootServiceMock.openFile.rejects(new Error('openFile failure'));
+
+        await rejects(
+          () => qcObjectService._getJsRootFormat(url),
+          (error) => error instanceof Error && error.message === `JSROOT failed to open file '${url}'`,
+        );
+      });
+
+      test('should throw if readObject fails', async () => {
+        const url = 'http://localhost:1234/test.root';
+        const fakeFile = { readObject: stub().rejects(new Error('readObject failure')) };
+        rootServiceMock.openFile.resolves(fakeFile);
+
+        await rejects(
+          () => qcObjectService._getJsRootFormat(url),
+          (error) => error instanceof Error
+            && error.message === `JSROOT failed to read object 'ccdb_object' from '${url}'`,
+        );
+      });
+
+      test('should serialize checker object with BigInt', async () => {
+        const url = 'http://localhost:1234/test.root';
+        const root = { [OBJECT_TYPE_KEY]: QC_CHECKER_TYPE, value: 123n };
+        const fakeFile = { readObject: stub().resolves(root) };
+        rootServiceMock.openFile.resolves(fakeFile);
+
+        const result = await qcObjectService._getJsRootFormat(url);
+
+        strictEqual(result.value, '123'); // BigInt converted to string
+      });
+
+      test('should call toJSON for non-checker object', async () => {
+        const url = 'http://localhost:1234/test.root';
+        const root = { [OBJECT_TYPE_KEY]: 'RootObject' };
+        const fakeFile = { readObject: stub().resolves(root) };
+        rootServiceMock.openFile.resolves(fakeFile);
+        rootServiceMock.toJSON.resolves({ serialized: true });
+
+        const result = await qcObjectService._getJsRootFormat(url);
+        deepStrictEqual(result, { serialized: true });
+      });
+
+      test('should throw if BigInt-safe JSON fails', async () => {
+        const url = 'http://localhost:1234/test.root';
+        const circularRoot = { [OBJECT_TYPE_KEY]: QC_CHECKER_TYPE };
+        circularRoot.self = circularRoot; // circular reference
+        const fakeFile = { readObject: stub().resolves(circularRoot) };
+        rootServiceMock.openFile.resolves(fakeFile);
+
+        await rejects(
+          () => qcObjectService._getJsRootFormat(url),
+          (error) => error instanceof Error
+            && error.message === `Failed to serialize ROOT object '${QC_CHECKER_TYPE}' with BigInt-safe JSON`,
+        );
+      });
+
+      test('should throw if toJSON fails', async () => {
+        const url = 'http://localhost:1234/test.root';
+        const root = { [OBJECT_TYPE_KEY]: 'RootObject' };
+        const fakeFile = { readObject: stub().resolves(root) };
+        rootServiceMock.openFile.resolves(fakeFile);
+        rootServiceMock.toJSON.rejects(new Error('toJSON failure'));
+
+        await rejects(
+          () => qcObjectService._getJsRootFormat(url),
+          (error) => error instanceof Error
+            && error.message === 'JSROOT failed to convert object \'RootObject\' to JSON',
+        );
+      });
+    });
   });
 };

--- a/QualityControl/test/public/pages/object-view-from-object-tree.test.js
+++ b/QualityControl/test/public/pages/object-view-from-object-tree.test.js
@@ -11,7 +11,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { strictEqual } from 'node:assert';
+import { match, strictEqual } from 'node:assert';
 const OBJECT_VIEW_PAGE_PARAM = '?page=objectView';
 
 export const objectViewFromObjectTreeTests = async (url, page, timeout = 5000, testParent) => {
@@ -63,7 +63,7 @@ export const objectViewFromObjectTreeTests = async (url, page, timeout = 5000, t
         (element) => document.querySelector(element).textContent,
         errorMessageElement,
       );
-      strictEqual(message, `404: Object "${objectName}" could not be found.`);
+      match(message, /^Request to server failed/i);
     },
   );
 

--- a/QualityControl/test/public/pages/object-view-from-object-tree.test.js
+++ b/QualityControl/test/public/pages/object-view-from-object-tree.test.js
@@ -11,7 +11,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { match, strictEqual } from 'node:assert';
+import { strictEqual } from 'node:assert';
 const OBJECT_VIEW_PAGE_PARAM = '?page=objectView';
 
 export const objectViewFromObjectTreeTests = async (url, page, timeout = 5000, testParent) => {
@@ -63,7 +63,7 @@ export const objectViewFromObjectTreeTests = async (url, page, timeout = 5000, t
         (element) => document.querySelector(element).textContent,
         errorMessageElement,
       );
-      match(message, /^Request to server failed/i);
+      strictEqual(message, `404: Object "${objectName}" could not be found.`);
     },
   );
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

* Add error messages for exceptions caused by:
  * `openFile` (via JSROOT)
  * `readObject` (via JSROOT)
  * `toJson` (via JSROOT)
* The backend passes these errors to the frontend