### PR TITLE
[OGUI-893] Reorder tabs in QCG layout

### DIFF
--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -192,6 +192,7 @@
   position: absolute;
   height: 100%;
   width: 50%;
+  pointer-events: none;
 
   &.before {
     left: 0;
@@ -208,4 +209,8 @@
       border-right: 2px solid var(--color-primary);
     }
   }
+}
+
+.pointer-events-auto {
+  pointer-events: auto;
 }

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -197,7 +197,7 @@
     left: 0;
 
     &.active {
-      border-left: 2px solid blue;
+      border-left: 2px solid var(--color-primary);
     }
   }
 
@@ -205,7 +205,7 @@
     right: 0;
 
     &.active {
-      border-right: 2px solid blue;
+      border-right: 2px solid var(--color-primary);
     }
   }
 }

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -214,3 +214,6 @@
 .pointer-events-auto {
   pointer-events: auto;
 }
+.pointer-events-none {
+  pointer-events: none;
+}

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -152,9 +152,9 @@
   }
 }
 
-.cursor-pointer {
-  cursor: pointer;
-}
+.cursor-pointer { cursor: pointer; }
+.cursor-grab { cursor: grab; }
+.cursor-inherit { cursor: inherit; }
 
 .header-layout {
   &.edit {

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -187,3 +187,25 @@
 .whitespace-nowrap {
   white-space: nowrap;
 }
+
+.drop-zone {
+  position: absolute;
+  height: 100%;
+  width: 50%;
+
+  &.before {
+    left: 0;
+
+    &.active {
+      border-left: 2px solid blue;
+    }
+  }
+
+  &.after {
+    right: 0;
+
+    &.active {
+      border-right: 2px solid blue;
+    }
+  }
+}

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -62,6 +62,7 @@ export default class Layout extends BaseViewModel {
     this.cellHeight = 100 / this.gridListSize * 0.95; // %, put some margin at bottom to see below
     this.cellWidth = 100 / this.gridListSize; // %
 
+    this.isDragging = false;
     this.dropTargetId = undefined;
     this.position = undefined;
   }
@@ -834,6 +835,27 @@ export default class Layout extends BaseViewModel {
     }
 
     this.item.tabs.splice(targetIndex, 0, movedTab);
+
+    this.notify();
+  }
+
+  /**
+   * Sets the layout state to indicate that a tab drag-and-drop operation has begun.
+   * It typically triggers a redraw and enables pointer events on all drop zones via CSS.
+   */
+  startDragging() {
+    this.isDragging = true;
+
+    this.notify();
+  }
+
+  /**
+   * Resets the layout state to indicate that a tab drag-and-drop operation has ended,
+   * regardless of whether the drop was successful or cancelled.
+   * It typically triggers a redraw and disables pointer events on the drop zones via CSS.
+   */
+  stopDragging() {
+    this.isDragging = false;
 
     this.notify();
   }

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -61,6 +61,9 @@ export default class Layout extends BaseViewModel {
     });
     this.cellHeight = 100 / this.gridListSize * 0.95; // %, put some margin at bottom to see below
     this.cellWidth = 100 / this.gridListSize; // %
