### PR TITLE
[OGUI-1851] ObjectInfo Panel on hover should be left/right depending on position

### DIFF
--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -78,7 +78,7 @@
 /* overwrite jsroot styles */
 .jsroot-container {}
 .jsroot-container pre { background-color: initial; }
-.jsrootdiv:hover + .resize-element, .resize-element:hover{ display: flex !important; }
+.jsrootdiv:hover + .resize-element, .resize-element:hover{ display: flex !important; visibility: visible !important; }
 
 .item-action-row { position: absolute; right: 0%; z-index: 100 }
 

--- a/QualityControl/public/common/utils.js
+++ b/QualityControl/public/common/utils.js
@@ -171,3 +171,22 @@ export const camelToTitleCase = (text) => {
   const titleCase = spaced.charAt(0).toUpperCase() + spaced.slice(1);
   return titleCase;
 };
+
+
+
+/**
+ * Determines whether the element is positioned on the left half of the viewport.
+ * This is used to decide which way a dropdown should anchor to stay within view.
+ * @param {HTMLElement} element - The DOM element (usually the button or container) to measure.
+ * @returns {boolean|undefined} Returns true if the element is on the left half of the window,
+ * false if it is on the right half, or undefined if no element is provided.
+ */
+export const isOnLeftSideOfViewport = (element) => {
+  if (!element) {
+    return;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const isLeft = rect.left - rect.width < window.innerWidth / 2;
+  return isLeft;
+}

--- a/QualityControl/public/common/utils.js
+++ b/QualityControl/public/common/utils.js
@@ -172,8 +172,6 @@ export const camelToTitleCase = (text) => {
   return titleCase;
 };
 
-
-
 /**
  * Determines whether the element is positioned on the left half of the viewport.
  * This is used to decide which way a dropdown should anchor to stay within view.
@@ -189,4 +187,4 @@ export const isOnLeftSideOfViewport = (element) => {
   const rect = element.getBoundingClientRect();
   const isLeft = rect.left - rect.width < window.innerWidth / 2;
   return isLeft;
-}
+};

--- a/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
+++ b/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
@@ -13,6 +13,7 @@
  */
 
 import { downloadButton } from '../../../common/downloadButton.js';
+import { isOnLeftSideOfViewport } from '../../../common/utils.js';
 import { defaultRowAttributes, qcObjectInfoPanel } from './../../../common/object/objectInfoCard.js';
 import { h, iconResizeBoth, info } from '/js/src/index.js';
 
@@ -24,9 +25,9 @@ import { h, iconResizeBoth, info } from '/js/src/index.js';
  * @returns {vnode} - virtual node element
  */
 export const objectInfoResizePanel = (model, tabObject) => {
-  const { name, id } = tabObject;
+  const { name } = tabObject;
   const { filterModel, router, object, services } = model;
-  const isSelectedOpen = object.selectedOpenName === id;
+  const isSelectedOpen = object.selectedOpenName === name;
   const objectRemoteData = services.object.objectsLoadedMap[name];
   let uri = `?page=objectView&objectId=${tabObject.id}&layoutId=${router.params.layoutId}`;
   Object.entries(filterModel.filterMap)
@@ -42,14 +43,14 @@ export const objectInfoResizePanel = (model, tabObject) => {
     }, [
       h('button.btn', {
         title: 'View details about histogram',
-        onclick: () => object.toggleInfoArea(id),
+        onclick: () => object.toggleInfoArea(name),
       }, info()),
       h(
         '.dropdown-menu',
         {
           style: 'right:0.1em; width: 35em;left: auto;',
           onupdate: (vnode) => {
-            if (object.isOnLeftSide(vnode.dom.parentElement)) {
+            if (isOnLeftSideOfViewport(vnode.dom.parentElement)) {
               vnode.dom.style.left = '0.1em';
               vnode.dom.style.right = 'auto';
             } else {

--- a/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
+++ b/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
@@ -27,7 +27,7 @@ import { h, iconResizeBoth, info } from '/js/src/index.js';
 export const objectInfoResizePanel = (model, tabObject) => {
   const { name } = tabObject;
   const { filterModel, router, object, services } = model;
-  const isSelectedOpen = object.selectedOpenName === name;
+  const isSelectedOpen = object.selectedOpen;
   const objectRemoteData = services.object.objectsLoadedMap[name];
   let uri = `?page=objectView&objectId=${tabObject.id}&layoutId=${router.params.layoutId}`;
   Object.entries(filterModel.filterMap)

--- a/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
+++ b/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
@@ -35,21 +35,29 @@ export const objectInfoResizePanel = (model, tabObject) => {
       uri += `&${key}=${encodeURI(value)}`;
     });
   return h('.text-right.resize-element.item-action-row.flex-row.g1', {
-    style: 'display: none; padding: .25rem .25rem 0rem .25rem;',
+    style: 'visibility: hidden; padding: .25rem .25rem 0rem .25rem;',
   }, [
 
     h('.dropdown', { class: isSelectedOpen ? 'dropdown-open' : '',
     }, [
       h('button.btn', {
         title: 'View details about histogram',
-        onclick: (e) => {
-          object.alignInfoArea(e);
-          object.toggleInfoArea(id);
-        },
+        onclick: () => object.toggleInfoArea(id),
       }, info()),
       h(
         '.dropdown-menu',
-        { style: 'right:0.1em; width: 35em;left: auto;' },
+        {
+          style: 'right:0.1em; width: 35em;left: auto;',
+          oncreate: (vnode) => {
+            if (object.isOnLeftSide(vnode.dom.parentElement)) {
+              vnode.dom.style.left = '0.1em';
+              vnode.dom.style.right = 'auto';
+            } else {
+              vnode.dom.style.right = '0.1em';
+              vnode.dom.style.left = 'auto';
+            }
+          },
+        },
         objectRemoteData.isSuccess() &&
           h('.p1', qcObjectInfoPanel(objectRemoteData.payload, {}, defaultRowAttributes(model.notification))),
       ),

--- a/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
+++ b/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
@@ -48,7 +48,7 @@ export const objectInfoResizePanel = (model, tabObject) => {
         '.dropdown-menu',
         {
           style: 'right:0.1em; width: 35em;left: auto;',
-          oncreate: (vnode) => {
+          onupdate: (vnode) => {
             if (object.isOnLeftSide(vnode.dom.parentElement)) {
               vnode.dom.style.left = '0.1em';
               vnode.dom.style.right = 'auto';

--- a/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
+++ b/QualityControl/public/layout/view/panels/objectInfoResizePanel.js
@@ -24,9 +24,9 @@ import { h, iconResizeBoth, info } from '/js/src/index.js';
  * @returns {vnode} - virtual node element
  */
 export const objectInfoResizePanel = (model, tabObject) => {
-  const { name } = tabObject;
+  const { name, id } = tabObject;
   const { filterModel, router, object, services } = model;
-  const isSelectedOpen = object.selectedOpen;
+  const isSelectedOpen = object.selectedOpenName === id;
   const objectRemoteData = services.object.objectsLoadedMap[name];
   let uri = `?page=objectView&objectId=${tabObject.id}&layoutId=${router.params.layoutId}`;
   Object.entries(filterModel.filterMap)
@@ -42,7 +42,10 @@ export const objectInfoResizePanel = (model, tabObject) => {
     }, [
       h('button.btn', {
         title: 'View details about histogram',
-        onclick: () => object.toggleInfoArea(name),
+        onclick: (e) => {
+          object.alignInfoArea(e);
+          object.toggleInfoArea(id);
+        },
       }, info()),
       h(
         '.dropdown-menu',

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -650,21 +650,4 @@ export default class QCObject extends BaseViewModel {
     }
     this.loadList();
   }
-
-  /**
-   * Determines whether the element is positioned on the left half of the viewport.
-   * This is used to decide which way a dropdown should anchor to stay within view.
-   * @param {HTMLElement} element - The DOM element (usually the button or container) to measure.
-   * @returns {boolean|undefined} Returns true if the element is on the left half of the window,
-   * false if it is on the right half, or undefined if no element is provided.
-   */
-  isOnLeftSide(element) {
-    if (!element) {
-      return;
-    }
-
-    const rect = element.getBoundingClientRect();
-    const isLeft = rect.left - rect.width < window.innerWidth / 2;
-    return isLeft;
-  }
 }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -664,7 +664,7 @@ export default class QCObject extends BaseViewModel {
     }
 
     const rect = element.getBoundingClientRect();
-    const isLeft = rect.left + rect.width / 2 < window.innerWidth / 2;
+    const isLeft = rect.left - rect.width < window.innerWidth / 2;
     return isLeft;
   }
 }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -100,15 +100,12 @@ export default class QCObject extends BaseViewModel {
    * @returns {undefined}
    */
   toggleInfoArea(objectName) {
-    this.selectedOpen = !this.selectedOpen;
-    this.notify();
-    if (objectName) {
+    this.selectedOpenName = this.selectedOpenName === objectName ? null : objectName;
+
+    if (this.selectedOpenName && objectName) {
       if (!this.list) {
         this.selected = { name: objectName };
-      } else if (this.selectedOpen && this.list
-        && (this.selected && !this.selected.lastModified
-          || !this.selected)
-      ) {
+      } else {
         this.selected = this.list.find((object) => object.name === objectName);
       }
     }
@@ -652,5 +649,30 @@ export default class QCObject extends BaseViewModel {
       }
     }
     this.loadList();
+  }
+
+  /**
+   * Aligns a dropdown menu to the left or right side based on screen position.
+   * @param {Event} event - The click event from the button
+   * @returns {undefined}
+   */
+  alignInfoArea(event) {
+    const button = event.currentTarget;
+    const menu = button.nextElementSibling;
+
+    if (!menu) {
+      return;
+    }
+
+    const rect = button.getBoundingClientRect();
+    const isLeft = rect.left + rect.width / 2 < window.innerWidth / 2;
+
+    if (isLeft) {
+      menu.style.left = '0.1em';
+      menu.style.right = 'auto';
+    } else {
+      menu.style.right = '0.1em';
+      menu.style.left = 'auto';
+    }
   }
 }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -100,12 +100,15 @@ export default class QCObject extends BaseViewModel {
    * @returns {undefined}
    */
   toggleInfoArea(objectName) {
-    this.selectedOpenName = this.selectedOpenName === objectName ? null : objectName;
-
-    if (this.selectedOpenName && objectName) {
+    this.selectedOpen = !this.selectedOpen;
+    this.notify();
+    if (objectName) {
       if (!this.list) {
         this.selected = { name: objectName };
-      } else {
+      } else if (this.selectedOpen && this.list
+        && (this.selected && !this.selected.lastModified
+          || !this.selected)
+      ) {
         this.selected = this.list.find((object) => object.name === objectName);
       }
     }

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -652,27 +652,19 @@ export default class QCObject extends BaseViewModel {
   }
 
   /**
-   * Aligns a dropdown menu to the left or right side based on screen position.
-   * @param {Event} event - The click event from the button
-   * @returns {undefined}
+   * Determines whether the element is positioned on the left half of the viewport.
+   * This is used to decide which way a dropdown should anchor to stay within view.
+   * @param {HTMLElement} element - The DOM element (usually the button or container) to measure.
+   * @returns {boolean|undefined} Returns true if the element is on the left half of the window,
+   * false if it is on the right half, or undefined if no element is provided.
    */
-  alignInfoArea(event) {
-    const button = event.currentTarget;
-    const menu = button.nextElementSibling;
-
-    if (!menu) {
+  isOnLeftSide(element) {
+    if (!element) {
       return;
     }
 
-    const rect = button.getBoundingClientRect();
+    const rect = element.getBoundingClientRect();
     const isLeft = rect.left + rect.width / 2 < window.innerWidth / 2;
-
-    if (isLeft) {
-      menu.style.left = '0.1em';
-      menu.style.right = 'auto';
-    } else {
-      menu.style.right = '0.1em';
-      menu.style.left = 'auto';
-    }
+    return isLeft;
   }
 }

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -177,7 +177,7 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
 
       strictEqual(leftStyle, '0.1em');
     }
-  )
+  );
 
   await testParent.test('should have second tab to be empty (according to demo data)', { timeout }, async () => {
     await page.locator('#tab-1').click();

--- a/QualityControl/test/public/pages/layout-show.test.js
+++ b/QualityControl/test/public/pages/layout-show.test.js
@@ -168,6 +168,17 @@ export const layoutShowTests = async (url, page, timeout = 5000, testParent) => 
     },
   );
 
+  await testParent.test(
+    'should align info dropdown to the right when container is on the left',
+    { timeout },
+    async () => {
+      await page.click('button.btn[title*="View details"]');
+      const leftStyle = await page.evaluate(() => document.querySelector('#subcanvas .dropdown-menu').style.left);
+
+      strictEqual(leftStyle, '0.1em');
+    }
+  )
+
   await testParent.test('should have second tab to be empty (according to demo data)', { timeout }, async () => {
     await page.locator('#tab-1').click();
     await delay(50);


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

When viewing a layout, the user has the option to hover over a plot and get multiple options. Here, they can click on the `info` icon to get a panel with information about the object.

The problem lies of the fact that if the object is positioned on the left side of the screen, it will not be visible properly.

Now when we are on the left side of the window it will render the dropdown to the right of the button anchor.