### PR TITLE
[OGUI-1577] Alert user of no filters set

### DIFF
--- a/InfoLogger/public/constants/text-filter-operators.const.js
+++ b/InfoLogger/public/constants/text-filter-operators.const.js
@@ -1,4 +1,18 @@
 /**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
  * Operators used with the text filters.
  */
 export const TEXT_FILTER_OPERATORS = Object.freeze(['since', 'until', 'match', 'exclude']);

--- a/InfoLogger/public/constants/text-filter-operators.const.js
+++ b/InfoLogger/public/constants/text-filter-operators.const.js
@@ -1,0 +1,4 @@
+/**
+ * Operators used with the text filters.
+ */
+export const TEXT_FILTER_OPERATORS = Object.freeze(['since', 'until', 'match', 'exclude']);

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -327,11 +327,8 @@ export default class Log extends Observable {
     }
 
     if (!this.filter.hasActiveTextFilters()) {
-      // If the browser does not support the confirm dialog, execute the query anyway
-      const shouldExecuteQueryWithoutFilters = typeof window.confirm === 'function'
-        ? window.confirm('No date or text filters set. This will return a large amount of data. Execute query anyway?')
-        : true;
-      if (!shouldExecuteQueryWithoutFilters) {
+      if (!window.confirm('No date or text filters set.'
+        + ' This will return a large amount of data. Execute query anyway?')) {
         return;
       }
     }

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -325,6 +325,17 @@ export default class Log extends Observable {
     if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
       throw new Error('Query service is not available');
     }
+
+    if (!this.filter.hasActiveTextFilters()) {
+      // If the browser does not support the confirm dialog, execute the query anyway
+      const shouldExecuteQueryWithoutFilters = typeof window.confirm === 'function'
+        ? window.confirm('No date or text filters set. This will return a large amount of data. Execute query anyway?')
+        : true;
+      if (!shouldExecuteQueryWithoutFilters) {
+        return;
+      }
+    }
+
     this.queryResult = RemoteData.loading();
     this.notify();
 

--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -13,6 +13,7 @@
  */
 
 import { Observable } from '/js/src/index.js';
+import { TEXT_FILTER_OPERATORS } from '../constants/text-filter-operators.const.js';
 
 /**
  * @typedef Criteria
@@ -148,9 +149,8 @@ export default class LogFilter extends Observable {
    * @returns {boolean} true if at least one text filter has a value
    */
   hasActiveTextFilters() {
-    const textOperators = ['since', 'until', 'match', 'exclude'];
     return Object.values(this.criterias).some((criteria) =>
-      textOperators.some((operator) => criteria[operator]?.trim()));
+      TEXT_FILTER_OPERATORS.some((operator) => criteria[operator]?.trim()));
   }
 
   /**

--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -143,6 +143,17 @@ export default class LogFilter extends Observable {
   }
 
   /**
+   * Check whether at least one text filter is set by the user.
+   * Only text filters use the since/until and match/exclude fields.
+   * @returns {boolean} true if at least one text filter has a value
+   */
+  hasActiveTextFilters() {
+    const textOperators = ['since', 'until', 'match', 'exclude'];
+    return Object.values(this.criterias).some((criteria) =>
+      textOperators.some((operator) => criteria[operator]?.trim()));
+  }
+
+  /**
    * Generates a function to filter a log passed as argument to it
    * Output of function is boolean.
    * @returns {Function.<WebSocketMessage, boolean>} - function to filter logs

--- a/InfoLogger/test/public/query-mode-mocha.js
+++ b/InfoLogger/test/public/query-mode-mocha.js
@@ -17,17 +17,36 @@
 const assert = require('assert');
 const test = require('../mocha-index');
 
+const TEXT_FILTER_VALUE_BY_OPERATOR = {
+  since: '2026-01-01T00:00:00.000Z',
+  until: '2026-01-01T00:00:00.000Z',
+  match: 'some-message',
+  exclude: 'some-message',
+};
+
+const TEXT_FILTER_FIELD_BY_OPERATOR = {
+  since: 'timestamp',
+  until: 'timestamp',
+  match: 'message',
+  exclude: 'message',
+};
+
 /**
  * Runs model.log.query() in the browser context with mocked dependencies.
  * @param {Page} page - puppeteer page
  * @param {object} options
  * @param {boolean} options.confirmReturn - value window.confirm will return
- * @param {boolean} [options.setTextFilter=false] - if true, sets a message match filter before querying
+ * @param {string} [options.textFilterOperator] - operator to set before querying
  * @returns {Promise<{confirmCalls: number, postCalls: number}>}
  */
-const runQueryWithMocks = (page, { confirmReturn, setTextFilter = false }) =>
+const runQueryWithMocks = (page, { confirmReturn, textFilterOperator }) =>
   // Sets up mocks for confirmation dialog and post request, needs to be run in the browser context
