### PR TITLE
[OGUI-1853] Move actionables of objectTree in the table header

### DIFF
--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -206,6 +206,7 @@
 
     .hover-icon {
       display: inline-block;
+      color: var(--color-gray-dark)
     }
   }
 }

--- a/QualityControl/public/app.css
+++ b/QualityControl/public/app.css
@@ -187,3 +187,20 @@
 .whitespace-nowrap {
   white-space: nowrap;
 }
+
+.sort-button {
+  .hover-icon {
+    display: none;
+    opacity: 0.6;
+  }
+
+  &:hover {
+    .current-icon {
+      display: none;
+    }
+
+    .hover-icon {
+      display: inline-block;
+    }
+  }
+}

--- a/QualityControl/public/common/enums/columnSort.enum.js
+++ b/QualityControl/public/common/enums/columnSort.enum.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Enumeration for sort directions
+ * @enum {number}
+ * @readonly
+ */
+export const SortDirectionsEnum = Object.freeze({
+  NONE: 0,
+  ASC: 1,
+  DESC: -1,
+});

--- a/QualityControl/public/common/enums/columnSort.enum.js
+++ b/QualityControl/public/common/enums/columnSort.enum.js
@@ -18,7 +18,6 @@
  * @readonly
  */
 export const SortDirectionsEnum = Object.freeze({
-  NONE: 0,
   ASC: 1,
   DESC: -1,
 });

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
+import { h, iconCircleX, iconArrowBottom, iconArrowTop } from '/js/src/index.js';
+
+/**
+ * Get the icon for the sort direction.
+ * @param {SortDirectionsEnum} direction - direction of the sort.
+ * @returns {vnode} the correct icon related to the direction.
+ */
+const getSortIcon = (direction) => {
+  if (direction === SortDirectionsEnum.ASC) {
+    return iconArrowTop();
+  }
+  if (direction === SortDirectionsEnum.DESC) {
+    return iconArrowBottom();
+  }
+  return iconCircleX();
+};
+
+/**
+ * @callback SortClickCallback
+ * @param {string} label - The label of the column being sorted.
+ * @param {number} order - The next sort direction in the cycle.
+ * @param {vnode} icon - The VNode for the icon representing the next sort state.
+ * @returns {void}
+ */
+
+/**
+ * Renders a sortable table header button that cycles through sort states.
+ * Displays the current sort icon and a preview icon of the next state on hover.
+ * @param {object} props - The component properties.
+ * @param {number} props.order - The current sort direction value from SortDirectionsEnum.
+ * @param {object|undefined} props.icon - The VNode/element for the current active sort icon.
+ * @param {string} props.label - The display text for the column header.
+ * @param {SortClickCallback} props.onclick - Callback triggered on click.
+ * @param {Array<number>} [props.sortOptions] - Array of SortDirectionsEnum values defining the
+ * order of the sort cycle. Defaults to all enum values.
+ * @returns {object} A HyperScript VNode representing the sortable button.
+ */
+export const sortableTableHead = ({
+  order,
+  icon,
+  label,
+  onclick,
+  sortOptions = [...Object.values(SortDirectionsEnum)]
+}) => {
+  const currentIndex = sortOptions.indexOf(order);
+  const nextIndex = (currentIndex + 1) % sortOptions.length;
+  const nextSortOrder = sortOptions[nextIndex];
+  const hoverIcon = getSortIcon(nextSortOrder);
+
+  return h('button.btn.sort-button', { onclick: () => onclick(label, nextSortOrder, hoverIcon) }, [
+    label,
+    h('span.icon-container', [
+      h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
+      h('span.hover-icon', [getSortIcon(nextSortOrder)])
+    ])
+  ]);
+}

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -64,7 +64,7 @@ export const sortableTableHead = ({
 
   return h('button.btn.sort-button', { onclick: () => onclick(label, nextSortOrder, hoverIcon) }, [
     label,
-    h('span.icon-container', [
+    h('span.icon-container.mh1', [
       h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
       h('span.hover-icon', [getSortIcon(nextSortOrder)])
     ])

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -68,7 +68,7 @@ export const sortableTableHead = ({
     'button.btn.sort-button',
     {
       onclick: () => onclick(label, nextSortOrder, hoverIcon),
-      title: `Sort by ${directionLabel}`,
+      title: `Sort ${directionLabel} by ${label}`,
     },
     [
       label,

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -62,11 +62,20 @@ export const sortableTableHead = ({
   const nextSortOrder = sortOptions[nextIndex];
   const hoverIcon = getSortIcon(nextSortOrder);
 
-  return h('button.btn.sort-button', { onclick: () => onclick(label, nextSortOrder, hoverIcon) }, [
-    label,
-    h('span.icon-container.mh1', [
-      h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
-      h('span.hover-icon', [getSortIcon(nextSortOrder)]),
-    ]),
-  ]);
+  const directionLabel = Object.keys(SortDirectionsEnum).find((key) => SortDirectionsEnum[key] === nextSortOrder);
+
+  return h(
+    'button.btn.sort-button',
+    {
+      onclick: () => onclick(label, nextSortOrder, hoverIcon),
+      title: `Sort by ${directionLabel}`
+    },
+    [
+      label,
+      h('span.icon-container.mh1', [
+        h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
+        h('span.hover-icon', [getSortIcon(nextSortOrder)]),
+      ]),
+    ]
+  );
 };

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -13,7 +13,7 @@
  */
 
 import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
-import { h, iconCircleX, iconArrowBottom, iconArrowTop } from '/js/src/index.js';
+import { h, iconCircleX, iconCaretBottom, iconCaretTop } from '/js/src/index.js';
 
 /**
  * Get the icon for the sort direction.
@@ -22,10 +22,10 @@ import { h, iconCircleX, iconArrowBottom, iconArrowTop } from '/js/src/index.js'
  */
 const getSortIcon = (direction) => {
   if (direction === SortDirectionsEnum.ASC) {
-    return iconArrowTop();
+    return iconCaretTop();
   }
   if (direction === SortDirectionsEnum.DESC) {
-    return iconArrowBottom();
+    return iconCaretBottom();
   }
   return iconCircleX();
 };
@@ -65,7 +65,7 @@ export const sortableTableHead = ({
   const directionLabel = Object.keys(SortDirectionsEnum).find((key) => SortDirectionsEnum[key] === nextSortOrder);
 
   return h(
-    'button.btn.sort-button',
+    '.sort-button.cursor-pointer',
     {
       onclick: () => onclick(label, nextSortOrder, hoverIcon),
       title: `Sort ${directionLabel} by ${label}`,

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -55,7 +55,7 @@ export const sortableTableHead = ({
   icon,
   label,
   onclick,
-  sortOptions = [...Object.values(SortDirectionsEnum)]
+  sortOptions = [...Object.values(SortDirectionsEnum)],
 }) => {
   const currentIndex = sortOptions.indexOf(order);
   const nextIndex = (currentIndex + 1) % sortOptions.length;
@@ -66,7 +66,7 @@ export const sortableTableHead = ({
     label,
     h('span.icon-container.mh1', [
       h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
-      h('span.hover-icon', [getSortIcon(nextSortOrder)])
-    ])
+      h('span.hover-icon', [getSortIcon(nextSortOrder)]),
+    ]),
   ]);
-}
+};

--- a/QualityControl/public/common/sortButton.js
+++ b/QualityControl/public/common/sortButton.js
@@ -68,7 +68,7 @@ export const sortableTableHead = ({
     'button.btn.sort-button',
     {
       onclick: () => onclick(label, nextSortOrder, hoverIcon),
-      title: `Sort by ${directionLabel}`
+      title: `Sort by ${directionLabel}`,
     },
     [
       label,
@@ -76,6 +76,6 @@ export const sortableTableHead = ({
         h('span.current-icon', [order != SortDirectionsEnum.NONE ? icon : undefined]),
         h('span.hover-icon', [getSortIcon(nextSortOrder)]),
       ]),
-    ]
+    ],
   );
 };

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { RemoteData, iconArrowTop, BrowserStorage } from '/js/src/index.js';
+import { RemoteData, iconCaretTop, BrowserStorage } from '/js/src/index.js';
 import ObjectTree from './ObjectTree.class.js';
 import { prettyFormatDate, setBrowserTabTitle } from './../common/utils.js';
 import { isObjectOfTypeChecker } from './../library/qcObject/utils.js';
@@ -46,7 +46,7 @@ export default class QCObject extends BaseViewModel {
       field: 'name',
       title: 'Name',
       order: 1,
-      icon: iconArrowTop(),
+      icon: iconCaretTop(),
     };
 
     this.tree = new ObjectTree('database');
@@ -242,7 +242,7 @@ export default class QCObject extends BaseViewModel {
       field: 'name',
       title: 'Name',
       order: 1,
-      icon: iconArrowTop(),
+      icon: iconCaretTop(),
     };
     this._computeFilters();
 

--- a/QualityControl/public/object/QCObject.js
+++ b/QualityControl/public/object/QCObject.js
@@ -47,7 +47,6 @@ export default class QCObject extends BaseViewModel {
       title: 'Name',
       order: 1,
       icon: iconArrowTop(),
-      open: false,
     };
 
     this.tree = new ObjectTree('database');
@@ -116,15 +115,6 @@ export default class QCObject extends BaseViewModel {
   }
 
   /**
-   * Toggle the display of the sort by dropdown
-   * @returns {undefined}
-   */
-  toggleSortDropdown() {
-    this.sortBy.open = !this.sortBy.open;
-    this.notify();
-  }
-
-  /**
    * Computes the final list of objects to be seen by user depending on search input from user
    * If any of those changes, this method should be called to update the outputs.
    * @returns {undefined}
@@ -189,7 +179,7 @@ export default class QCObject extends BaseViewModel {
 
     this._computeFilters();
 
-    this.sortBy = { field, title, order, icon, open: false };
+    this.sortBy = { field, title, order, icon };
     this.notify();
   }
 
@@ -253,7 +243,6 @@ export default class QCObject extends BaseViewModel {
       title: 'Name',
       order: 1,
       icon: iconArrowTop(),
-      open: false,
     };
     this._computeFilters();
 

--- a/QualityControl/public/object/objectTreeHeader.js
+++ b/QualityControl/public/object/objectTreeHeader.js
@@ -38,22 +38,9 @@ export default function objectTreeHeader(qcObject, filterModel) {
       qcObject.objectsRemote.isSuccess() && h('span', `(${howMany})`),
     ]),
 
-    rightCol: h('.w-25.flex-row.items-center.g2.justify-end', [
-      filterModel.isRunModeActivated ? null : filterPanelToggleButton(filterModel),
-    ]),
+    rightCol: h(
+      '.w-25.flex-row.items-center.g2.justify-end',
+      [filterModel.isRunModeActivated ? null : filterPanelToggleButton(filterModel)],
+    ),
   };
 }
-
-/**
- * Create a menu-item for sort-by dropdown
- * @param {QcObject} qcObject - Model that manages the QCObject state.
- * @param {string} shortTitle - title that gets displayed to the user
- * @param {string} title - title that gets displayed to the user on hover
- * @param {Icon} icon - svg icon to be used
- * @param {string} field - field by which sorting should happen
- * @param {number} order - {-1/1}/{DESC/ASC}
- * @returns {vnode} - virtual node element
- */
-const sortMenuItem = (qcObject, shortTitle, title, icon, field, order) => h('a.menu-item', {
-  title: title, style: 'white-space: nowrap;', onclick: () => qcObject.sortTree(shortTitle, field, order, icon),
-}, [shortTitle, ' ', icon]);

--- a/QualityControl/public/object/objectTreeHeader.js
+++ b/QualityControl/public/object/objectTreeHeader.js
@@ -13,7 +13,7 @@
  */
 
 import { h } from '/js/src/index.js';
-import { iconCollapseUp, iconArrowBottom, iconArrowTop } from '/js/src/icons.js';
+import { iconArrowBottom, iconArrowTop } from '/js/src/icons.js';
 import { filterPanelToggleButton } from '../common/filters/filterViews.js';
 
 /**
@@ -55,21 +55,6 @@ export default function objectTreeHeader(qcObject, filterModel) {
 
         ]),
       ]),
-      ' ',
-      h('button.btn', {
-        title: 'Close whole tree',
-        onclick: () => qcObject.tree.closeAll(),
-        disabled: Boolean(qcObject.searchInput),
-      }, iconCollapseUp()),
-      ' ',
-      h('input.form-control.form-inline.mh1.w-33', {
-        id: 'searchObjectTree',
-        placeholder: 'Search',
-        type: 'text',
-        value: qcObject.searchInput,
-        disabled: qcObject.queryingObjects ? true : false,
-        oninput: (e) => qcObject.search(e.target.value),
-      }),
       ' ',
     ]),
   };

--- a/QualityControl/public/object/objectTreeHeader.js
+++ b/QualityControl/public/object/objectTreeHeader.js
@@ -13,7 +13,6 @@
  */
 
 import { h } from '/js/src/index.js';
-import { iconArrowBottom, iconArrowTop } from '/js/src/icons.js';
 import { filterPanelToggleButton } from '../common/filters/filterViews.js';
 
 /**
@@ -41,21 +40,6 @@ export default function objectTreeHeader(qcObject, filterModel) {
 
     rightCol: h('.w-25.flex-row.items-center.g2.justify-end', [
       filterModel.isRunModeActivated ? null : filterPanelToggleButton(filterModel),
-      ' ',
-      h('.dropdown', {
-        id: 'sortTreeButton', title: 'Sort by', class: qcObject.sortBy.open ? 'dropdown-open' : '',
-      }, [
-        h('button.btn', {
-          title: 'Sort by',
-          onclick: () => qcObject.toggleSortDropdown(),
-        }, [qcObject.sortBy.title, ' ', qcObject.sortBy.icon]),
-        h('.dropdown-menu.text-left', [
-          sortMenuItem(qcObject, 'Name', 'Sort by name ASC', iconArrowTop(), 'name', 1),
-          sortMenuItem(qcObject, 'Name', 'Sort by name DESC', iconArrowBottom(), 'name', -1),
-
-        ]),
-      ]),
-      ' ',
     ]),
   };
 }

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -56,15 +56,9 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return h('', [
-              tableHeader(model.object),
-              virtualTable(model, 'main', objectsToDisplay),
-            ]);
+            return virtualTable(model, 'main', objectsToDisplay);
           }
-          return h('', [
-            tableHeader(model.object),
-            tableShow(model),
-          ]);
+          return tableShow(model);
         },
         Failure: () => null, // Notification is displayed
       })),
@@ -183,15 +177,18 @@ const tableShow = (model) =>
   h('table.table.table-sm.text-no-select', [
     h('thead', [
       h('tr', [
-        h('th', sortableTableHead({
-          order: model.object.sortBy.order,
-          icon: model.object.sortBy.icon,
-          label: 'Name',
-          sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-          onclick: (label, order, icon) => {
-            model.object.sortTree(label, 'name', order, icon);
-          },
-        })),
+        h('th', [
+          sortableTableHead({
+            order: model.object.sortBy.order,
+            icon: model.object.sortBy.icon,
+            label: 'Name',
+            sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+            onclick: (label, order, icon) => {
+              model.object.sortTree(label, 'name', order, icon);
+            },
+          }),
+          tableHeader(model.object),
+        ]),
       ]),
     ]),
     h('tbody', [treeRows(model)]),
@@ -203,15 +200,15 @@ const tableHeader = (qcObject) =>
     tableCollapseAll(qcObject),
   ]);
 
-const tableCollapseAll = (qcObject) =>
+export const tableCollapseAll = (qcObject) =>
   h('button.btn.m2', {
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
     disabled: Boolean(qcObject.searchInput),
   }, iconCollapseUp());
 
-const tableSearchInput = (qcObject) =>
-  h('input.form-control.form-inline.m2.flex-grow', {
+export const tableSearchInput = (qcObject) =>
+  h('input.form-control.form-inline.mv2.mh3.flex-grow', {
     id: 'searchObjectTree',
     placeholder: 'Search',
     type: 'text',

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -206,6 +206,7 @@ const tableCollapseAll = (qcObject) =>
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
     disabled: Boolean(qcObject.searchInput),
+    id: 'collapse-tree-button'
   }, iconCollapseUp());
 
 const tableSearchInput = (qcObject) =>

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -12,7 +12,15 @@
  * or submit itself to any jurisdiction.
  */
 
-import { h, iconBarChart, iconCaretRight, iconResizeBoth, iconCaretBottom, iconCircleX } from '/js/src/index.js';
+import {
+  h,
+  iconCollapseUp,
+  iconBarChart,
+  iconCaretRight,
+  iconResizeBoth,
+  iconCaretBottom,
+  iconCircleX
+} from '/js/src/index.js';
 import { spinner } from '../common/spinner.js';
 import { draw } from '../common/object/draw.js';
 import timestampSelectForm from './../common/timestampSelectForm.js';
@@ -47,12 +55,12 @@ export default (model) => {
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
             return [
-              tableSearchInput(model.object),
+              tableHeader(model.object),
               virtualTable(model, 'main', objectsToDisplay),
             ];
           }
           return [
-            tableSearchInput(model.object),
+            tableHeader(model.object),
             tableShow(model),
           ];
         },
@@ -175,8 +183,21 @@ const tableShow = (model) =>
     h('tbody', [treeRows(model)]),
   ])
 
+const tableHeader = (qcObject) =>
+  h('.flex-row.w-100', [
+    tableSearchInput(qcObject),
+    tableCollapseAll(qcObject),
+  ])
+
+const tableCollapseAll = (qcObject) =>
+  h('button.btn.m2', {
+    title: 'Close whole tree',
+    onclick: () => qcObject.tree.closeAll(),
+    disabled: Boolean(qcObject.searchInput),
+  }, iconCollapseUp())
+
 const tableSearchInput = (qcObject) =>
-  h('input.form-control.form-inline.m2', {
+  h('input.form-control.form-inline.m2.flex-grow', {
     id: 'searchObjectTree',
     placeholder: 'Search',
     type: 'text',

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -19,7 +19,7 @@ import {
   iconCaretRight,
   iconResizeBoth,
   iconCaretBottom,
-  iconCircleX
+  iconCircleX,
 } from '/js/src/index.js';
 import { spinner } from '../common/spinner.js';
 import { draw } from '../common/object/draw.js';
@@ -28,6 +28,8 @@ import virtualTable from './virtualTable.js';
 import { defaultRowAttributes, qcObjectInfoPanel } from '../common/object/objectInfoCard.js';
 import { downloadButton } from '../common/downloadButton.js';
 import { resizableDivider } from '../common/resizableDivider.js';
+import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
+import { sortableTableHead } from '../common/sortButton.js';
 
 /**
  * Shows a page to explore though a tree of objects with a preview on the right if clicked
@@ -179,7 +181,19 @@ const statusBarRight = (model) => model.object.selected
  */
 const tableShow = (model) =>
   h('table.table.table-sm.text-no-select', [
-    h('thead', [h('tr', [h('th', 'Name')])]),
+    h('thead', [
+      h('tr', [
+        h('th', sortableTableHead({
+          order: model.object.sortBy.order,
+          icon: model.object.sortBy.icon,
+          label: 'Name',
+          sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+          onclick: (label, order, icon) => {
+            model.object.sortTree(label, 'name', order, icon)
+          }
+        }))
+      ])
+    ]),
     h('tbody', [treeRows(model)]),
   ])
 

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -189,26 +189,26 @@ const tableShow = (model) =>
           label: 'Name',
           sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
           onclick: (label, order, icon) => {
-            model.object.sortTree(label, 'name', order, icon)
-          }
-        }))
-      ])
+            model.object.sortTree(label, 'name', order, icon);
+          },
+        })),
+      ]),
     ]),
     h('tbody', [treeRows(model)]),
