### PR TITLE
[OGUI-1073] Infologger link can get stuck if provided invalid filter parameters

### DIFF
--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -333,7 +333,13 @@ export default class Model extends Observable {
       return;
     } else if (params.q) {
       this.getUserProfile();
-      this.log.filter.fromObject(JSON.parse(params.q.replaceAll('\n', '\\n')));
+      try {
+        this.log.filter.fromObject(JSON.parse(params.q.replaceAll('\n', '\\n')));
+      } catch (error) {
+        this.log.filter.resetCriteria();
+        this.updateRouteOnModelChange();
+        this.notification.show(`Invalid URL filter format: ${error.message}`, 'danger');
+      }
     } else {
       this.getUserProfile();
     }

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -93,6 +93,25 @@ describe('Filter actions test-suite', async () => {
     assert.strictEqual(searchParams, expectedParams);
   });
 
+  it('should redirect to default filters and show JSON parse error on malformed q in URI', async () => {
+    const expectedDefaultParams = '?q={"severity":{"in":"I W E F"}}';
+
+    const locationAndNotification = await page.evaluate(() => {
+      const params = { q: '{"severity":{"in":"W I E F"' };
+      window.model.parseLocation(params);
+      return {
+        search: window.location.search,
+        notification: window.model.notification,
+      };
+    });
+
+    assert.strictEqual(decodeURI(locationAndNotification.search), expectedDefaultParams);
+    assert.strictEqual(locationAndNotification.notification.type, 'danger');
+    assert.strictEqual(
+      locationAndNotification.notification.message,
+      'Invalid URL filter format: JSON.parse: expected \'.\' or \'}\' after property value in object at line 1 column 28 of the JSON data');
+  });
+
   it('should update URI with new encoded "match" criteria', async () => {
     /* eslint-disable max-len */
     const decodedParams = '?q={"hostname":{"match":"\\"%ald_qdip01%"},"severity":{"in":"I W E F"}}';

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -107,9 +107,10 @@ describe('Filter actions test-suite', async () => {
 
     assert.strictEqual(decodeURI(locationAndNotification.search), expectedDefaultParams);
     assert.strictEqual(locationAndNotification.notification.type, 'danger');
+    // CI/CD runs on Chromium so this assertion is based on Chromium's JSON engine's error message
     assert.strictEqual(
       locationAndNotification.notification.message,
-      'Invalid URL filter format: JSON.parse: expected \'.\' or \'}\' after property value in object at line 1 column 28 of the JSON data');
+      'Invalid URL filter format: Expected \',\' or \'}\' after property value in JSON at position 27 (line 1 column 28)');
   });
 
   it('should update URI with new encoded "match" criteria', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [X] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [X] PR labels are selected
- [ ] FLP integration tests were ran successful

This PR adds a try and catch when the parsing of filter params occurs on location change. 

- It catches the parsing error
- Resets filters & navigates to the default page 
- Shows a danger notification with JSON line col error message