-  page.evaluate(async ({ confirmReturn, setTextFilter }) => {
+  page.evaluate(async ({
+    confirmReturn,
+    textFilterOperator,
+    textFilterValueByOperator,
+    textFilterFieldByOperator,
+  }) => {
     let confirmCalls = 0;
     let postCalls = 0;
 
@@ -49,13 +68,22 @@ const runQueryWithMocks = (page, { confirmReturn, setTextFilter = false }) =>
 
     // Default state of filters includes no text filters
     window.model.log.filter.resetCriteria();
-    if (setTextFilter) {
-      window.model.log.filter.setCriteria('message', 'match', 'some-message');
+    if (textFilterOperator) {
+      window.model.log.filter.setCriteria(
+        textFilterFieldByOperator[textFilterOperator],
+        textFilterOperator,
+        textFilterValueByOperator[textFilterOperator],
+      );
     }
     await window.model.log.query();
 
     return { confirmCalls, postCalls };
-  }, { confirmReturn, setTextFilter });
+  }, {
+    confirmReturn,
+    textFilterOperator,
+    textFilterValueByOperator: TEXT_FILTER_VALUE_BY_OPERATOR,
+    textFilterFieldByOperator: TEXT_FILTER_FIELD_BY_OPERATOR,
+  });
 
 describe('Query Mode test-suite', async () => {
   let page;
@@ -76,6 +104,14 @@ describe('Query Mode test-suite', async () => {
   });
 
   describe('no-text-filter confirmation dialog', () => {
+    let textFilterOperators;
+
+    before(async () => {
+      ({
+        TEXT_FILTER_OPERATORS: textFilterOperators,
+      } = await import('../../public/constants/text-filter-operators.const.js'));
+    });
+
     it('should ask for confirmation when no text filters are set and not execute query when user cancels', async () => {
       const result = await runQueryWithMocks(page, { confirmReturn: false });
       assert.strictEqual(result.confirmCalls, 1);
@@ -88,10 +124,12 @@ describe('Query Mode test-suite', async () => {
       assert.strictEqual(result.postCalls, 1);
     });
 
-    it('should not ask for confirmation when at least one text filter is set', async () => {
-      const result = await runQueryWithMocks(page, { confirmReturn: true, setTextFilter: true });
-      assert.strictEqual(result.confirmCalls, 0);
-      assert.strictEqual(result.postCalls, 1);
+    it('should not ask for confirmation for each active text filter operator', async () => {
+      for (const operator of textFilterOperators) {
+        const result = await runQueryWithMocks(page, { confirmReturn: true, textFilterOperator: operator });
+        assert.strictEqual(result.confirmCalls, 0, `expected no confirm dialog for operator "${operator}"`);
+        assert.strictEqual(result.postCalls, 1, `expected query execution for operator "${operator}"`);
+      }
     });
   });
 });

--- a/InfoLogger/test/public/query-mode-mocha.js
+++ b/InfoLogger/test/public/query-mode-mocha.js
@@ -17,6 +17,46 @@
 const assert = require('assert');
 const test = require('../mocha-index');
 
+/**
+ * Runs model.log.query() in the browser context with mocked dependencies.
+ * @param {Page} page - puppeteer page
+ * @param {object} options
+ * @param {boolean} options.confirmReturn - value window.confirm will return
+ * @param {boolean} [options.setTextFilter=false] - if true, sets a message match filter before querying
+ * @returns {Promise<{confirmCalls: number, postCalls: number}>}
+ */
+const runQueryWithMocks = (page, { confirmReturn, setTextFilter = false }) =>
+  // Sets up mocks for confirmation dialog and post request, needs to be run in the browser context
+  page.evaluate(async ({ confirmReturn, setTextFilter }) => {
+    let confirmCalls = 0;
+    let postCalls = 0;
+
+    window.confirm = () => {
+      confirmCalls += 1;
+      return confirmReturn;
+    };
+
+    window.model.loader.post = async () => {
+      postCalls += 1;
+      return { ok: true, result: { rows: [] } };
+    };
+
+    // Mock the frameworkInfo to make the query method think the query service is available in its check
+    window.model.frameworkInfo = {
+      isSuccess: () => true,
+      payload: { mysql: { status: { ok: true } } },
+    };
+
+    // Default state of filters includes no text filters
+    window.model.log.filter.resetCriteria();
+    if (setTextFilter) {
+      window.model.log.filter.setCriteria('message', 'match', 'some-message');
+    }
+    await window.model.log.query();
+
+    return { confirmCalls, postCalls };
+  }, { confirmReturn, setTextFilter });
+
 describe('Query Mode test-suite', async () => {
   let page;
 
@@ -33,5 +73,25 @@ describe('Query Mode test-suite', async () => {
     } catch (e) {
       // code failed, so it is a successful test
     }
+  });
+
+  describe('no-text-filter confirmation dialog', () => {
+    it('should ask for confirmation when no text filters are set and not execute query when user cancels', async () => {
+      const result = await runQueryWithMocks(page, { confirmReturn: false });
+      assert.strictEqual(result.confirmCalls, 1);
+      assert.strictEqual(result.postCalls, 0);
+    });
+
+    it('should execute the query when no text filters are set but user confirms the dialog anyway', async () => {
+      const result = await runQueryWithMocks(page, { confirmReturn: true });
+      assert.strictEqual(result.confirmCalls, 1);
+      assert.strictEqual(result.postCalls, 1);
+    });
+
+    it('should not ask for confirmation when at least one text filter is set', async () => {
+      const result = await runQueryWithMocks(page, { confirmReturn: true, setTextFilter: true });
+      assert.strictEqual(result.confirmCalls, 0);
+      assert.strictEqual(result.postCalls, 1);
+    });
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [X] branch and/or PR name(s) includes JIRA ID
- [X] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [X] PR labels are selected
- [ ] FLP integration tests were ran successful

* Adds a method to the filter model to check if any text filters are active. 
* Query handler calls this method and if false opens a confirmation dialog to the user.
* Does or doesn't execute query based on user's response.

<img width="418" height="186" alt="image" src="https://github.com/user-attachments/assets/e150d2ae-9b4a-41e7-898d-90b45c811e6e" />