-  ])
+  ]);
 
 const tableHeader = (qcObject) =>
   h('.flex-row.w-100', [
     tableSearchInput(qcObject),
     tableCollapseAll(qcObject),
-  ])
+  ]);
 
 const tableCollapseAll = (qcObject) =>
   h('button.btn.m2', {
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
     disabled: Boolean(qcObject.searchInput),
-  }, iconCollapseUp())
+  }, iconCollapseUp());
 
 const tableSearchInput = (qcObject) =>
   h('input.form-control.form-inline.m2.flex-grow', {
@@ -218,7 +218,7 @@ const tableSearchInput = (qcObject) =>
     value: qcObject.searchInput,
     disabled: qcObject.queryingObjects ? true : false,
     oninput: (e) => qcObject.search(e.target.value),
-  })
+  });
 
 /**
  * Shows a list of lines <tr> of objects

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -60,13 +60,13 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return h('.scroll-y.flex-column.flex-grow', [
-              tableHeaderRow(model),
+            return h('.flex-column.flex-grow', [
+              actionablesHeaderGroup(model.object),
               virtualTable(model, 'side', objectsToDisplay),
             ]);
           }
           return h('', [
-            tableHeaderRow(model),
+            actionablesHeaderGroup(model.object),
             tableShow(model),
           ]);
         },
@@ -188,26 +188,51 @@ const statusBarRight = (model) => model.object.selected
 const tableShow = (model) =>
   h('table.table.table-sm.text-no-select', h('tbody', [treeRows(model)]));
 
-const tableHeaderRow = (model) => h('.bg-gray-light.pv2', [
-  sortableTableHead({
-    order: model.object.sortBy.order,
-    icon: model.object.sortBy.icon,
-    label: 'Name',
-    sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-    onclick: (label, order, icon) => {
-      model.object.sortTree(label, 'name', order, icon);
-    },
-  }),
-  tableHeader(model.object),
-]);
+/**
+ * A composite header component for the actionables section.
+ * It groups the column sorting header and the functional toolbar (search/collapse).
+ * @param {QCObject} qcObject - The state object for Quality Control actionables.
+ * @returns {vnode} A virtual DOM node containing the grouped header elements.
+ */
+const actionablesHeaderGroup = (qcObject) => {
+  const {
+    order = SortDirectionsEnum.ASC,
+    icon = 'sort'
+  } = qcObject.sortBy || {};
 
-const tableHeader = (qcObject) =>
+  return h('.bg-gray-light.pv2', [
+    sortableTableHead({
+      order,
+      icon,
+      label: 'Name',
+      sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+      onclick: (label, order, icon) => {
+        qcObject.sortTree(label, 'name', order, icon);
+      },
+    }),
+    actionablesContainer(qcObject),
+  ]);
+};
+
+/**
+ * A toolbar containing interactive controls for the object tree table,
+ * specifically the search input and the 'Collapse All' button.
+ * @param {QCObject} qcObject - The state object for managing tree interactions.
+ * @returns {vnode} A flex-row container with search and collapse actions.
+ */
+const actionablesContainer = (qcObject) =>
   h('.flex-row.w-100', [
-    tableSearchInput(qcObject),
-    tableCollapseAll(qcObject),
+    actionableSearchInput(qcObject),
+    actionableCollapseAll(qcObject),
   ]);
 
