### PR TITLE
[OGUI-1900] Use existing middleware to check if existing detectors are still active before req on deployment

### DIFF
--- a/Control/lib/api.js
+++ b/Control/lib/api.js
@@ -26,6 +26,8 @@ const {logDeploymentRequestMiddleware} = require('./middleware/logDeploymentRequ
 const {minimumRoleMiddleware} = require('./middleware/minimumRole.middleware.js');
 const {requireDetectorOrGlobalRoleMiddleware} = require('./middleware/requireDetectorOrGlobalRole.middleware.js');
 const {validateConsulServiceMiddlewareFactory} = require('./middleware/validateConsulServiceMiddlewareFactory.js');
+/* eslint-disable max-len */
+const {verifyDetectorsAvailabilityMiddlewareFactory} = require('./middleware/verifyDetectorsAvailabilityMiddlewareFactory.middleware.js');
 
 const {
   setDetectorsFromEnvironmentMiddlewareFactory
@@ -176,6 +178,7 @@ module.exports.setup = (http, ws) => {
   const setDetectorsFromEnvironmentMiddleware = setDetectorsFromEnvironmentMiddlewareFactory(environmentService);
   const verifyLockOwnershipMiddleware = getDetectorsLockOwnershipMiddlewareFactory(lockService);
   const validateConsulServiceMiddleware = validateConsulServiceMiddlewareFactory(consulService);
+  const verifyDetectorsAvailabilityMiddleware = verifyDetectorsAvailabilityMiddlewareFactory(detectorService);
 
   ctrlProxy.methods.forEach(
     (method) => http.post(`/${method}`, coreMiddleware, (req, res) => ctrlService.executeCommand(req, res)),
@@ -215,6 +218,7 @@ module.exports.setup = (http, ws) => {
     logDeploymentRequestMiddleware,
     minimumRoleMiddleware(Role.DETECTOR),
     verifyLockOwnershipMiddleware,
+    verifyDetectorsAvailabilityMiddleware,
     deploymentController.newAsyncDeploymentHandler.bind(deploymentController)
   );
 

--- a/Control/test/api/deployment/api-post-deployment.test.js
+++ b/Control/test/api/deployment/api-post-deployment.test.js
@@ -13,7 +13,7 @@
 */
 
 const request = require('supertest');
-const { DET_MID_TEST_TOKEN, GUEST_TEST_TOKEN, TEST_URL } = require('../generateToken.js');
+const { DET_MID_TEST_TOKEN, GLOBAL_TEST_TOKEN, GUEST_TEST_TOKEN, TEST_URL } = require('../generateToken.js');
 const { DetectorLockAction } = require('../../../lib/common/lock/detectorLockAction.enum.js');
 
 describe('POST /deploy', function () {
@@ -90,5 +90,30 @@ describe('POST /deploy', function () {
         DCS: { name: 'DCS', state: 'FREE' },
         ODC: { name: 'ODC', state: 'FREE' }
       });
+  });
+
+  it('should reject deployment request due to detectors being currently active in ECS', async function () {
+    // Take the DCS lock with a GLOBAL user to pass the lock ownership middleware
+    await request(`${TEST_URL}/api/locks`)
+      .put(`/${DetectorLockAction.TAKE}/DCS?token=${GLOBAL_TEST_TOKEN}`)
+      .expect(200);
+
+    await request(`${TEST_URL}/api`)
+      .post(`/deploy?token=${GLOBAL_TEST_TOKEN}`)
+      .send({
+        workflowTemplate: 'test-template',
+        detectors: ['DCS'],
+        userVars: { foo: 'bar' }
+      })
+      .expect(503, {
+        message: 'Requested detectors DCS are not available',
+        status: 503,
+        title: 'Service Unavailable'
+      });
+
+    // Release the DCS lock after the test so that tests are not chained
+    await request(`${TEST_URL}/api/locks`)
+      .put(`/${DetectorLockAction.RELEASE}/DCS?token=${GLOBAL_TEST_TOKEN}`)
+      .expect(200);
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* in the `POST` deployment API endpoint makes use of the middleware check to ensure there are no active detectors among the ones the user is requesting to deploy
* adds tests for this scenario in API test suite