### PR TITLE
[OGUI-1884] Improve lock action error log in case of unauthorized action

### DIFF
--- a/Control/lib/controllers/Lock.controller.js
+++ b/Control/lib/controllers/Lock.controller.js
@@ -77,12 +77,12 @@ class LockController {
               try {
                 this._lockService.takeLock(detector, user, shouldForce);
               } catch (error) {
-                console.error(error);
+                this._logger.errorMessage(error, {level: LogLevel.DEVELOPER, facility: LOG_FACILITY});
               }
             });
         } else {
           this._lockService.takeLock(detectorId, user, shouldForce);
-        }
+        } 
         res.status(200).json(this._lockService.locksByDetectorToJSON());
       } else if (action.toLocaleUpperCase() === DetectorLockAction.RELEASE) {
         if (detectorId === DetectorId.ALL) {
@@ -92,7 +92,7 @@ class LockController {
               try {
                 this._lockService.releaseLock(detector, user, shouldForce);
               } catch (error) {
-                console.error(error);
+                this._logger.errorMessage(error, {level: LogLevel.DEVELOPER, facility: LOG_FACILITY});
               }
             });
         } else {

--- a/Control/lib/services/Lock.service.js
+++ b/Control/lib/services/Lock.service.js
@@ -87,9 +87,8 @@ class LockService {
       throw new NotFoundError(`Detector ${detectorName} not found in the list of detectors`);
     } else if (lock.isTaken()) {
       if (!lock.isOwnedBy(user) && !shouldForce) {
-        throw new UnauthorizedAccessError(
-          `Unauthorized TAKE action for lock ${detectorName} by ${user.fullName} while lock is held by ${lock.owner.fullName}`
-        );
+        throw new UnauthorizedAccessError(`Unauthorized TAKE action for lock ${detectorName} `
+          + `by ${ user.fullName } while lock is held by ${ lock.owner.fullName }`);
       }
       if (lock.isOwnedBy(user)) {
         return this._locksByDetector;
@@ -117,9 +116,8 @@ class LockService {
     } else if (lock.isFree()) {
       return this._locksByDetector;
     } else if (!lock.isOwnedBy(user) && !shouldForce) {
-      throw new UnauthorizedAccessError(
-        `Unauthorized RELEASE action for lock ${detectorName} by ${user.fullName} while lock is held by ${lock.owner.fullName}`
-      );
+      throw new UnauthorizedAccessError(`Unauthorized RELEASE action for lock ${detectorName} `
+        + `by ${ user.fullName } while lock is held by ${ lock.owner.fullName }`);
     }
     this._locksByDetector[detectorName].release();
 

--- a/Control/lib/services/Lock.service.js
+++ b/Control/lib/services/Lock.service.js
@@ -88,7 +88,7 @@ class LockService {
     } else if (lock.isTaken()) {
       if (!lock.isOwnedBy(user) && !shouldForce) {
         throw new UnauthorizedAccessError(
-          `Unauthorized TAKE action for lock of detector ${detectorName} by user ${user.fullName}`
+          `Unauthorized TAKE action for lock ${detectorName} by ${user.fullName} while lock is held by ${lock.owner.fullName}`
         );
       }
       if (lock.isOwnedBy(user)) {
@@ -118,7 +118,7 @@ class LockService {
       return this._locksByDetector;
     } else if (!lock.isOwnedBy(user) && !shouldForce) {
       throw new UnauthorizedAccessError(
-        `Unauthorized RELEASE action for lock of detector ${detectorName} by user ${user.fullName}`
+        `Unauthorized RELEASE action for lock ${detectorName} by ${user.fullName} while lock is held by ${lock.owner.fullName}`
       );
     }
     this._locksByDetector[detectorName].release();

--- a/Control/test/api/lock/api-put-locks.test.js
+++ b/Control/test/api/lock/api-put-locks.test.js
@@ -82,7 +82,7 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
     await request(`${TEST_URL}/api/locks`)
       .put(`/${DetectorLockAction.TAKE}/MID?token=${ADMIN_TEST_TOKEN}`)
       .expect(403, {
-        message: 'Unauthorized TAKE action for lock of detector MID by user Admin User',
+        message: 'Unauthorized TAKE action for lock MID by Admin User while lock is held by Global User',
         title: 'Unauthorized Access',
         status: 403,
       });
@@ -172,7 +172,7 @@ describe(`'API - PUT - /locks/:action/:detectorId' test suite`, () => {
     await request(`${TEST_URL}/api/locks`)
       .put(`/${DetectorLockAction.RELEASE}/MID?token=${DET_MID_TEST_TOKEN}`)
       .expect(403, {
-        message: 'Unauthorized RELEASE action for lock of detector MID by user Detector User',
+        message: 'Unauthorized RELEASE action for lock MID by Detector User while lock is held by Admin User',
         status: 403,
         title: 'Unauthorized Access',
       });

--- a/Control/test/lib/controllers/mocha-lock.controller.test.js
+++ b/Control/test/lib/controllers/mocha-lock.controller.test.js
@@ -115,7 +115,7 @@ describe(`'LockController' test suite`, () => {
       }, res);
       assert.ok(res.status.calledWith(403));
       assert.ok(res.json.calledWith({
-        message: 'Unauthorized TAKE action for lock of detector ABC by user NotAnonymous',
+        message: 'Unauthorized TAKE action for lock ABC by NotAnonymous while lock is held by Anonymous',
         status: 403,
         title: 'Unauthorized Access',
       }));
@@ -134,7 +134,7 @@ describe(`'LockController' test suite`, () => {
       }, res);
       assert.ok(res.status.calledWith(403));
       assert.ok(res.json.calledWith({
-        message: 'Unauthorized RELEASE action for lock of detector ABC by user NotAnonymous',
+        message: 'Unauthorized RELEASE action for lock ABC by NotAnonymous while lock is held by Anonymous',
         title: 'Unauthorized Access',
         status: 403,
       }));

--- a/Control/test/lib/services/mocha-lock.service.test.js
+++ b/Control/test/lib/services/mocha-lock.service.test.js
@@ -70,7 +70,7 @@ describe(`'LockService' test suite`, () => {
   it('should throw error when a user attempts to take a lock that is already held by another user', () => {
     assert.throws(
       () => lockService.takeLock('ABC', userB),
-      new UnauthorizedAccessError(`Unauthorized TAKE action for lock of detector ABC by user userB`)
+      new UnauthorizedAccessError('Unauthorized TAKE action for lock ABC by userB while lock is held by userA')
     );
   });
 
@@ -98,7 +98,7 @@ describe(`'LockService' test suite`, () => {
     lockService.takeLock('ABC', userA);
     assert.throws(
       () => lockService.releaseLock('ABC', userB),
-      new UnauthorizedAccessError(`Unauthorized RELEASE action for lock of detector ABC by user userB`)
+      new UnauthorizedAccessError('Unauthorized RELEASE action for lock ABC by userB while lock is held by userA')
     );
   });
 


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* remove the usage of native console.error and instead uses the webui-logger so that trace is not displayed
* improves the error log message