-const tableCollapseAll = (qcObject) =>
+/**
+ * A button to collapse all expanded nodes in the object tree table.
+ * Disabled when a search filter is active to prevent UI inconsistency.
+ * @param {QCObject} qcObject - The state object containing the tree controller.
+ * @returns {vnode} A button element with a collapse icon.
+ */
+const actionableCollapseAll = (qcObject) =>
   h('button.btn.m2', {
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
@@ -215,7 +240,12 @@ const tableCollapseAll = (qcObject) =>
     id: 'collapse-tree-button',
   }, iconCollapseUp());
 
-const tableSearchInput = (qcObject) =>
+/**
+ * A text input for filtering the object tree table based on user queries.
+ * @param {QCObject} qcObject - The state object managing search input and loading state.
+ * @returns {vnode} An input element for searching.
+ */
+const actionableSearchInput = (qcObject) =>
   h('input.form-control.form-inline.mv2.mh3.flex-grow', {
     id: 'searchObjectTree',
     placeholder: 'Search',

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -197,7 +197,7 @@ const tableShow = (model) =>
 const actionablesHeaderGroup = (qcObject) => {
   const {
     order = SortDirectionsEnum.ASC,
-    icon = 'sort'
+    icon = 'sort',
   } = qcObject.sortBy || {};
 
   return h('.bg-gray-light.pv2', [

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -46,9 +46,15 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return virtualTable(model, 'main', objectsToDisplay);
+            return [
+              tableSearchInput(model.object),
+              virtualTable(model, 'main', objectsToDisplay),
+            ];
           }
-          return tableShow(model);
+          return [
+            tableSearchInput(model.object),
+            tableShow(model),
+          ];
         },
         Failure: () => null, // Notification is displayed
       })),