+
+    this.dropTargetId = undefined;
+    this.position = undefined;
   }
 
   /**
@@ -776,5 +779,52 @@ export default class Layout extends BaseViewModel {
    */
   ownsLayout(layoutOwnerId) {
     return this.model.session.personid == layoutOwnerId;
+  }
+
+  /**
+   * TODO
+   * @param {*} tabId TODO
+   * @param {*} position TODO
+   */
+  setDropTarget(tabId, position) {
+    this.dropTargetId = tabId;
+    this.position = position;
+  }
+
+  /**
+   * TODO
+   */
+  clearDropTarget() {
+    this.dropTargetId = undefined
+    this.position = undefined
+  }
+
+  /**
+   * TODO
+   * @param {*} sourceId TODO
+   * @param {*} targetId TODO
+   * @param {*} position TODO
+   */
+  reorderTabs(sourceId, targetId, position) {
+    const sourceIndex = this.item.tabs.findIndex((t) => t.id === sourceId);
+    let targetIndex = this.item.tabs.findIndex((t) => t.id === targetId);
+
+    if (sourceIndex === -1 || targetIndex === -1) {
+      return;
+    }
+
+    if (position === 'after') {
+      targetIndex += 1;
+    }
+
+    const [movedTab] = this.item.tabs.splice(sourceIndex, 1);
+
+    if (sourceIndex < targetIndex) {
+      targetIndex--;
+    }
+
+    this.item.tabs.splice(targetIndex, 0, movedTab);
+
+    this.notify();
   }
 }

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -782,9 +782,11 @@ export default class Layout extends BaseViewModel {
   }
 
   /**
-   * TODO
-   * @param {*} tabId TODO
-   * @param {*} position TODO
+   * Sets the current drop target for a drag-and-drop operation.
+   * This is typically used to render a visual indicator (like a blue line)
+   * in the UI showing where the dragged tab will be placed.
+   * @param {string|number} tabId - The ID of the tab currently being hovered over.
+   * @param {'before'|'after'} position - The side of the target tab where the drop indicator should appear.
    */
   setDropTarget(tabId, position) {
     this.dropTargetId = tabId;
@@ -794,7 +796,9 @@ export default class Layout extends BaseViewModel {
   }
 
   /**
-   * TODO
+   * Clears the current drop target state, usually when the drag operation
+   * is finished or the dragged item is no longer over a valid drop zone.
+   * This action typically causes the visual drop indicator to be hidden.
    */
   clearDropTarget() {
     this.dropTargetId = undefined
@@ -804,10 +808,12 @@ export default class Layout extends BaseViewModel {
   }
 
   /**
-   * TODO
-   * @param {*} sourceId TODO
-   * @param {*} targetId TODO
-   * @param {*} position TODO
+   * Reorders the tabs in the internal array based on the drag source and drop target.
+   * This function calculates the correct index for insertion, accounting for the
+   * tab being removed from its original position.
+   * @param {string|number} sourceId - The ID of the tab that was dragged.
+   * @param {string|number} targetId - The ID of the tab that the source was dropped onto.
+   * @param {'before'|'after'} position - The placement relative to the target tab.
    */
   reorderTabs(sourceId, targetId, position) {
     const sourceIndex = this.item.tabs.findIndex((t) => t.id === sourceId);

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -789,6 +789,8 @@ export default class Layout extends BaseViewModel {
   setDropTarget(tabId, position) {
     this.dropTargetId = tabId;
     this.position = position;
+
+    this.notify();
   }
 
   /**
@@ -797,6 +799,8 @@ export default class Layout extends BaseViewModel {
   clearDropTarget() {
     this.dropTargetId = undefined
     this.position = undefined
+
+    this.notify();
   }
 
   /**

--- a/QualityControl/public/layout/Layout.js
+++ b/QualityControl/public/layout/Layout.js
@@ -801,8 +801,8 @@ export default class Layout extends BaseViewModel {
    * This action typically causes the visual drop indicator to be hidden.
    */
   clearDropTarget() {
-    this.dropTargetId = undefined
-    this.position = undefined
+    this.dropTargetId = undefined;
+    this.position = undefined;
 
     this.notify();
   }

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -143,6 +143,8 @@ const toolbarEditModeTab = (layout, tab, i) => {
    */
   const selectTab = () => layout.selectTab(i);
 
+  const dropZoneClass = (position) => layout.dropTargetId === tab.id && layout.position === position ? 'active' : ''
+
   return [
     h(
       '.btn-group.flex-fixed',
@@ -150,32 +152,41 @@ const toolbarEditModeTab = (layout, tab, i) => {
         style: 'position: relative;',
         draggable: true,
         ondragstart: (e) => {
-          e.dataTransfer.setData('text/plain', tab.id)
+          e.dataTransfer.setData('text/plain', tab.id);
         },
         ondrop: (e) => {
-          layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position)
+          layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position);
+          layout.clearDropTarget();
         }
       },
       [
         h('button.br-pill.ph2.btn.btn-tab.whitespace-nowrap', { class: linkClass, onclick: selectTab }, tab.name),
         [
           h(
-            '.before',
+            '.drop-zone.before',
             {
-              style: 'position: absolute; left: 0; width: 50%; height: 100%; background-color: rgb(30 80 120 / 25%);',
+              class: dropZoneClass('before'),
               ondragenter: () => layout.setDropTarget(tab.id, 'before'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
-              ondragleave: () => layout.clearDropTarget()
+              ondragleave: () => {
+                if (layout.dropTargetId === tab.id && layout.position === 'before') {
+                  layout.clearDropTarget();
+                }
+              }
             },
             ''
           ),
           h(
-            '.after',
+            '.drop-zone.after',
             {
-              style: 'position: absolute; right: 0; width: 50%; height: 100%; background-color: rgb(80 20 70 / 25%);',
+              class: dropZoneClass('after'),
               ondragenter: () => layout.setDropTarget(tab.id, 'after'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
-              ondragleave: () => layout.clearDropTarget()
+              ondragleave: () => {
+                if (layout.dropTargetId === tab.id && layout.position === 'after') {
+                  layout.clearDropTarget();
+                }
+              }
             },
             ''
           ),

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -199,9 +199,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
             '',
           ),
           selected && [
-            editTabButton(layout, `${linkClass} ${dragDisableClass}`, tab, i),
+            editTabButton(layout, linkClass, tab, i),
             resizeGridTabDropDown(layout, tab),
-            deleteTabButton(layout, `${linkClass} ${dragDisableClass}`, i),
+            deleteTabButton(layout, linkClass, i),
           ],
         ].flat().filter(Boolean),
       ],

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -148,7 +148,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
 
   return [
     h(
-      '.btn-group.flex-fixed.relative',
+      '.btn-group.flex-fixed.relative.cursor-grab',
       {
         draggable: true,
         ondragstart: (e) => {
@@ -162,7 +162,11 @@ const toolbarEditModeTab = (layout, tab, i) => {
         },
       },
       [
-        h('button.br-pill.ph2.btn.btn-tab.whitespace-nowrap', { class: linkClass, onclick: selectTab }, tab.name),
+        h(
+          'button.br-pill.ph2.btn.btn-tab.whitespace-nowrap',
+          { id: 'btn-tab', class: `${linkClass} cursor-inherit`, onclick: selectTab },
+          tab.name,
+        ),
         [
           h(
             '.drop-zone.before',

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -136,6 +136,7 @@ const toolbarEditMode = (layout) => {
 const toolbarEditModeTab = (layout, tab, i) => {
   const selected = layout.tab.name === tab.name;
   const linkClass = selected ? 'selected' : '';
+  const dragDisableClass = layout.isDragging ? 'pointer-events-none' : '';
 
   /**
    * Handler when user click on a tab to select it
@@ -198,9 +199,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
             '',
           ),
           selected && [
-            editTabButton(layout, linkClass, tab, i),
+            editTabButton(layout, `${linkClass} ${dragDisableClass}`, tab, i),
             resizeGridTabDropDown(layout, tab),
-            deleteTabButton(layout, linkClass, i),
+            deleteTabButton(layout, `${linkClass} ${dragDisableClass}`, i),
           ],
         ].flat().filter(Boolean),
       ],

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -136,7 +136,6 @@ const toolbarEditMode = (layout) => {
 const toolbarEditModeTab = (layout, tab, i) => {
   const selected = layout.tab.name === tab.name;
   const linkClass = selected ? 'selected' : '';
-  const dragDisableClass = layout.isDragging ? 'pointer-events-none' : '';
 
   /**
    * Handler when user click on a tab to select it

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -143,6 +143,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
    */
   const selectTab = () => layout.selectTab(i);
 
+  const dragActiveClass = layout.isDragging ? 'pointer-events-auto' : '';
   const dropZoneClass = (position) => layout.dropTargetId === tab.id && layout.position === position ? 'active' : '';
 
   return [
@@ -150,10 +151,14 @@ const toolbarEditModeTab = (layout, tab, i) => {
       '.btn-group.flex-fixed.relative',
       {
         draggable: true,
-        ondragstart: (e) => e.dataTransfer.setData('text/plain', tab.id),
+        ondragstart: (e) => {
+          e.dataTransfer.setData('text/plain', tab.id);
+          layout.startDragging();
+        },
         ondrop: (e) => {
           layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position);
           layout.clearDropTarget();
+          layout.stopDragging();
         },
       },
       [
@@ -162,7 +167,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
           h(
             '.drop-zone.before',
             {
-              class: dropZoneClass('before'),
+              class: `${dragActiveClass} ${dropZoneClass('before')}`,
               ondragenter: () => layout.setDropTarget(tab.id, 'before'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
               ondragleave: () => {
@@ -176,7 +181,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
           h(
             '.drop-zone.after',
             {
-              class: dropZoneClass('after'),
+              class: `${dragActiveClass} ${dropZoneClass('after')}`,
               ondragenter: () => layout.setDropTarget(tab.id, 'after'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
               ondragleave: () => {

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -144,6 +144,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
   const selectTab = () => layout.selectTab(i);
 
   const dragActiveClass = layout.isDragging ? 'pointer-events-auto' : '';
+  const disableButtonsOnDragClass = layout.isDragging ? 'pointer-events-none' : '';
   const dropZoneClass = (position) => layout.dropTargetId === tab.id && layout.position === position ? 'active' : '';
 
   return [
@@ -161,6 +162,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
           layout.clearDropTarget();
           layout.stopDragging();
         },
+        ondragend: () => layout.stopDragging(),
       },
       [
         h(
@@ -198,9 +200,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
             '',
           ),
           selected && [
-            editTabButton(layout, linkClass, tab, i),
+            editTabButton(layout, `${disableButtonsOnDragClass} ${linkClass}`, tab, i),
             resizeGridTabDropDown(layout, tab),
-            deleteTabButton(layout, linkClass, i),
+            deleteTabButton(layout, `${disableButtonsOnDragClass} ${linkClass}`, i),
           ],
         ].flat().filter(Boolean),
       ],

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -143,7 +143,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
    */
   const selectTab = () => layout.selectTab(i);
 
-  const dropZoneClass = (position) => layout.dropTargetId === tab.id && layout.position === position ? 'active' : ''
+  const dropZoneClass = (position) => layout.dropTargetId === tab.id && layout.position === position ? 'active' : '';
 
   return [
     h(
@@ -154,7 +154,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
         ondrop: (e) => {
           layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position);
           layout.clearDropTarget();
-        }
+        },
       },
       [
         h('button.br-pill.ph2.btn.btn-tab.whitespace-nowrap', { class: linkClass, onclick: selectTab }, tab.name),
@@ -169,9 +169,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
                 if (layout.dropTargetId === tab.id && layout.position === 'before') {
                   layout.clearDropTarget();
                 }
-              }
+              },
             },
-            ''
+            '',
           ),
           h(
             '.drop-zone.after',
@@ -183,17 +183,17 @@ const toolbarEditModeTab = (layout, tab, i) => {
                 if (layout.dropTargetId === tab.id && layout.position === 'after') {
                   layout.clearDropTarget();
                 }
-              }
+              },
             },
-            ''
+            '',
           ),
           selected && [
             editTabButton(layout, linkClass, tab, i),
             resizeGridTabDropDown(layout, tab),
             deleteTabButton(layout, linkClass, i),
           ],
-        ].flat().filter(Boolean)
-      ]
+        ].flat().filter(Boolean),
+      ],
     ),
     ' ',
   ];

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -151,12 +151,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
         draggable: true,
         ondragstart: (e) => {
           e.dataTransfer.setData('text/plain', tab.id)
-          console.log(e.dataTransfer.getData('text/plain'))
-          console.log('dragstart', e)
         },
         ondrop: (e) => {
-          console.log('ondrop', e)
-          console.log(e.dataTransfer.getData('text/plain'))
+          layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position)
         }
       },
       [
@@ -166,9 +163,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
             '.before',
             {
               style: 'position: absolute; left: 0; width: 50%; height: 100%; background-color: rgb(30 80 120 / 25%);',
-              ondragenter: (e) => console.log('enter before', e),
+              ondragenter: () => layout.setDropTarget(tab.id, 'before'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
-              ondragleave: (e) => console.log('leave before', e)
+              ondragleave: () => layout.clearDropTarget()
             },
             ''
           ),
@@ -176,9 +173,9 @@ const toolbarEditModeTab = (layout, tab, i) => {
             '.after',
             {
               style: 'position: absolute; right: 0; width: 50%; height: 100%; background-color: rgb(80 20 70 / 25%);',
-              ondragenter: (e) => console.log('enter after', e),
+              ondragenter: () => layout.setDropTarget(tab.id, 'after'),
               ondragover: (e) => e.preventDefault(), // prevent default to allow drop
-              ondragleave: (e) => console.log('leave after', e)
+              ondragleave: () => layout.clearDropTarget()
             },
             ''
           ),

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -150,6 +150,7 @@ const toolbarEditModeTab = (layout, tab, i) => {
     h(
       '.btn-group.flex-fixed.relative.cursor-grab',
       {
+        title: 'Drag the tab to re-arrange them',
         draggable: true,
         ondragstart: (e) => {
           e.dataTransfer.setData('text/plain', tab.id);

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -144,14 +144,52 @@ const toolbarEditModeTab = (layout, tab, i) => {
   const selectTab = () => layout.selectTab(i);
 
   return [
-    h('.btn-group.flex-fixed', [
-      h('button.br-pill.ph2.btn.btn-tab.whitespace-nowrap', { class: linkClass, onclick: selectTab }, tab.name),
-      selected && [
-        editTabButton(layout, linkClass, tab, i),
-        resizeGridTabDropDown(layout, tab),
-        deleteTabButton(layout, linkClass, i),
-      ],
-    ]),
+    h(
+      '.btn-group.flex-fixed',
+      {
+        style: 'position: relative;',
+        draggable: true,
+        ondragstart: (e) => {
+          e.dataTransfer.setData('text/plain', tab.id)
+          console.log(e.dataTransfer.getData('text/plain'))
+          console.log('dragstart', e)
+        },
+        ondrop: (e) => {
+          console.log('ondrop', e)
+          console.log(e.dataTransfer.getData('text/plain'))
+        }
+      },
+      [
+        h('button.br-pill.ph2.btn.btn-tab.whitespace-nowrap', { class: linkClass, onclick: selectTab }, tab.name),
+        [
+          h(
+            '.before',
+            {
+              style: 'position: absolute; left: 0; width: 50%; height: 100%; background-color: rgb(30 80 120 / 25%);',
+              ondragenter: (e) => console.log('enter before', e),
+              ondragover: (e) => e.preventDefault(), // prevent default to allow drop
+              ondragleave: (e) => console.log('leave before', e)
+            },
+            ''
+          ),
+          h(
+            '.after',
+            {
+              style: 'position: absolute; right: 0; width: 50%; height: 100%; background-color: rgb(80 20 70 / 25%);',
+              ondragenter: (e) => console.log('enter after', e),
+              ondragover: (e) => e.preventDefault(), // prevent default to allow drop
+              ondragleave: (e) => console.log('leave after', e)
+            },
+            ''
+          ),
+          selected && [
+            editTabButton(layout, linkClass, tab, i),
+            resizeGridTabDropDown(layout, tab),
+            deleteTabButton(layout, linkClass, i),
+          ],
+        ].flat().filter(Boolean)
+      ]
+    ),
     ' ',
   ];
 };

--- a/QualityControl/public/layout/view/header.js
+++ b/QualityControl/public/layout/view/header.js
@@ -147,13 +147,10 @@ const toolbarEditModeTab = (layout, tab, i) => {
 
   return [
     h(
-      '.btn-group.flex-fixed',
+      '.btn-group.flex-fixed.relative',
       {
-        style: 'position: relative;',
         draggable: true,
-        ondragstart: (e) => {
-          e.dataTransfer.setData('text/plain', tab.id);
-        },
+        ondragstart: (e) => e.dataTransfer.setData('text/plain', tab.id),
         ondrop: (e) => {
           layout.reorderTabs(e.dataTransfer.getData('text/plain'), layout.dropTargetId, layout.position);
           layout.clearDropTarget();

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -317,9 +317,6 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
-      await page.screenshot({
-        path: 'something.png'
-      });
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -300,96 +300,8 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
 
   await testParent.test(
     'should reorder tabs via drag and drop in edit mode',
-    { timeout: Infinity },
+    { timeout },
     async () => {
-      const installMouseHelper = async (page) => {
-        await page.evaluate(() => {
-          const box = document.createElement('puppeteer-mouse-pointer');
-          const style = document.createElement('style');
-          style.innerHTML = `
-            puppeteer-mouse-pointer {
-              pointer-events: none;
-              position: fixed; /* Changed to FIXED to match Puppeteer's viewport logic */
-              top: 0;
-              z-index: 999999;
-              left: 0;
-              width: 20px;
-              height: 20px;
-              background: rgba(255, 0, 0, 0.8);
-              border: 3px solid white;
-              border-radius: 50%;
-              margin: -10px 0 0 -10px;
-              padding: 0;
-              box-sizing: border-box;
-            }
-            puppeteer-mouse-pointer.down {
-              background: rgba(0, 255, 0, 0.9);
-              transform: scale(1.2);
-            }
-          `;
-          document.head.appendChild(style);
-          document.body.appendChild(box);
-
-          document.addEventListener('mousemove', event => {
-            // clientX/Y is relative to the viewport, matching Puppeteer's mouse
-            box.style.left = event.clientX + 'px';
-            box.style.top = event.clientY + 'px';
-          }, true);
-
-          document.addEventListener('mousedown', () => {
-            box.classList.add('down');
-          }, true);
-
-          document.addEventListener('mouseup', () => {
-            box.classList.remove('down');
-          }, true);
-        });
-      };
-
-      const drawDebugDot = async (page, coord, label = '', color = 'red') => {
-        await page.evaluate(({ x, y, label, color }) => {
-          const dot = document.createElement('div');
-          dot.className = 'debug-dot';
-          dot.style.cssText = `
-            position: fixed;
-            left: ${x}px;
-            top: ${y}px;
-            width: 12px;
-            height: 12px;
-            background-color: ${color};
-            border: 2px solid white;
-            border-radius: 50%;
-            z-index: 1000000;
-            pointer-events: none;
-            margin-left: -6px;
-            margin-top: -6px;
-            box-shadow: 0 0 5px rgba(0,0,0,0.5);
-          `;
-
-          if (label) {
-            const text = document.createElement('span');
-            text.textContent = label;
-            text.style.cssText = `
-              position: absolute;
-              top: 15px;
-              left: 50%;
-              transform: translateX(-50%);
-              background: black;
-              color: white;
-              padding: 2px 5px;
-              font-size: 10px;
-              border-radius: 3px;
-              white-space: nowrap;
-            `;
-            dot.appendChild(text);
-          }
-
-          document.body.appendChild(dot);
-        }, { x: coord.x, y: coord.y, label, color });
-      };
-
-      await installMouseHelper(page);
-
       const originalTabNames = await page.$$eval('#btn-tab', (elements) =>
         elements.map((element) => element.textContent.trim()));
 
@@ -398,9 +310,6 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
 
       const sourceCenter = await getElementCenter(page, sourceTabSelector);
       const targetCenter = await getElementCenter(page, targetZoneSelector);
-
-      await drawDebugDot(page, sourceCenter, 'Source', 'blue');
-      await drawDebugDot(page, targetCenter, 'Target', 'orange');
 
       await page.mouse.move(sourceCenter.x, sourceCenter.y);
       await page.mouse.down();

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -317,6 +317,8 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
+      await delay(1000);
+
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -302,6 +302,9 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
     'should reorder tabs via drag and drop in edit mode',
     { timeout },
     async () => {
+      const originalTabNames = await page.$$eval('#btn-tab', (elements) =>
+        elements.map((element) => element.textContent.trim()));
+
       const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1)';
       const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) .drop-zone.after';
 
@@ -322,7 +325,7 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       const tabNames = await page.$$eval('#btn-tab', (elements) =>
         elements.map((element) => element.textContent.trim()));
 
-      strictEqual(tabNames[1], 'main');
+      strictEqual(tabNames[1], originalTabNames[0]);
     }
   );
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -305,7 +305,7 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       const originalTabNames = await page.$$eval('#btn-tab', (elements) =>
         elements.map((element) => element.textContent.trim()));
 
-      const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1)';
+      const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1) > .btn-tab';
       const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) .drop-zone.after';
 
       const sourceCenter = await getElementCenter(page, sourceTabSelector);
@@ -317,10 +317,8 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
-      console.log('before');
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
-      console.log('after');
 
       await page.mouse.up();
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -314,11 +314,15 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       await page.mouse.move(sourceCenter.x, sourceCenter.y);
       await page.mouse.down();
 
+      await delay(100);
+
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
+
+      await delay(100);
 
       await page.mouse.up();
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -314,15 +314,13 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       await page.mouse.move(sourceCenter.x, sourceCenter.y);
       await page.mouse.down();
 
-      await delay(100);
-
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
+      console.log('before');
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
-
-      await delay(100);
+      console.log('after');
 
       await page.mouse.up();
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -306,7 +306,7 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
         elements.map((element) => element.textContent.trim()));
 
       const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1) > .btn-tab';
-      const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) .drop-zone.after';
+      const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) select';
 
       const sourceCenter = await getElementCenter(page, sourceTabSelector);
       const targetCenter = await getElementCenter(page, targetZoneSelector);

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -300,16 +300,107 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
 
   await testParent.test(
     'should reorder tabs via drag and drop in edit mode',
-    { timeout },
+    { timeout: Infinity },
     async () => {
+      const installMouseHelper = async (page) => {
+        await page.evaluate(() => {
+          const box = document.createElement('puppeteer-mouse-pointer');
+          const style = document.createElement('style');
+          style.innerHTML = `
+            puppeteer-mouse-pointer {
+              pointer-events: none;
+              position: fixed; /* Changed to FIXED to match Puppeteer's viewport logic */
+              top: 0;
+              z-index: 999999;
+              left: 0;
+              width: 20px;
+              height: 20px;
+              background: rgba(255, 0, 0, 0.8);
+              border: 3px solid white;
+              border-radius: 50%;
+              margin: -10px 0 0 -10px;
+              padding: 0;
+              box-sizing: border-box;
+            }
+            puppeteer-mouse-pointer.down {
+              background: rgba(0, 255, 0, 0.9);
+              transform: scale(1.2);
+            }
+          `;
+          document.head.appendChild(style);
+          document.body.appendChild(box);
+
+          document.addEventListener('mousemove', event => {
+            // clientX/Y is relative to the viewport, matching Puppeteer's mouse
+            box.style.left = event.clientX + 'px';
+            box.style.top = event.clientY + 'px';
+          }, true);
+
+          document.addEventListener('mousedown', () => {
+            box.classList.add('down');
+          }, true);
+
+          document.addEventListener('mouseup', () => {
+            box.classList.remove('down');
+          }, true);
+        });
+      };
+
+      const drawDebugDot = async (page, coord, label = '', color = 'red') => {
+        await page.evaluate(({ x, y, label, color }) => {
+          const dot = document.createElement('div');
+          dot.className = 'debug-dot';
+          dot.style.cssText = `
+            position: fixed;
+            left: ${x}px;
+            top: ${y}px;
+            width: 12px;
+            height: 12px;
+            background-color: ${color};
+            border: 2px solid white;
+            border-radius: 50%;
+            z-index: 1000000;
+            pointer-events: none;
+            margin-left: -6px;
+            margin-top: -6px;
+            box-shadow: 0 0 5px rgba(0,0,0,0.5);
+          `;
+
+          if (label) {
+            const text = document.createElement('span');
+            text.textContent = label;
+            text.style.cssText = `
+              position: absolute;
+              top: 15px;
+              left: 50%;
+              transform: translateX(-50%);
+              background: black;
+              color: white;
+              padding: 2px 5px;
+              font-size: 10px;
+              border-radius: 3px;
+              white-space: nowrap;
+            `;
+            dot.appendChild(text);
+          }
+
+          document.body.appendChild(dot);
+        }, { x: coord.x, y: coord.y, label, color });
+      };
+
+      await installMouseHelper(page);
+
       const originalTabNames = await page.$$eval('#btn-tab', (elements) =>
         elements.map((element) => element.textContent.trim()));
 
       const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1)';
-      const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) select';
+      const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) .drop-zone.after';
 
       const sourceCenter = await getElementCenter(page, sourceTabSelector);
       const targetCenter = await getElementCenter(page, targetZoneSelector);
+
+      await drawDebugDot(page, sourceCenter, 'Source', 'blue');
+      await drawDebugDot(page, targetCenter, 'Target', 'orange');
 
       await page.mouse.move(sourceCenter.x, sourceCenter.y);
       await page.mouse.down();
@@ -317,6 +408,9 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       // We add 'steps' to make the move smoother, which helps trigger event
       await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
 
+      await page.screenshot({
+        path: 'something.png'
+      });
       // Wait a moment for the 'active' class to appear in the UI
       await page.waitForSelector('.drop-zone.after.active');
 

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -305,7 +305,7 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
       const originalTabNames = await page.$$eval('#btn-tab', (elements) =>
         elements.map((element) => element.textContent.trim()));
 
-      const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1) > .btn-tab';
+      const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1)';
       const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) select';
 
       const sourceCenter = await getElementCenter(page, sourceTabSelector);

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -14,6 +14,7 @@
 import { strictEqual, ok, deepStrictEqual } from 'node:assert';
 import { delay } from '../../testUtils/delay.js';
 import { editedMockedLayout } from '../../setup/seeders/layout-show/json-file-mock.js';
+import { getElementCenter } from '../../testUtils/dragAndDrop.js';
 
 /**
  * Performs a series of automated tests on the layoutShow page using Puppeteer.
@@ -295,6 +296,34 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
         document.querySelectorAll(secondElementPath).length, secondElementPath);
       strictEqual(rowsCount, 1);
     },
+  );
+
+  await testParent.test(
+    'should reorder tabs via drag and drop in edit mode',
+    { timeout },
+    async () => {
+      const sourceTabSelector = '.btn-group.flex-fixed.relative:nth-child(1)';
+      const targetZoneSelector = '.btn-group.flex-fixed.relative:nth-child(2) .drop-zone.after';
+
+      const sourceCenter = await getElementCenter(page, sourceTabSelector);
+      const targetCenter = await getElementCenter(page, targetZoneSelector);
+
+      await page.mouse.move(sourceCenter.x, sourceCenter.y);
+      await page.mouse.down();
+
+      // We add 'steps' to make the move smoother, which helps trigger event
+      await page.mouse.move(targetCenter.x, targetCenter.y, { steps: 10 });
+
+      // Wait a moment for the 'active' class to appear in the UI
+      await page.waitForSelector('.drop-zone.after.active');
+
+      await page.mouse.up();
+
+      const tabNames = await page.$$eval('#btn-tab', (elements) =>
+        elements.map((element) => element.textContent.trim()));
+
+      strictEqual(tabNames[1], 'main');
+    }
   );
 
   await testParent.test(

--- a/QualityControl/test/testUtils/dragAndDrop.js
+++ b/QualityControl/test/testUtils/dragAndDrop.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Helper to get the center of an element.
+ * @param {object} page - Puppeteer page object.
+ * @param {string} selector - Element selector to look for.
+ * @returns {Promise<{x: number, y: number}>} A promise that resolves to the center x & y coordinates.
+ */
+export const getElementCenter = async (page, selector) => {
+  const element = await page.waitForSelector(selector);
+  const box = await element.boundingBox();
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2
+  };
+};


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

User Request:
```
Hi,
it would be nice to have the possibility to reorder existing tabs in a certain QCG layout. Is it possible?
Thank you
```

Tabs in layout overview need to be reorganized using existing behaviour seen in layouts or by implementing a customized version of such mechanism but with some tweaks to make it feel more familiar (like how you reorganize tabs in firefox). Currently this is only possible through editting the json of a layout by reorganizing from top to bottom which tabs should appear. These tweaks would be for example splitting up each tab in two sections; left and right, to allow tabs to be put in between other tabs, after other tabs, etc.

The drag and drop API is being utilized to create the effect of reordering the tabs.