### PR TITLE
[OGUI-1866] At server start fetch a list of detectors from Bookkeeping

### DIFF
--- a/QualityControl/common/library/typedef/DetectorSummary.js
+++ b/QualityControl/common/library/typedef/DetectorSummary.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * @typedef {object} DetectorSummary
+ * @property {string} name - Human-readable detector name.
+ * @property {string} type - Detector type identifier.
+ */

--- a/QualityControl/lib/controllers/FilterController.js
+++ b/QualityControl/lib/controllers/FilterController.js
@@ -63,12 +63,11 @@ export class FilterController {
    */
   async getFilterConfigurationHandler(req, res) {
     try {
-      let runTypes = [];
-      if (this._filterService) {
-        runTypes = await this._filterService.runTypes;
-      }
+      const runTypes = this._filterService?.runTypes ?? [];
+      const detectors = this._filterService?.detectors ?? [];
       res.status(200).json({
         runTypes,
+        detectors,
       });
     } catch (error) {
       res.status(503).json({ error: error.message || error });

--- a/QualityControl/lib/controllers/FilterController.js
+++ b/QualityControl/lib/controllers/FilterController.js
@@ -58,10 +58,10 @@ export class FilterController {
 
   /**
    * HTTP GET endpoint for retrieving a list of run types from Bookkeeping
-   * @param {Request} req - HTTP request
+   * @param {Request} _ - HTTP request
    * @param {Response} res - HTTP response to provide run types information
    */
-  async getFilterConfigurationHandler(req, res) {
+  getFilterConfigurationHandler(_, res) {
     try {
       const runTypes = this._filterService?.runTypes ?? [];
       const detectors = this._filterService?.detectors ?? [];
@@ -76,10 +76,10 @@ export class FilterController {
 
   /**
    * HTTP GET endpoint for retrieving a list of ongoing runs from Runs Mode Service
-   * @param {Request} req HTTP Request
+   * @param {Request} _ HTTP Request
    * @param {Response} res HTTP Response with the ongoing runs
    */
-  getOngoingRunsHandler(req, res) {
+  getOngoingRunsHandler(_, res) {
     const ongoingRuns = this._runsModeService?.ongoingRuns ?? [];
     res.status(200).json({ ongoingRuns });
   }

--- a/QualityControl/lib/services/BookkeepingService.js
+++ b/QualityControl/lib/services/BookkeepingService.js
@@ -25,12 +25,6 @@ const GET_DETECTORS_PATH = '/api/detectors';
 const LOG_FACILITY = `${process.env.npm_config_log_label ?? 'qcg'}/bkp-service`;
 
 /**
- * @typedef {object} DetectorSummary
- * @property {string} name - Human-readable detector name.
- * @property {string} type - Detector type identifier.
- */
-
-/**
  * BookkeepingService class to be used to retrieve data from Bookkeeping
  */
 export class BookkeepingService {
@@ -45,9 +39,6 @@ export class BookkeepingService {
     this._protocol = '';
 
     this._logger = LogManager.getLogger(LOG_FACILITY);
-
-    /** @type {Readonly<DetectorSummary[]>} */
-    this._detectors = Object.freeze([]);
   }
 
   /**
@@ -87,14 +78,7 @@ export class BookkeepingService {
       return;
     }
     this.active = await this.simulateConnection();
-    if (this.active) {
-      try {
-        const detectorSummaries = await this._retrieveDetectorSummaries();
-        this._detectors = Object.freeze(detectorSummaries.map((detector) => Object.freeze({ ...detector })));
-      } catch (error) {
-        this._logger.errorMessage(`Failed to retrieve detectors: ${error?.message || error}`);
-      }
-    } else {
+    if (!this.active) {
       this._logger.infoMessage(`Bookkeeping service will not be used. Reason: ${this.error}`);
     }
   }
@@ -200,10 +184,9 @@ export class BookkeepingService {
 
   /**
    * Retrieves the information about the detectors from the Bookkeeping service.
-   * @private
    * @returns {Promise<DetectorSummary[]>} Array of detector summaries.
    */
-  async _retrieveDetectorSummaries() {
+  async retrieveDetectorSummaries() {
     const { data } = await httpGetJson(
       this._hostname,
       this._port,
@@ -214,14 +197,6 @@ export class BookkeepingService {
       },
     );
     return Array.isArray(data) ? data.map(({ name, type }) => ({ name, type })) : [];
-  }
-
-  /**
-   * Returns a list of detector summaries.
-   * @returns {Readonly<DetectorSummary[]>} An immutable array of detector summaries.
-   */
-  get detectors() {
-    return this._detectors;
   }
 
   /**

--- a/QualityControl/lib/services/BookkeepingService.js
+++ b/QualityControl/lib/services/BookkeepingService.js
@@ -20,7 +20,7 @@ import { wrapRunStatus } from '../dtos/BookkeepingDto.js';
 const GET_BKP_DATABASE_STATUS_PATH = '/api/status/database';
 const GET_RUN_TYPES_PATH = '/api/runTypes';
 const GET_RUN_PATH = '/api/runs';
-const GET_DETECTORS_PATH = '/api/detectors';
+export const GET_DETECTORS_PATH = '/api/detectors';
 
 const LOG_FACILITY = `${process.env.npm_config_log_label ?? 'qcg'}/bkp-service`;
 

--- a/QualityControl/lib/services/BookkeepingService.js
+++ b/QualityControl/lib/services/BookkeepingService.js
@@ -20,8 +20,15 @@ import { wrapRunStatus } from '../dtos/BookkeepingDto.js';
 const GET_BKP_DATABASE_STATUS_PATH = '/api/status/database';
 const GET_RUN_TYPES_PATH = '/api/runTypes';
 const GET_RUN_PATH = '/api/runs';
+const GET_DETECTORS_PATH = '/api/detectors';
 
 const LOG_FACILITY = `${process.env.npm_config_log_label ?? 'qcg'}/bkp-service`;
+
+/**
+ * @typedef {object} DetectorSummary
+ * @property {string} name - Human-readable detector name.
+ * @property {string} type - Detector type identifier.
+ */
 
 /**
  * BookkeepingService class to be used to retrieve data from Bookkeeping
@@ -38,6 +45,9 @@ export class BookkeepingService {
     this._protocol = '';
 
     this._logger = LogManager.getLogger(LOG_FACILITY);
+
+    /** @type {Readonly<DetectorSummary[]>} */
+    this._detectors = Object.freeze([]);
   }
 
   /**
@@ -77,7 +87,14 @@ export class BookkeepingService {
       return;
     }
     this.active = await this.simulateConnection();
-    if (!this.active) {
+    if (this.active) {
+      try {
+        const detectorSummaries = await this._retrieveDetectorSummaries();
+        this._detectors = Object.freeze(detectorSummaries.map((detector) => Object.freeze({ ...detector })));
+      } catch (error) {
+        this._logger.errorMessage(`Failed to retrieve detectors: ${error?.message || error}`);
+      }
+    } else {
       this._logger.infoMessage(`Bookkeeping service will not be used. Reason: ${this.error}`);
     }
   }
@@ -179,6 +196,32 @@ export class BookkeepingService {
       this._logger.errorMessage(`Error fetching run status: ${error.message || error}`);
       return wrapRunStatus(RunStatus.UNKNOWN);
     }
+  }
+
+  /**
+   * Retrieves the information about the detectors from the Bookkeeping service.
+   * @private
+   * @returns {Promise<DetectorSummary[]>} Array of detector summaries.
+   */
+  async _retrieveDetectorSummaries() {
+    const { data } = await httpGetJson(
+      this._hostname,
+      this._port,
+      this._createPath(GET_DETECTORS_PATH),
+      {
+        protocol: this._protocol,
+        rejectUnauthorized: false,
+      },
+    );
+    return Array.isArray(data) ? data.map(({ name, type }) => ({ name, type })) : [];
+  }
+
+  /**
+   * Returns a list of detector summaries.
+   * @returns {Readonly<DetectorSummary[]>} An immutable array of detector summaries.
+   */
+  get detectors() {
+    return this._detectors;
   }
 
   /**

--- a/QualityControl/lib/services/BookkeepingService.js
+++ b/QualityControl/lib/services/BookkeepingService.js
@@ -184,7 +184,7 @@ export class BookkeepingService {
 
   /**
    * Retrieves the information about the detectors from the Bookkeeping service.
-   * @returns {Promise<DetectorSummary[]>} Array of detector summaries.
+   * @returns {Promise<object[]>} Array of detector summaries.
    */
   async retrieveDetectorSummaries() {
     const { data } = await httpGetJson(
@@ -196,7 +196,7 @@ export class BookkeepingService {
         rejectUnauthorized: false,
       },
     );
-    return Array.isArray(data) ? data.map(({ name, type }) => ({ name, type })) : [];
+    return Array.isArray(data) ? data : [];
   }
 
   /**

--- a/QualityControl/lib/services/FilterService.js
+++ b/QualityControl/lib/services/FilterService.js
@@ -78,6 +78,10 @@ export class FilterService {
    */
   async _initializeDetectors() {
     try {
+      if (!this._bookkeepingService.active) {
+        return;
+      }
+      
       const detectorSummaries = await this._bookkeepingService.retrieveDetectorSummaries();
       this._detectors = Object.freeze(detectorSummaries.map(({ name, type }) => Object.freeze({ name, type })));
     } catch (error) {

--- a/QualityControl/lib/services/FilterService.js
+++ b/QualityControl/lib/services/FilterService.js
@@ -81,7 +81,7 @@ export class FilterService {
       if (!this._bookkeepingService.active) {
         return;
       }
-      
+
       const detectorSummaries = await this._bookkeepingService.retrieveDetectorSummaries();
       this._detectors = Object.freeze(detectorSummaries.map(({ name, type }) => Object.freeze({ name, type })));
     } catch (error) {

--- a/QualityControl/lib/services/FilterService.js
+++ b/QualityControl/lib/services/FilterService.js
@@ -77,11 +77,10 @@ export class FilterService {
    * @returns {Promise<undefined>} Resolves when the list of detectors is available
    */
   async _initializeDetectors() {
+    if (!this._bookkeepingService?.active) {
+      return;
+    }
     try {
-      if (!this._bookkeepingService.active) {
-        return;
-      }
-
       const detectorSummaries = await this._bookkeepingService.retrieveDetectorSummaries();
       this._detectors = Object.freeze(detectorSummaries.map(({ name, type }) => Object.freeze({ name, type })));
     } catch (error) {

--- a/QualityControl/lib/services/FilterService.js
+++ b/QualityControl/lib/services/FilterService.js
@@ -31,7 +31,7 @@ export class FilterService {
     this._logger = LogManager.getLogger(LOG_FACILITY);
     this._bookkeepingService = bookkeepingService;
     this._runTypes = [];
-    this.initFilters();
+    this._detectors = Object.freeze([]);
 
     this._runTypesRefreshInterval = config?.bookkeeping?.runTypesRefreshInterval ??
       (config?.bookkeeping ? 24 * 60 * 60 * 1000 : -1);
@@ -48,6 +48,7 @@ export class FilterService {
   async initFilters() {
     await this._bookkeepingService.connect();
     await this.getRunTypes();
+    await this._initializeDetectors();
   }
 
   /**
@@ -69,6 +70,27 @@ export class FilterService {
       this._logger.errorMessage(`Error while retrieving run types: ${error.message || error}`);
       this._runTypes = [];
     }
+  }
+
+  /**
+   * This method is used to retrieve the list of detectors from the bookkeeping service
+   * @returns {Promise<undefined>} Resolves when the list of detectors is available
+   */
+  async _initializeDetectors() {
+    try {
+      const detectorSummaries = await this._bookkeepingService.retrieveDetectorSummaries();
+      this._detectors = Object.freeze(detectorSummaries.map((detector) => Object.freeze({ ...detector })));
+    } catch (error) {
+      this._logger.errorMessage(`Failed to retrieve detectors: ${error?.message || error}`);
+    }
+  }
+
+  /**
+   * Returns a list of detector summaries.
+   * @returns {Readonly<DetectorSummary[]>} An immutable array of detector summaries.
+   */
+  get detectors() {
+    return this._detectors;
   }
 
   /**

--- a/QualityControl/lib/services/FilterService.js
+++ b/QualityControl/lib/services/FilterService.js
@@ -79,7 +79,7 @@ export class FilterService {
   async _initializeDetectors() {
     try {
       const detectorSummaries = await this._bookkeepingService.retrieveDetectorSummaries();
-      this._detectors = Object.freeze(detectorSummaries.map((detector) => Object.freeze({ ...detector })));
+      this._detectors = Object.freeze(detectorSummaries.map(({ name, type }) => Object.freeze({ name, type })));
     } catch (error) {
       this._logger.errorMessage(`Failed to retrieve detectors: ${error?.message || error}`);
     }

--- a/QualityControl/test/lib/controllers/FiltersController.test.js
+++ b/QualityControl/test/lib/controllers/FiltersController.test.js
@@ -37,14 +37,14 @@ export const filtersControllerTestSuite = async () => {
     });
   });
 
-  suite('getFilterConfigurationHandler', async () => {
+  suite('getFilterConfigurationHandler', () => {
     test('should successfully retrieve run types and detectors from Bookkeeping service', async () => {
       const filterService = sinon.createStubInstance(FilterService);
       const mockedRunTypes = ['runType1', 'runType2'];
       const mockedDetectors = [
         {
-          name: 'Detector human-readable name',
-          type: 'Detector type identifier',
+          name: 'ITS',
+          type: 'PHYSICAL',
         },
       ];
       sinon.stub(filterService, 'runTypes').get(() => mockedRunTypes);
@@ -56,14 +56,14 @@ export const filtersControllerTestSuite = async () => {
       };
       const req = {};
       const filterController = new FilterController(filterService);
-      await filterController.getFilterConfigurationHandler(req, res);
+      filterController.getFilterConfigurationHandler(req, res);
       ok(res.status.calledWith(200), 'Response status was not 200');
       ok(
         res.json.calledWith({ runTypes: mockedRunTypes, detectors: mockedDetectors }),
         'Response should include runTypes and detectors',
       );
     });
-    test('should return an empty arrays if bookkeeping service is not defined', async () => {
+    test('should return an empty arrays if bookkeeping service is not defined', () => {
       const bkpService = null;
       const res = {
         status: sinon.stub().returnsThis(),
@@ -71,7 +71,7 @@ export const filtersControllerTestSuite = async () => {
       };
       const req = {};
       const filterController = new FilterController(bkpService);
-      await filterController.getFilterConfigurationHandler(req, res);
+      filterController.getFilterConfigurationHandler(req, res);
       ok(res.status.calledWith(200), 'Response status was not 200');
       ok(
         res.json.calledWith({ runTypes: [], detectors: [] }),

--- a/QualityControl/test/lib/controllers/FiltersController.test.js
+++ b/QualityControl/test/lib/controllers/FiltersController.test.js
@@ -38,10 +38,17 @@ export const filtersControllerTestSuite = async () => {
   });
 
   suite('getFilterConfigurationHandler', async () => {
-    test('should successfully retrieve run types from Bookkeeping service', async () => {
+    test('should successfully retrieve run types and detectors from Bookkeeping service', async () => {
       const filterService = sinon.createStubInstance(FilterService);
       const mockedRunTypes = ['runType1', 'runType2'];
+      const mockedDetectors = [
+        {
+          name: 'Detector human-readable name',
+          type: 'Detector type identifier',
+        },
+      ];
       sinon.stub(filterService, 'runTypes').get(() => mockedRunTypes);
+      sinon.stub(filterService, 'detectors').get(() => mockedDetectors);
 
       const res = {
         status: sinon.stub().returnsThis(),
@@ -51,9 +58,12 @@ export const filtersControllerTestSuite = async () => {
       const filterController = new FilterController(filterService);
       await filterController.getFilterConfigurationHandler(req, res);
       ok(res.status.calledWith(200), 'Response status was not 200');
-      ok(res.json.calledWith({ runTypes: mockedRunTypes }), 'Run types were not sent back');
+      ok(
+        res.json.calledWith({ runTypes: mockedRunTypes, detectors: mockedDetectors }),
+        'Response should include runTypes and detectors',
+      );
     });
-    test('should return an empty array if bookkeeping service is not defined', async () => {
+    test('should return an empty arrays if bookkeeping service is not defined', async () => {
       const bkpService = null;
       const res = {
         status: sinon.stub().returnsThis(),
@@ -64,8 +74,8 @@ export const filtersControllerTestSuite = async () => {
       await filterController.getFilterConfigurationHandler(req, res);
       ok(res.status.calledWith(200), 'Response status was not 200');
       ok(
-        res.json.calledWith({ runTypes: [] }),
-        'Run types were not sent as an empty array',
+        res.json.calledWith({ runTypes: [], detectors: [] }),
+        'runTypes and detectors were not sent as an empty array',
       );
     });
   });

--- a/QualityControl/test/lib/services/BookkeepingService.test.js
+++ b/QualityControl/test/lib/services/BookkeepingService.test.js
@@ -44,8 +44,6 @@ export const bookkeepingServiceTestSuite = async () => {
         strictEqual(bookkeepingService._port, null);
         strictEqual(bookkeepingService._token, '');
         strictEqual(bookkeepingService._protocol, '');
-        deepStrictEqual(bookkeepingService._detectors, []);
-        ok(Object.isFrozen(bookkeepingService._detectors));
       });
     });
 
@@ -136,22 +134,6 @@ export const bookkeepingServiceTestSuite = async () => {
         strictEqual(service.active, false);
         ok(service.error.includes('Error trying to connect to Bookkeeping'));
         ok(service.error.includes('simulated failure'));
-      });
-
-      test('should call _retrieveDetectorSummaries and set _detectors if active is true', async () => {
-        const DETECTOR_SUMMARIES = [
-          {
-            name: 'Detector human-readable name',
-            type: 'Detector type identifier',
-          },
-        ];
-
-        stub(service, 'simulateConnection').resolves(true);
-        simulateStub = stub(service, '_retrieveDetectorSummaries').resolves(DETECTOR_SUMMARIES);
-        await service.connect();
-        ok(simulateStub.calledOnce);
-        deepStrictEqual(service._detectors, DETECTOR_SUMMARIES);
-        ok(Object.isFrozen(service._detectors));
       });
     });
     suite('simulateConnection', () => {
@@ -338,7 +320,7 @@ export const bookkeepingServiceTestSuite = async () => {
             .query({ token: VALID_CONFIG.bookkeeping.token })
             .reply(200, mockResponse);
 
-          const result = await bkpService._retrieveDetectorSummaries();
+          const result = await bkpService.retrieveDetectorSummaries();
 
           ok(Array.isArray(result));
           strictEqual(result.length, mockResponse.data.length);
@@ -358,7 +340,7 @@ export const bookkeepingServiceTestSuite = async () => {
             .query({ token: VALID_CONFIG.bookkeeping.token })
             .reply(200, mockResponse);
 
-          const result = await bkpService._retrieveDetectorSummaries();
+          const result = await bkpService.retrieveDetectorSummaries();
 
           ok(Array.isArray(result));
           strictEqual(result.length, 0);
@@ -374,7 +356,7 @@ export const bookkeepingServiceTestSuite = async () => {
             .query({ token: VALID_CONFIG.bookkeeping.token })
             .reply(200, mockResponse);
 
-          const result = await bkpService._retrieveDetectorSummaries();
+          const result = await bkpService.retrieveDetectorSummaries();
 
           ok(Array.isArray(result));
           strictEqual(result.length, 0);

--- a/QualityControl/test/lib/services/BookkeepingService.test.js
+++ b/QualityControl/test/lib/services/BookkeepingService.test.js
@@ -17,7 +17,7 @@ import { suite, test, before, beforeEach, afterEach } from 'node:test';
 import nock from 'nock';
 import { stub, restore } from 'sinon';
 
-import { BookkeepingService } from '../../../lib/services/BookkeepingService.js';
+import { BookkeepingService, GET_DETECTORS_PATH } from '../../../lib/services/BookkeepingService.js';
 import { RunStatus } from '../../../common/library/runStatus.enum.js';
 
 /**
@@ -34,6 +34,7 @@ export const bookkeepingServiceTestSuite = async () => {
       },
     };
     before(() => nock.cleanAll());
+
     suite('Create a new instance of BookkeepingService', () => {
       test('should successfully initialize Bookkeeping Service', () => {
         const bookkeepingService = new BookkeepingService(VALID_CONFIG.bookkeeping);
@@ -91,6 +92,7 @@ export const bookkeepingServiceTestSuite = async () => {
         strictEqual(service._token, 'my-token');
       });
     });
+
     suite('connect', () => {
       let service = null;
       let validConfig = null;
@@ -136,6 +138,7 @@ export const bookkeepingServiceTestSuite = async () => {
         ok(service.error.includes('simulated failure'));
       });
     });
+
     suite('simulateConnection', () => {
       let service = null;
 
@@ -288,80 +291,6 @@ export const bookkeepingServiceTestSuite = async () => {
         ok(Object.values(RunStatus).includes(runStatus));
       });
 
-      suite('Retrieve detector summaries', () => {
-        const GET_DETECTORS_PATH = '/api/detectors';
-
-        let bkpService = null;
-
-        beforeEach(() => {
-          bkpService = new BookkeepingService(VALID_CONFIG.bookkeeping);
-          bkpService.validateConfig(); // ensures internal fields like _hostname/_port/_token are set
-          bkpService.connect();
-        });
-
-        afterEach(() => {
-          nock.cleanAll();
-        });
-
-        test('should handle all detector types correctly', async () => {
-          const mockResponse = {
-            data: [
-              { id: 1, name: 'ACO', type: 'PHYSICAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
-              { id: 2, name: 'EVS', type: 'AOT-EVENT', createdAt: 1765468282000, updatedAt: 1765468282000 },
-              { id: 3, name: 'GLO', type: 'QC', createdAt: 1765468282000, updatedAt: 1765468282000 },
-              { id: 4, name: 'MUD', type: 'MUON-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
-              { id: 5, name: 'VTX', type: 'AOT-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
-              { id: 6, name: 'TST', type: 'VIRTUAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
-            ],
-          };
-
-          nock(VALID_CONFIG.bookkeeping.url)
-            .get(GET_DETECTORS_PATH)
-            .query({ token: VALID_CONFIG.bookkeeping.token })
-            .reply(200, mockResponse);
-
-          const result = await bkpService.retrieveDetectorSummaries();
-
-          ok(Array.isArray(result));
-          strictEqual(result.length, mockResponse.data.length);
-
-          // Verify detector data is preserved
-          deepStrictEqual(result, mockResponse.data);
-        });
-
-        test('should return empty array when data is not an array', async () => {
-          const mockResponse = {
-            data: null,
-          };
-
-          nock(VALID_CONFIG.bookkeeping.url)
-            .get(GET_DETECTORS_PATH)
-            .query({ token: VALID_CONFIG.bookkeeping.token })
-            .reply(200, mockResponse);
-
-          const result = await bkpService.retrieveDetectorSummaries();
-
-          ok(Array.isArray(result));
-          strictEqual(result.length, 0);
-        });
-
-        test('should return empty array when data is empty array', async () => {
-          const mockResponse = {
-            data: [],
-          };
-
-          nock(VALID_CONFIG.bookkeeping.url)
-            .get(GET_DETECTORS_PATH)
-            .query({ token: VALID_CONFIG.bookkeeping.token })
-            .reply(200, mockResponse);
-
-          const result = await bkpService.retrieveDetectorSummaries();
-
-          ok(Array.isArray(result));
-          strictEqual(result.length, 0);
-        });
-      });
-
       test('should return ONGOING status when timeO2End is not present', async () => {
         const mockResponse = { data: { timeO2End: undefined } };
 
@@ -404,6 +333,77 @@ export const bookkeepingServiceTestSuite = async () => {
 
         const { runStatus } = await bkpService.retrieveRunInformation(123);
         strictEqual(runStatus, RunStatus.BOOKKEEPING_UNAVAILABLE);
+      });
+    });
+    suite('Retrieve detector summaries', () => {
+      let bkpService = null;
+
+      before(() => {
+        bkpService = new BookkeepingService(VALID_CONFIG.bookkeeping);
+        bkpService.validateConfig(); // ensures internal fields like _hostname/_port/_token are set
+        bkpService.connect();
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      test('should handle all detector types correctly', async () => {
+        const mockResponse = {
+          data: [
+            { id: 1, name: 'ACO', type: 'PHYSICAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            { id: 2, name: 'EVS', type: 'AOT-EVENT', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            { id: 3, name: 'GLO', type: 'QC', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            { id: 4, name: 'MUD', type: 'MUON-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            { id: 5, name: 'VTX', type: 'AOT-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            { id: 6, name: 'TST', type: 'VIRTUAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
+          ],
+        };
+
+        nock(VALID_CONFIG.bookkeeping.url)
+          .get(GET_DETECTORS_PATH)
+          .query({ token: VALID_CONFIG.bookkeeping.token })
+          .reply(200, mockResponse);
+
+        const result = await bkpService.retrieveDetectorSummaries();
+
+        ok(Array.isArray(result));
+        strictEqual(result.length, mockResponse.data.length);
+
+        // Verify detector data is preserved
+        deepStrictEqual(result, mockResponse.data);
+      });
+
+      test('should return empty array when data is not an array', async () => {
+        const mockResponse = {
+          data: null,
+        };
+
+        nock(VALID_CONFIG.bookkeeping.url)
+          .get(GET_DETECTORS_PATH)
+          .query({ token: VALID_CONFIG.bookkeeping.token })
+          .reply(200, mockResponse);
+
+        const result = await bkpService.retrieveDetectorSummaries();
+
+        ok(Array.isArray(result));
+        strictEqual(result.length, 0);
+      });
+
+      test('should return empty array when data is empty array', async () => {
+        const mockResponse = {
+          data: [],
+        };
+
+        nock(VALID_CONFIG.bookkeeping.url)
+          .get(GET_DETECTORS_PATH)
+          .query({ token: VALID_CONFIG.bookkeeping.token })
+          .reply(200, mockResponse);
+
+        const result = await bkpService.retrieveDetectorSummaries();
+
+        ok(Array.isArray(result));
+        strictEqual(result.length, 0);
       });
     });
   });

--- a/QualityControl/test/lib/services/BookkeepingService.test.js
+++ b/QualityControl/test/lib/services/BookkeepingService.test.js
@@ -325,9 +325,8 @@ export const bookkeepingServiceTestSuite = async () => {
           ok(Array.isArray(result));
           strictEqual(result.length, mockResponse.data.length);
 
-          // Verify each detector is preserved
-          const detectorSummaries = result.map(({ name, type }) => ({ name, type }));
-          deepStrictEqual(result, detectorSummaries);
+          // Verify detector data is preserved
+          deepStrictEqual(result, mockResponse.data);
         });
 
         test('should return empty array when data is not an array', async () => {

--- a/QualityControl/test/lib/services/BookkeepingService.test.js
+++ b/QualityControl/test/lib/services/BookkeepingService.test.js
@@ -44,6 +44,8 @@ export const bookkeepingServiceTestSuite = async () => {
         strictEqual(bookkeepingService._port, null);
         strictEqual(bookkeepingService._token, '');
         strictEqual(bookkeepingService._protocol, '');
+        deepStrictEqual(bookkeepingService._detectors, []);
+        ok(Object.isFrozen(bookkeepingService._detectors));
       });
     });
 
@@ -134,6 +136,22 @@ export const bookkeepingServiceTestSuite = async () => {
         strictEqual(service.active, false);
         ok(service.error.includes('Error trying to connect to Bookkeeping'));
         ok(service.error.includes('simulated failure'));
+      });
+
+      test('should call _retrieveDetectorSummaries and set _detectors if active is true', async () => {
+        const DETECTOR_SUMMARIES = [
+          {
+            name: 'Detector human-readable name',
+            type: 'Detector type identifier',
+          },
+        ];
+
+        stub(service, 'simulateConnection').resolves(true);
+        simulateStub = stub(service, '_retrieveDetectorSummaries').resolves(DETECTOR_SUMMARIES);
+        await service.connect();
+        ok(simulateStub.calledOnce);
+        deepStrictEqual(service._detectors, DETECTOR_SUMMARIES);
+        ok(Object.isFrozen(service._detectors));
       });
     });
     suite('simulateConnection', () => {
@@ -286,6 +304,81 @@ export const bookkeepingServiceTestSuite = async () => {
 
         deepStrictEqual(data, mockResponse.data);
         ok(Object.values(RunStatus).includes(runStatus));
+      });
+
+      suite('Retrieve detector summaries', () => {
+        const GET_DETECTORS_PATH = '/api/detectors';
+
+        let bkpService = null;
+
+        beforeEach(() => {
+          bkpService = new BookkeepingService(VALID_CONFIG.bookkeeping);
+          bkpService.validateConfig(); // ensures internal fields like _hostname/_port/_token are set
+          bkpService.connect();
+        });
+
+        afterEach(() => {
+          nock.cleanAll();
+        });
+
+        test('should handle all detector types correctly', async () => {
+          const mockResponse = {
+            data: [
+              { id: 1, name: 'ACO', type: 'PHYSICAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
+              { id: 2, name: 'EVS', type: 'AOT-EVENT', createdAt: 1765468282000, updatedAt: 1765468282000 },
+              { id: 3, name: 'GLO', type: 'QC', createdAt: 1765468282000, updatedAt: 1765468282000 },
+              { id: 4, name: 'MUD', type: 'MUON-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
+              { id: 5, name: 'VTX', type: 'AOT-GLO', createdAt: 1765468282000, updatedAt: 1765468282000 },
+              { id: 6, name: 'TST', type: 'VIRTUAL', createdAt: 1765468282000, updatedAt: 1765468282000 },
+            ],
+          };
+
+          nock(VALID_CONFIG.bookkeeping.url)
+            .get(GET_DETECTORS_PATH)
+            .query({ token: VALID_CONFIG.bookkeeping.token })
+            .reply(200, mockResponse);
+
+          const result = await bkpService._retrieveDetectorSummaries();
+
+          ok(Array.isArray(result));
+          strictEqual(result.length, mockResponse.data.length);
+
+          // Verify each detector is preserved
+          const detectorSummaries = result.map(({ name, type }) => ({ name, type }));
+          deepStrictEqual(result, detectorSummaries);
+        });
+
+        test('should return empty array when data is not an array', async () => {
+          const mockResponse = {
+            data: null,
+          };
+
+          nock(VALID_CONFIG.bookkeeping.url)
+            .get(GET_DETECTORS_PATH)
+            .query({ token: VALID_CONFIG.bookkeeping.token })
+            .reply(200, mockResponse);
+
+          const result = await bkpService._retrieveDetectorSummaries();
+
+          ok(Array.isArray(result));
+          strictEqual(result.length, 0);
+        });
+
+        test('should return empty array when data is empty array', async () => {
+          const mockResponse = {
+            data: [],
+          };
+
+          nock(VALID_CONFIG.bookkeeping.url)
+            .get(GET_DETECTORS_PATH)
+            .query({ token: VALID_CONFIG.bookkeeping.token })
+            .reply(200, mockResponse);
+
+          const result = await bkpService._retrieveDetectorSummaries();
+
+          ok(Array.isArray(result));
+          strictEqual(result.length, 0);
+        });
       });
 
       test('should return ONGOING status when timeO2End is not present', async () => {

--- a/QualityControl/test/lib/services/FilterService.test.js
+++ b/QualityControl/test/lib/services/FilterService.test.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { deepStrictEqual } from 'node:assert';
+import { deepStrictEqual, ok } from 'node:assert';
 import { suite, test, beforeEach, afterEach } from 'node:test';
 import { FilterService } from '../../../lib/services/FilterService.js';
 import { RunStatus } from '../../../common/library/runStatus.enum.js';
@@ -32,6 +32,7 @@ export const filterServiceTestSuite = async () => {
       connect: stub(),
       retrieveRunTypes: stub(),
       retrieveRunInformation: stub(),
+      retrieveDetectorSummaries: stub(),
       active: true, // assume the bookkeeping service is active by default
     };
     filterService = new FilterService(bookkeepingServiceMock, configMock);
@@ -63,6 +64,11 @@ export const filterServiceTestSuite = async () => {
       deepStrictEqual(filterServiceWithCustomConfig._runTypesRefreshInterval, 5000);
     });
 
+    test('should init _detectors on instantiation', async () => {
+      deepStrictEqual(filterService._detectors, []);
+      ok(Object.isFrozen(filterService._detectors));
+    });
+
     test('should init filters on instantiation', async () => {
       const initFiltersStub = stub(filterService, 'initFilters');
       await filterService.initFilters();
@@ -71,7 +77,26 @@ export const filterServiceTestSuite = async () => {
   });
 
   suite('initFilters', async () => {
+    test('should call _initializeDetectors', async () => {
+      const initializeDetectorsStub = stub(filterService, '_initializeDetectors');
+      await filterService.initFilters();
+      ok(initializeDetectorsStub.calledOnce);
+    });
 
+    test('should set _detectors on _initializeDetectors call', async () => {
+      const DETECTOR_SUMMARIES = [
+        {
+          name: 'Detector human-readable name',
+          type: 'Detector type identifier',
+        },
+      ];
+
+      bookkeepingServiceMock.retrieveDetectorSummaries.resolves(DETECTOR_SUMMARIES);
+      await filterService._initializeDetectors();
+
+      deepStrictEqual(filterService._detectors, DETECTOR_SUMMARIES);
+      ok(Object.isFrozen(filterService._detectors));
+    });
   });
 
   suite('getRunTypes', async () => {

--- a/QualityControl/test/setup/testSetupForBkp.js
+++ b/QualityControl/test/setup/testSetupForBkp.js
@@ -44,6 +44,48 @@ export const initializeNockForBkp = () => {
     });
   nock(BKP_URL)
     .persist()
+    .get(`/api/detectors${TOKEN_PATH}`)
+    .reply(200, {
+      data: [
+        {
+          id: 17,
+          name: 'ACO',
+          type: 'PHYSICAL',
+          createdAt: 1765468282000,
+          updatedAt: 1765468282000,
+        },
+        {
+          id: 1,
+          name: 'CPV',
+          type: 'PHYSICAL',
+          createdAt: 1765468282000,
+          updatedAt: 1765468282000,
+        },
+        {
+          id: 23,
+          name: 'EVS',
+          type: 'AOT-EVENT',
+          createdAt: 1765468282000,
+          updatedAt: 1765468282000,
+        },
+        {
+          id: 21,
+          name: 'GLO',
+          type: 'QC',
+          createdAt: 1765468282000,
+          updatedAt: 1765468282000,
+        },
+        {
+          id: 15,
+          name: 'TST',
+          type: 'VIRTUAL',
+          createdAt: 1765468282000,
+          updatedAt: 1765468282000,
+        },
+      ],
+    });
+  nock(BKP_URL)
+    .persist()
     .get(`/api/runs/0${TOKEN_PATH}`)
     .reply(200, {
       data: {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

Changes:
- On server startup, fetch the list of detectors from Bookkeeping. Only the following fields are retained from the response:
  - `name` (string)
  - `type` (string)