@@ -167,7 +173,17 @@ const tableShow = (model) =>
   h('table.table.table-sm.text-no-select', [
     h('thead', [h('tr', [h('th', 'Name')])]),
     h('tbody', [treeRows(model)]),
-  ]);
+  ])
+
+const tableSearchInput = (qcObject) =>
+  h('input.form-control.form-inline.m2', {
+    id: 'searchObjectTree',
+    placeholder: 'Search',
+    type: 'text',
+    value: qcObject.searchInput,
+    disabled: qcObject.queryingObjects ? true : false,
+    oninput: (e) => qcObject.search(e.target.value),
+  })
 
 /**
  * Shows a list of lines <tr> of objects

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -56,7 +56,7 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return h('', [
+            return h('.scroll-y.flex-column.flex-grow', [
               tableHeaderRow(model),
               virtualTable(model, 'side', objectsToDisplay),
             ]);

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -56,15 +56,15 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return [
+            return h('', [
               tableHeader(model.object),
               virtualTable(model, 'main', objectsToDisplay),
-            ];
+            ]);
           }
-          return [
+          return h('', [
             tableHeader(model.object),
             tableShow(model),
-          ];
+          ]);
         },
         Failure: () => null, // Notification is displayed
       })),

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -56,9 +56,15 @@ export default (model) => {
             const objectsLoaded = object.list;
             const objectsToDisplay = objectsLoaded.filter((qcObject) =>
               qcObject.name.toLowerCase().includes(searchInput.toLowerCase()));
-            return virtualTable(model, 'main', objectsToDisplay);
+            return h('', [
+              tableHeaderRow(model),
+              virtualTable(model, 'side', objectsToDisplay),
+            ]);
           }
-          return tableShow(model);
+          return h('', [
+            tableHeaderRow(model),
+            tableShow(model),
+          ]);
         },
         Failure: () => null, // Notification is displayed
       })),
@@ -174,25 +180,20 @@ const statusBarRight = (model) => model.object.selected
  * @returns {vnode} - virtual node element
  */
 const tableShow = (model) =>
