### PR TITLE
Refactor layout error assertion to use path normalization

### DIFF
--- a/QualityControl/test/lib/services/JsonFileService.test.js
+++ b/QualityControl/test/lib/services/JsonFileService.test.js
@@ -17,6 +17,7 @@ import assert from 'assert';
 import fs from 'fs';
 import { JsonFileService } from '../../../lib/services/JsonFileService.js';
 import { config } from '../../config.js';
+import { normalize } from 'node:path';
 
 export const jsonFileServiceTestSuite = async () => {
   suite('JSON File Service Test Suite', () => {
@@ -42,7 +43,7 @@ export const jsonFileServiceTestSuite = async () => {
       return assert.rejects(
         service.ready,
         (err) => err instanceof Error
-          && err.message === `DB file should have an array of layouts ${config.dbFile.split('./')[1]}`,
+          && err.message === `DB file should have an array of layouts ${normalize(config.dbFile)}`,
       );
     });
 
@@ -52,7 +53,7 @@ export const jsonFileServiceTestSuite = async () => {
       return assert.rejects(
         service.ready,
         (err) => err instanceof Error
-          && err.message === `Unable to parse DB file ${config.dbFile.split('./')[1]}`,
+          && err.message === `Unable to parse DB file ${normalize(config.dbFile)}`,
       );
     });
 
@@ -62,7 +63,7 @@ export const jsonFileServiceTestSuite = async () => {
       return assert.rejects(
         service.ready,
         (err) => err instanceof Error
-          && err.message === `DB file should have an array of layouts ${config.dbFile.split('./')[1]}`,
+          && err.message === `DB file should have an array of layouts ${normalize(config.dbFile)}`,
       );
     });
 
@@ -87,7 +88,7 @@ export const jsonFileServiceTestSuite = async () => {
       await assert.rejects(
         service.ready,
         (err) => err instanceof Error
-          && err.message === `Unable to parse DB file ${config.dbFile.split('./')[1]}`,
+          && err.message === `Unable to parse DB file ${normalize(config.dbFile)}`,
       );
     });
   });


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is new feature explain how plan to use it
- [ ] test are added
- [ ] documentation is changed or added
- [ ] FLP integration tests were ran successful

To prevent false negatives in tests due to path formatting differences:
* Updated expected error message to use `path.normalize(config.dbFile)` instead of `config.dbFile.split('./')[1]`, see docs: https://nodejs.org/api/path.html#pathnormalizepath
  * Ensures consistent behavior across platforms
  * Improves resilience when users provide paths with mixed or repeated slashes