### PR TITLE
Use `pathToFileURL` for dynamic import of config file

### DIFF
--- a/QualityControl/lib/config/configProvider.js
+++ b/QualityControl/lib/config/configProvider.js
@@ -16,7 +16,7 @@
 import { LogManager } from '@aliceo2/web-ui';
 import { realpath } from 'node:fs/promises';
 import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'qcg'}/config`);
 
@@ -27,7 +27,7 @@ let configFilePath = _getConfigurationFilePath();
 
 try {
   configFilePath = await realpath(configFilePath);
-  ({ config } = await import(configFilePath));
+  ({ config } = await import(pathToFileURL(configFilePath).href));
 
   logger.info(`Configuration file successfully read from: "${configFilePath}"`);
 } catch (err) {


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is new feature explain how plan to use it
- [ ] test are added
- [ ] documentation is changed or added
- [ ] FLP integration tests were ran successful

* Use `pathToFileURL(configFilePath).href` when importing the config to ensure cross-platform compatibility (Windows _(windows filepath)_, macOS _(posix)_, Linux _(posix)_) and correct handling of special characters. The `windows` option is left `undefined`, so the platform system default is used.

- See docs here: https://nodejs.org/api/url.html#urlpathtofileurlpath-options