-  h('table.table.table-sm.text-no-select', [
-    h('thead', [
-      h('tr', [
-        h('th', [
-          sortableTableHead({
-            order: model.object.sortBy.order,
-            icon: model.object.sortBy.icon,
-            label: 'Name',
-            sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-            onclick: (label, order, icon) => {
-              model.object.sortTree(label, 'name', order, icon);
-            },
-          }),
-          tableHeader(model.object),
-        ]),
-      ]),
-    ]),
-    h('tbody', [treeRows(model)]),
-  ]);
+  h('table.table.table-sm.text-no-select', h('tbody', [treeRows(model)]));
+
+const tableHeaderRow = (model) => h('.bg-gray-light.pv2', [
+  sortableTableHead({
+    order: model.object.sortBy.order,
+    icon: model.object.sortBy.icon,
+    label: 'Name',
+    sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+    onclick: (label, order, icon) => {
+      model.object.sortTree(label, 'name', order, icon);
+    },
+  }),
+  tableHeader(model.object),
+]);
 
 const tableHeader = (qcObject) =>
   h('.flex-row.w-100', [
@@ -200,14 +201,14 @@ const tableHeader = (qcObject) =>
     tableCollapseAll(qcObject),
   ]);
 
-export const tableCollapseAll = (qcObject) =>
+const tableCollapseAll = (qcObject) =>
   h('button.btn.m2', {
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
     disabled: Boolean(qcObject.searchInput),
   }, iconCollapseUp());
 
