### PR TITLE
[OGUI-1861] Allow `blob:` in img-src CSP

### DIFF
--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -156,6 +156,7 @@ class HttpServer {
       directives: {
         /* eslint-disable */
         defaultSrc: ["'self'", "data:", hostname + ':*'],
+        imgSrc: ["'self'", "data:", "blob:"],
         scriptSrc: ["'self'", ...(allow ? ["'unsafe-eval'"] : [])],
         styleSrc: ["'self'", "'unsafe-inline'"],
         connectSrc: ["'self'", 'http://' + hostname + ':' + port, 'https://' + hostname, 'wss://' + hostname, 'ws://' + hostname + ':' + port],

--- a/Framework/Backend/http/server.js
+++ b/Framework/Backend/http/server.js
@@ -135,8 +135,9 @@ class HttpServer {
    * @param {number} config.port secure port number
    * @param {list} config.iframeCsp list of URLs for frame-src CSP
    * @param {boolean} config.allow allow unsafe-eval in CSP
+   * @param {boolean} config.allowIframeCsp allow iframe embedding from given URLs
    */
-  configureHelmet({ hostname, port, iframeCsp = [], allow = false }) {
+  configureHelmet({ hostname, port, iframeCsp = [], allow = false, allowIframeCsp = false }) {
     // Sets "X-Frame-Options: DENY" (doesn't allow to be in any iframe)
     this.app.use(helmet.frameguard({ action: 'deny' }));
     // Sets "Strict-Transport-Security: max-age=5184000 (60 days) (stick to HTTPS)
@@ -156,7 +157,7 @@ class HttpServer {
       directives: {
         /* eslint-disable */
         defaultSrc: ["'self'", "data:", hostname + ':*'],
-        imgSrc: ["'self'", "data:", "blob:"],
+        ...(allowIframeCsp && { imgSrc: ["'self'", "data:", "blob:"] }),
         scriptSrc: ["'self'", ...(allow ? ["'unsafe-eval'"] : [])],
         styleSrc: ["'self'", "'unsafe-inline'"],
         connectSrc: ["'self'", 'http://' + hostname + ':' + port, 'https://' + hostname, 'wss://' + hostname, 'ws://' + hostname + ':' + port],


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful


Changes:
- Update Content-Security-Policy to permit `blob:` URLs for images only.

The changes allow for Blob-based images to be previewed or downloaded.
Other Blob types such as `script-src` are not permitted, mainly to prevent unwanted code execution via:
```js
const blob = new Blob(['console.log(\'executed\')'], { type: 'application/javascript' });
```
By default, Helmet's CSP middleware allows `"'self'", "data:"` in `img-src`, see: https://github.com/helmetjs/helmet/blob/dd6e18f735d61248f654df3960da80db7fb2120a/middlewares/content-security-policy/index.ts#L63.

Do note that `blob:` URLs are entirely local to the browser. When you create a blob URL using `URL.createObjectURL(blob)`, the browser generates an internal reference to an in-memory `Blob` or `MediaSource` object. It cannot be used to fetch resources from another website. For more information, please see the documentation: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/blob