### PR TITLE
[OGUI-1899] Fix bug where if hosts were selected, user would not be able to save as new configuration

### DIFF
--- a/Control/public/workflow/panels/loadConfiguration/loadConfiguration.js
+++ b/Control/public/workflow/panels/loadConfiguration/loadConfiguration.js
@@ -155,8 +155,8 @@ const btnSaveEnvConfiguration = (model) => {
       class: model.environment.itemNew.isLoading() ? 'loading' : '',
       disabled: model.environment.itemNew.isLoading() || !model.workflow.form.isInputSelected(),
       onclick: () => {
-        let isUserSureOfNoHosts = false;
-        if (!model.workflow.form.hosts || model.workflow.form.hosts.length === 0) {
+        let isUserSureOfNoHosts = true;
+        if (!model.workflow.form?.hosts?.length) {
           isUserSureOfNoHosts = confirm(USER_INFORMATIVE_MESSAGE_ON_NO_HOST);
         }
         if (isUserSureOfNoHosts) {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* fixes a bug in the logic of saving a new configuration via "Save As"
* issue was present due to taking into account scenario of not needing confirmation to save without hosts