-export const tableSearchInput = (qcObject) =>
+const tableSearchInput = (qcObject) =>
   h('input.form-control.form-inline.mv2.mh3.flex-grow', {
     id: 'searchObjectTree',
     placeholder: 'Search',

--- a/QualityControl/public/object/objectTreePage.js
+++ b/QualityControl/public/object/objectTreePage.js
@@ -206,7 +206,7 @@ const tableCollapseAll = (qcObject) =>
     title: 'Close whole tree',
     onclick: () => qcObject.tree.closeAll(),
     disabled: Boolean(qcObject.searchInput),
-    id: 'collapse-tree-button'
+    id: 'collapse-tree-button',
   }, iconCollapseUp());
 
 const tableSearchInput = (qcObject) =>

--- a/QualityControl/public/object/virtualTable.js
+++ b/QualityControl/public/object/virtualTable.js
@@ -12,6 +12,8 @@
  * or submit itself to any jurisdiction.
  */
 
+import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
+import { sortableTableHead } from '../common/sortButton.js';
 import { h, iconBarChart } from '/js/src/index.js';
 
 let ROW_HEIGHT = 33.6;
@@ -102,7 +104,15 @@ const objectFullRow = (model, item, location) =>
 const tableHeader = () =>
   h('table.table.table-sm.text-no-select', {
     style: 'margin-bottom:0',
-  }, h('thead', [h('tr', [h('th', 'Name')])]));
+  }, h('thead', [h('tr', [h('th', sortableTableHead({
+    order: model.object.sortBy.order,
+    icon: model.object.sortBy.icon,
+    label: 'Name',
+    sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+    onclick: (label, order, icon) => {
+      model.object.sortTree(label, 'name', order, icon)
+    }
+  }))])]));
 
 /**
  * Set styles of the floating table and its position inside the big div .tableLogsContentPlaceholder

--- a/QualityControl/public/object/virtualTable.js
+++ b/QualityControl/public/object/virtualTable.js
@@ -104,15 +104,19 @@ const objectFullRow = (model, item, location) =>
 const tableHeader = () =>
   h('table.table.table-sm.text-no-select', {
     style: 'margin-bottom:0',
-  }, h('thead', [h('tr', [h('th', sortableTableHead({
-    order: model.object.sortBy.order,
-    icon: model.object.sortBy.icon,
-    label: 'Name',
-    sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-    onclick: (label, order, icon) => {
-      model.object.sortTree(label, 'name', order, icon)
-    }
-  }))])]));
+  }, h('thead', [
+    h('tr', [
+      h('th', sortableTableHead({
+        order: model.object.sortBy.order,
+        icon: model.object.sortBy.icon,
+        label: 'Name',
+        sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+        onclick: (label, order, icon) => {
+          model.object.sortTree(label, 'name', order, icon);
+        },
+      })),
+    ]),
+  ]));
 
 /**
  * Set styles of the floating table and its position inside the big div .tableLogsContentPlaceholder

--- a/QualityControl/public/object/virtualTable.js
+++ b/QualityControl/public/object/virtualTable.js
@@ -12,9 +12,6 @@
  * or submit itself to any jurisdiction.
  */
 
