### PR TITLE
[OGUI-1846] Pass on drawing options from qcdb metadata in layout show

### DIFF
--- a/QualityControl/public/layout/view/page.js
+++ b/QualityControl/public/layout/view/page.js
@@ -192,16 +192,30 @@ function chartView(model, tabObject) {
 /**
  * Method to generate a component containing a header with actions and a jsroot plot
  * @param {Model} model - root model of the application
- * @param {object} tabObject - to be drawn with jsroot
+ * @param {TabObject} tabObject - object with information form QCG own storage
  * @returns {vnode} - virtual node element
  */
 const drawComponent = (model, tabObject) => {
   const { displayTimestamp = false } = model.layout.item;
-  const { name, options: drawingOptions = [] } = tabObject;
+
+  const objectFromLayoutAsRemoteData = tabObject;
+  const { name, options: drawingOptions = [], ignoreDefaults } = objectFromLayoutAsRemoteData;
+
+  const objectFromQcdbAsRemoteData = model.object.objects[name];
+  const { displayHints = [], drawOptions = [] } = objectFromQcdbAsRemoteData?.payload ?? {};
+
+  let toUseDrawingOptions = [];
+  if (ignoreDefaults) {
+    toUseDrawingOptions = Array.from(new Set(drawingOptions));
+  } else {
+    toUseDrawingOptions = Array.from(new Set([...drawingOptions, ...displayHints, ...drawOptions]));
+  }
   const lastModified = model.object.getLastModifiedByName(name);
   const runNumber = model.object.getRunNumberByName(name);
-
-  return h('', { style: 'height:100%; display: flex; flex-direction: column' }, [
+  return h('', {
+    key: `key-chart-component-${name}-${toUseDrawingOptions.join('-')}`,
+    style: 'height:100%; display: flex; flex-direction: column',
+  }, [
     h('.jsrootdiv', {
       style: {
         'z-index': 90,
@@ -211,9 +225,9 @@ const drawComponent = (model, tabObject) => {
         'flex-direction': 'column',
       },
     }, draw(
-      model.object.objects[tabObject.name],
+      objectFromQcdbAsRemoteData,
       {},
-      drawingOptions,
+      toUseDrawingOptions,
       (error) => model.object.invalidObject(tabObject.name, error.message),
     )),
     objectInfoResizePanel(model, tabObject),

--- a/QualityControl/public/layout/view/page.js
+++ b/QualityControl/public/layout/view/page.js
@@ -198,10 +198,9 @@ function chartView(model, tabObject) {
 const drawComponent = (model, tabObject) => {
   const { displayTimestamp = false } = model.layout.item;
 
-  const objectFromLayoutAsRemoteData = tabObject;
-  const { name, options: drawingOptions = [], ignoreDefaults } = objectFromLayoutAsRemoteData;
+  const { name, options: drawingOptions = [], ignoreDefaults } = tabObject;
 
-  const objectFromQcdbAsRemoteData = model.object.objects[name];
+  const objectFromQcdbAsRemoteData = model?.object?.objects?.[name] ?? {};
   const { displayHints = [], drawOptions = [] } = objectFromQcdbAsRemoteData?.payload ?? {};
 
   let toUseDrawingOptions = [];


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* takes into consideration drawoptions and displayhints from CCDB metadata and the `ignoreDefaults` option set by the user in the layout
* combines these options with the user saved layout options and uses them to plot the object.