### PR TITLE
[OGUI-1880] Use transition status instead of message string comparison by ECS

### DIFF
--- a/Control/lib/common/ecsOperationAndStepStatus.enum.js
+++ b/Control/lib/common/ecsOperationAndStepStatus.enum.js
@@ -14,11 +14,15 @@
 
 /**
  * Available ECS Statuses of operations for Kafka Events
+ * https://github.com/AliceO2Group/Control/blob/master/core/protos/o2control.proto#L228
  * These operations can be under the label:
  * * operationStatus
  * * operationStepStatus
  */
 const EcsOperationAndStepStatus = Object.freeze({
+  NULL: 'NULL',
+  STARTED: 'STARTED',
+  ONGOING: 'ONGOING',
   DONE_OK: 'DONE_OK',
   DONE_ERROR: 'DONE_ERROR',
   DONE_TIMEOUT: 'DONE_TIMEOUT',

--- a/Control/lib/services/environment/EnvironmentCache.service.js
+++ b/Control/lib/services/environment/EnvironmentCache.service.js
@@ -24,10 +24,8 @@ const {
 const { EnvironmentState } = require('../../common/environmentState.enum.js');
 const { TaskState } = require('../../common/taskState.enum.js');
 const { EnvironmentTransitionType } = require('../../common/environmentTransitionType.enum.js');
+const { EcsOperationAndStepStatus } = require('../../common/ecsOperationAndStepStatus.enum.js');
 const EPN_PATH_IN_ENVIRONMENT_INFO = 'hardware.epn.info';
-
-const ECS_TRANSITION_DONE_MESSAGE = 'transition completed successfully';
-const ECS_DESTROY_TRANSITION_DONE_MESSAGE = 'environment teardown complete';
 
 /**
  * @class
@@ -219,7 +217,7 @@ class EnvironmentCacheService {
    * @returns {void}
    */
   _handleEnvironmentEvent(environmentEvent) {
-    const { id, state, transition = {}, message, error, runNumber } = environmentEvent;
+    const { id, state, transition = {}, error, runNumber } = environmentEvent;
     const cachedEnvironment = this._environments.has(id)
       ? this._environments.get(id)
       : { id, events: [] };
@@ -238,8 +236,7 @@ class EnvironmentCacheService {
    
     if (
       state === EnvironmentState.CONFIGURED &&
-      message === ECS_TRANSITION_DONE_MESSAGE
-      // OCTRL-1038 - currently comparing to hardcoded string, but this should be replaced with transition status
+      transition?.status === EcsOperationAndStepStatus.DONE_OK
     ) {
       // Once the environment is configured and ongoing transition is done, we can set the isDeploying to false
       // This can happen when the environment also goes form RUNNING to CONFIGURED but it is already marked as not deploying anymore
@@ -256,9 +253,9 @@ class EnvironmentCacheService {
     this.addOrUpdateEnvironment(cachedEnvironment, false);
 
     if (
-      transition?.name === EnvironmentTransitionType.DESTROY  &&
+      transition?.name === EnvironmentTransitionType.DESTROY &&
+      transition?.status === EcsOperationAndStepStatus.DONE_OK &&
       state === EnvironmentState.DONE &&
-      message === ECS_DESTROY_TRANSITION_DONE_MESSAGE &&
       !cachedEnvironment.deploymentError
     ) {
       // That is, if the environment successfully ended the DESTROY transition

--- a/Control/test/lib/services/environment/mocha-environment-cache.service.test.js
+++ b/Control/test/lib/services/environment/mocha-environment-cache.service.test.js
@@ -23,6 +23,7 @@ EmitterKeys} = require('../../../../lib/common/emitterKeys.enum.js');
 const { BroadcastKeys: {ENVIRONMENT_EVENTS, ENVIRONMENTS_OVERVIEW} } = require('../../../../lib/common/broadcastKeys.enum.js');
 const { EnvironmentState } = require('../../../../lib/common/environmentState.enum.js');
 const { EnvironmentTransitionType } = require('../../../../lib/common/environmentTransitionType.enum.js');
+const { EcsOperationAndStepStatus } = require('../../../../lib/common/ecsOperationAndStepStatus.enum.js');
 
 describe(`'EnvironmentCacheService' - test suite`, () => {
   let broadcastServiceMock;
@@ -376,14 +377,35 @@ describe(`'EnvironmentCacheService' - test suite`, () => {
         id: 'env1',
         transition: {
           name: EnvironmentTransitionType.DESTROY,
+          status: EcsOperationAndStepStatus.DONE_OK
         },
-        message: 'environment teardown complete',
         state: EnvironmentState.DONE
       });
 
       const env = environmentCacheService._environments.get('env1');
       assert.ok(!env, 'Environment "env1" should be removed from the cache');
       assert.strictEqual(broadcastServiceMock.broadcast.callCount, 2, 'Broadcast (event and overview) should be made when environment is removed');
+    });
+
+    it('should successfully remove isDeploying flag on CONFIGURED state after deployment', () => {
+      const initialEnvironment = {
+        id: 'env1',
+        isDeploying: true,
+        state: EnvironmentState.DEPLOYED
+      };
+      environmentCacheService.addOrUpdateEnvironment(initialEnvironment);
+
+      eventEmitter.emit(EmitterKeys.ENVIRONMENTS_TRACK, {
+        id: 'env1',
+        transition: {
+          name: EnvironmentTransitionType.CONFIGURE,
+          status: EcsOperationAndStepStatus.DONE_OK
+        },
+        state: EnvironmentState.CONFIGURED
+      });
+      const env = environmentCacheService._environments.get('env1');
+      assert.ok(env, 'Environment "env1" should exist in the cache without isDeploying flag');
+      assert.strictEqual(env.isDeploying, false, 'isDeploying flag should be removed after successful deployment');
     });
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* updates the logic of environment events to use transition status now that ECS is providing it
* removes the previous use of hardcoded message string comparison
* Extend `EcsOperationAndStepStatus` enum with additional ECS statuses (`NULL/STARTED/ONGOING`).