-import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
-import { sortableTableHead } from '../common/sortButton.js';
-import { tableCollapseAll, tableSearchInput } from './objectTreePage.js';
 import { h, iconBarChart } from '/js/src/index.js';
 
 let ROW_HEIGHT = 33.6;
@@ -105,28 +102,7 @@ const objectFullRow = (model, item, location) =>
 const tableHeader = () =>
   h('table.table.table-sm.text-no-select', {
     style: 'margin-bottom:0',
-  }, h('thead', [
-    h('tr', [
-      h('th', [
-        sortableTableHead({
-          order: model.object.sortBy.order,
-          icon: model.object.sortBy.icon,
-          label: 'Name',
-          sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-          onclick: (label, order, icon) => {
-            model.object.sortTree(label, 'name', order, icon);
-          },
-        }),
-        tableActions(model.object),
-      ]),
-    ]),
-  ]));
-
-const tableActions = (qcObject) =>
-  h('.flex-row.w-100', [
-    tableSearchInput(qcObject),
-    tableCollapseAll(qcObject),
-  ]);
+  }, h('thead', [h('tr', [h('th', 'Name')])]));
 
 /**
  * Set styles of the floating table and its position inside the big div .tableLogsContentPlaceholder

--- a/QualityControl/public/object/virtualTable.js
+++ b/QualityControl/public/object/virtualTable.js
@@ -14,6 +14,7 @@
 
 import { SortDirectionsEnum } from '../common/enums/columnSort.enum.js';
 import { sortableTableHead } from '../common/sortButton.js';
+import { tableCollapseAll, tableSearchInput } from './objectTreePage.js';
 import { h, iconBarChart } from '/js/src/index.js';
 
 let ROW_HEIGHT = 33.6;
@@ -106,17 +107,26 @@ const tableHeader = () =>
     style: 'margin-bottom:0',
   }, h('thead', [
     h('tr', [
-      h('th', sortableTableHead({
-        order: model.object.sortBy.order,
-        icon: model.object.sortBy.icon,
-        label: 'Name',
-        sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
-        onclick: (label, order, icon) => {
-          model.object.sortTree(label, 'name', order, icon);
-        },
-      })),
+      h('th', [
+        sortableTableHead({
+          order: model.object.sortBy.order,
+          icon: model.object.sortBy.icon,
+          label: 'Name',
+          sortOptions: [SortDirectionsEnum.ASC, SortDirectionsEnum.DESC],
+          onclick: (label, order, icon) => {
+            model.object.sortTree(label, 'name', order, icon);
+          },
+        }),
+        tableActions(model.object),
+      ]),
     ]),
   ]));
+
+const tableActions = (qcObject) =>
+  h('.flex-row.w-100', [
+    tableSearchInput(qcObject),
+    tableCollapseAll(qcObject),
+  ]);
 
 /**
  * Set styles of the floating table and its position inside the big div .tableLogsContentPlaceholder

--- a/QualityControl/test/public/features/filterTest.test.js
+++ b/QualityControl/test/public/features/filterTest.test.js
@@ -241,16 +241,15 @@ export const filterTests = async (url, page, timeout = 5000, testParent) => {
     );
 
     let rowCount = await page.evaluate(() => document.querySelectorAll('tr').length);
-    strictEqual(rowCount, 7);
+    strictEqual(rowCount, 6);
 
     const runNumber = '0';
     await page.locator('#runNumberFilter').fill(runNumber);
     await page.locator('#filterElement #triggerFilterButton').click();
-
-    await extendTree(3, 5);
+    await delay(100);
 
     rowCount = await page.evaluate(() => document.querySelectorAll('tr').length);
-    strictEqual(rowCount, 5); // Due to the filter there are two objects fewer.
+    strictEqual(rowCount, 4); // Due to the filter there are two objects fewer.
   });
 
   await testParent.test('ObjectTree infoPanel should show filtered object versions', { timeout }, async () => {

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -44,18 +44,18 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should preserve state if refreshed', { timeout }, async () => {
-    const selector = 'section > div > div > div > table > tbody > tr:nth-child(2)';
+    const selector = 'section > div > div > div > div > table > tbody > tr:nth-child(2)';
     await page.locator(selector).click();
     await page.reload({ waitUntil: 'networkidle0' });
 
     const rowCountExpanded = await page.evaluate(() =>
-      document.querySelectorAll('section > div > div > div > table > tbody > tr').length);
+      document.querySelectorAll('section > div > div > div > div > table > tbody > tr').length);
 
     await page.locator(selector).click();
     await page.reload({ waitUntil: 'networkidle0' });
 
     const rowCountCollapsed = await page.evaluate(() =>
-      document.querySelectorAll('section > div > div > div > table > tbody > tr').length);
+      document.querySelectorAll('section > div > div > div > div > table > tbody > tr').length);
 
     strictEqual(rowCountExpanded, 3);
     strictEqual(rowCountCollapsed, 2);
@@ -232,7 +232,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   );
 
   await testParent.test('should update local storage when tree node is clicked', { timeout }, async () => {
-    const selector = 'section > div > div > div > table > tbody > tr:nth-child(2)';
+    const selector = 'section > div > div > div > div > table > tbody > tr:nth-child(2)';
     const personid = await page.evaluate(() => window.model.session.personid);
     const storageKey = `${StorageKeysEnum.OBJECT_TREE_OPEN_NODES}-${personid}`;
 
@@ -287,7 +287,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
       await delay(100);
       const storedNodes = await getLocalStorageAsJson(page, storageKey);
       const tableRowCount = await page.evaluate(() =>
-        document.querySelectorAll('section > div > div > div > table > tbody > tr').length);
+        document.querySelectorAll('section > div > div > div > div > table > tbody > tr').length);
 
       deepStrictEqual(storedNodes, {}, 'Stores nodes should be empty');
       strictEqual(tableRowCount, 1, 'Tree should be fully collapsed');
@@ -298,7 +298,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
     await page.type('#searchObjectTree', 'qc/test/object/1');
     const rowsDisplayed = await page.evaluate(() => {
       const rows = [];
-      document.querySelectorAll('section > div > div > div > table > tbody > tr')
+      document.querySelectorAll('section > div > div > div > div > table > tbody > tr')
         .forEach((item) => rows.push(item.innerText));
       return rows;
     }, { timeout: 5000 });

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -62,8 +62,8 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should have a button to sort by (default "Name" ASC)', async () => {
-    const sortByButtonTitle = await page.evaluate((path) => document.querySelector(path).title, '.btn.sort-button');
-    strictEqual(sortByButtonTitle, 'Sort by DESC');
+    const sortByButtonTitle = await page.evaluate((path) => document.querySelector(path).title, '.sort-button');
+    strictEqual(sortByButtonTitle, 'Sort DESC by Name');
   });
 
   await testParent.test('should have first element in tree as "qc/test/object/1"', async () => {
@@ -260,7 +260,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should sort list of histograms by name in descending order', async () => {
-    await page.locator('.btn.sort-button').click();
+    await page.locator('.sort-button').click();
 
     const sorted = await page.evaluate(() => ({
       list: window.model.object.currentList,
@@ -273,7 +273,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should sort list of histograms by name in ascending order', async () => {
-    await page.locator('.btn.sort-button').click();
+    await page.locator('.sort-button').click();
 
     const sorted = await page.evaluate(() => ({
       list: window.model.object.currentList,

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -55,8 +55,8 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should have a button to sort by (default "Name" ASC)', async () => {
-    const sortByButtonTitle = await page.evaluate((path) => document.querySelector(path).title, '#sortTreeButton');
-    strictEqual(sortByButtonTitle, 'Sort by');
+    const sortByButtonTitle = await page.evaluate((path) => document.querySelector(path).title, '.btn.sort-button');
+    strictEqual(sortByButtonTitle, 'Sort by DESC');
   });
 
   await testParent.test('should have first element in tree as "qc/test/object/1"', async () => {
@@ -229,9 +229,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   );
 
   await testParent.test('should sort list of histograms by name in descending order', async () => {
-    await page.locator('#sortTreeButton').click();
-    const sortingByNameOptionPath = '#sortTreeButton > div > a:nth-child(2)';
-    await page.locator(sortingByNameOptionPath).click();
+    await page.locator('.btn.sort-button').click();
 
     const sorted = await page.evaluate(() => ({
       list: window.model.object.currentList,
@@ -244,9 +242,8 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should sort list of histograms by name in ascending order', async () => {
-    await page.locator('#sortTreeButton').click();
-    const sortingByNameOptionPath = '#sortTreeButton > div > a:nth-child(1)';
-    await page.locator(sortingByNameOptionPath).click();
+    await page.locator('.btn.sort-button').click();
+
     const sorted = await page.evaluate(() => ({
       list: window.model.object.currentList,
       sort: window.model.object.sortBy,

--- a/QualityControl/test/public/pages/object-tree.test.js
+++ b/QualityControl/test/public/pages/object-tree.test.js
@@ -34,7 +34,7 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should have a tree as a table', { timeout }, async () => {
-    const tableRowPath = 'section > div > div > div > table > tbody > tr';
+    const tableRowPath = 'section > div > div > div > div > table > tbody > tr';
     await page.waitForSelector(tableRowPath, { timeout: 1000 });
     const rowsCount = await page.evaluate(
       (tableRowPath) => document.querySelectorAll(tableRowPath).length,
@@ -44,12 +44,12 @@ export const objectTreePageTests = async (url, page, timeout = 5000, testParent)
   });
 
   await testParent.test('should not preserve state if refreshed not in run mode', { timeout }, async () => {
-    const tbodyPath = 'section > div > div > div > table > tbody';
+    const tbodyPath = 'section > div > div > div > div > table > tbody';
     await page.locator(`${tbodyPath} > tr:nth-child(2)`).click();
     await page.reload({ waitUntil: 'networkidle0' });
 
     const rowCount = await page.evaluate(() =>
-      document.querySelectorAll('section > div > div > div > table > tbody > tr').length);
+      document.querySelectorAll('section > div > div > div > div > table > tbody > tr').length);
 
     strictEqual(rowCount, 2);
   });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

As a user, it is difficult to see that object tree can be filtered by name. Thus, the search input text (from top right in header) should be moved in the table header in a nice UI and UX manner.

Moreover, the (collapse all tree button) should be moved also in the table header(right most).
Moreover, the sort by name buton should also become part of the header so that when the user clicks on the header Name column, to display a sort icon up, or down or nothing depending on what is currently being sorted.
See for example how Bookkeeping sorts by Title on page "Log Entries" (log-overview)