### PR TITLE
[OGUI-1188] Do not send a WS message if client connection is closing 

### DIFF
--- a/Framework/Backend/test/mocha-ws.js
+++ b/Framework/Backend/test/mocha-ws.js
@@ -150,6 +150,34 @@ describe('websocket', () => {
     });
   });
 
+  it('should not throw by broadcast when a client is in CLOSING state', (done) => {
+    const connection = new WebSocketClient(`ws://localhost:${config.http.port}/?token=${token}`);
+    // On connnection, server sends auth message which will trigger the 'message' listener
+    connection.on('message', (message) => {
+      const { command, id } = JSON.parse(message);
+      assert.strictEqual(command, 'authed');
+      // Find the server-side socket - it is still in server.clients
+      const serverSideClient = [...ws.server.clients]
+        .find(({ id: clientId }) => clientId === id);
+
+      /**
+       * Function `terminate()` synchronously sets readyState to CLOSING (2) on the server-side socket
+       * but the client is not yet removed from server.clients (removal is async)
+       * Thus, we can test if broadcast will still send a message causing error on the server-side
+       */
+      serverSideClient.terminate();
+
+      // Broadcast() and unfilteredBroadcast() must not throw even though the socket is CLOSING
+      assert.doesNotThrow(() => {
+        ws.broadcast(new WebSocketMessage(200).setCommand('test'));
+        ws.unfilteredBroadcast(new WebSocketMessage(200).setCommand('test'));
+      });
+
+      connection.terminate();
+      done();
+    });
+  });
+
   after(() => {
     ws.shutdown();
     http.close();

--- a/Framework/Backend/websocket/server.js
+++ b/Framework/Backend/websocket/server.js
@@ -134,7 +134,9 @@ class WebSocket {
   }
 
   /**
-   * Called when a new message arrives
+   * Called when a new message arrives. It is important to check that a client connection is
+   * still OPEN before responding, because the client may be in closing process and still appear in client list
+   * * if the response is sent in the case above, it will cause an error on server side.
    * Handles connection with a client
    * @param {object} message received message
    * @param {object} client TCP socket of the client
@@ -155,17 +157,23 @@ class WebSocket {
               this.broadcast(response);
             } else {
               // 5. Send back to a client
-              client.send(JSON.stringify(response.json));
+              if (client.readyState === client.OPEN) {
+                client.send(JSON.stringify(response.json));
+              }
             }
           }, (response) => {
             // 6. If generating response fails
-            client.send(JSON.stringify(response.json));
-            this.logger.errorMessage(`ID ${client.id} Processing request failed: ${response.message}`);
-            client.close(1008);
+            if (client.readyState === client.OPEN) {
+              client.send(JSON.stringify(response.json));
+              this.logger.errorMessage(`ID ${client.id} Processing request failed: ${response.message}`);
+              client.close(1008);
+            }
           });
       }, (failed) => {
         // 7. If parsing message fails
-        client.send(JSON.stringify(failed.json));
+        if (client.readyState === client.OPEN) {
+          client.send(JSON.stringify(failed.json));
+        }
       })
       .catch((error) => {
         this.logger.warn(`ID ${client.id} ${error.name} : ${error.message}`);
@@ -221,7 +229,9 @@ class WebSocket {
           return; // Don't send
         }
       }
-      client.send(JSON.stringify(message.json));
+      if (client.readyState === client.OPEN) {
+        client.send(JSON.stringify(message.json));
+      }
     });
   }
 
@@ -230,7 +240,11 @@ class WebSocket {
    * @param {WebSocketMessage} message - message to be broadcasted
    */
   unfilteredBroadcast(message) {
-    this.server.clients.forEach((client) => client.send(JSON.stringify(message.json)));
+    this.server.clients.forEach((client) => {
+      if (client.readyState === client.OPEN) {
+        client.send(JSON.stringify(message.json));
+      }
+    });
   }
 }
 

--- a/Framework/Backend/websocket/server.js
+++ b/Framework/Backend/websocket/server.js
@@ -17,6 +17,8 @@ const url = require('url');
 const WebSocketMessage = require('./message.js');
 const { LogManager } = require('../log/LogManager');
 
+const RESERVED_BIND_NAME = 'filter';
+
 /**
  * It represents WebSocket server (RFC 6455).
  * In addition, it provides custom authentication with JWT tokens.
@@ -39,7 +41,7 @@ class WebSocket {
     this.logger.info('Server started');
 
     this.#callbackMap = {};
-    this.bind('filter', (message) => new WebSocketMessage(200).setCommand(message.getCommand()));
+    this.bind(RESERVED_BIND_NAME, (message) => new WebSocketMessage(200).setCommand(message.getCommand()));
     this.ping();
   }
 
@@ -59,7 +61,11 @@ class WebSocket {
    *                              it can send a response back to client by returning WebSocketMessage instance
    */
   bind(name, callback) {
-    if (Object.prototype.hasOwnProperty.call(this.#callbackMap, name)) {
+    if (name === RESERVED_BIND_NAME) {
+      throw Error(`Name "${RESERVED_BIND_NAME}" is reserved for internal use`);
+    } else if (typeof callback !== 'function') {
+      throw Error('Callback must be a function');
+    } else if (Object.prototype.hasOwnProperty.call(this.#callbackMap, name)) {
       throw Error('Callback already exists.');
     }
     this.#callbackMap[name] = callback;

--- a/Framework/Backend/websocket/server.js
+++ b/Framework/Backend/websocket/server.js
@@ -23,6 +23,8 @@ const { LogManager } = require('../log/LogManager');
  * @author Adam Wegrzynek <adam.wegrzynek@cern.ch>
  */
 class WebSocket {
+  #callbackMap;
+
   /**
    * Starts up the server and binds event handler.
    * @param {object} httpsServer - HTTPS server instance
@@ -36,7 +38,7 @@ class WebSocket {
     this.logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'framework'}/ws`);
     this.logger.info('Server started');
 
-    this.callbackArray = [];
+    this.#callbackMap = {};
     this.bind('filter', (message) => new WebSocketMessage(200).setCommand(message.getCommand()));
     this.ping();
   }
@@ -57,10 +59,10 @@ class WebSocket {
    *                              it can send a response back to client by returning WebSocketMessage instance
    */
   bind(name, callback) {
-    if (Object.prototype.hasOwnProperty.call(this.callbackArray, name)) {
+    if (Object.prototype.hasOwnProperty.call(this.#callbackMap, name)) {
       throw Error('Callback already exists.');
     }
-    this.callbackArray[name] = callback;
+    this.#callbackMap[name] = callback;
   }
 
   /**
@@ -83,8 +85,8 @@ class WebSocket {
       // Transfer decoded JWT data to request
       Object.assign(req, data);
       // Check whether callback exists
-      if (Object.prototype.hasOwnProperty.call(this.callbackArray, req.getCommand())) {
-        const res = this.callbackArray[req.getCommand()](req);
+      if (Object.prototype.hasOwnProperty.call(this.#callbackMap, req.getCommand())) {
+        const res = this.#callbackMap[req.getCommand()](req);
         // Verify that response is type of WebSocketMessage
         if (res && res.constructor.name === 'WebSocketMessage') {
           if (typeof res.getCommand() !== 'string') {

--- a/Framework/Backend/websocket/server.js
+++ b/Framework/Backend/websocket/server.js
@@ -40,8 +40,9 @@ class WebSocket {
     this.logger = LogManager.getLogger(`${process.env.npm_config_log_label ?? 'framework'}/ws`);
     this.logger.info('Server started');
 
-    this.#callbackMap = {};
-    this.bind(RESERVED_BIND_NAME, (message) => new WebSocketMessage(200).setCommand(message.getCommand()));
+    this.#callbackMap = {
+      [RESERVED_BIND_NAME]: (message) => new WebSocketMessage(200).setCommand(message.getCommand()),
+    };
     this.ping();
   }
 

--- a/Framework/Backend/websocket/server.js
+++ b/Framework/Backend/websocket/server.js
@@ -53,7 +53,7 @@ class WebSocket {
    * Binds callback to websocket message command
    * Name "filter" is reserved for internal use
    * @param {string} name       - command name
-   * @param {function} callback - function that receives message as WebSocketMessage object;
+   * @param {void} callback - function that receives message as WebSocketMessage object;
    *                              it can send a response back to client by returning WebSocketMessage instance
    */
   bind(name, callback) {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* fixes an issue in which the `broadcast`, `send`, `unfilteredBroadcast` would log an error on WS server due to attempting to send a message to a client that already started the terminate connection stage
* error message: `WebSocket is not open: readyState 2 (CLOSING)`
* the bug was happening because while the closing state is happening, the client still appears in client list. 
* by using the client state which gets updated on immediate call of `terminate`, we can better know which client to still respond to
* rename `callbackArray` and initialize in a Map as per its actual use in the server
* add input validation to bind method to ensure overriding of server bindings is not happening