### PR TITLE
[OGUI-1298] Add button to cancel ongoing query request

### DIFF
--- a/InfoLogger/public/app.css
+++ b/InfoLogger/public/app.css
@@ -29,6 +29,7 @@
     --row-height: 0.91rem; /* default, overridden by JS zoom */
 }
 .logs-content { border-top: 1px solid #aaa; }
+.bold { font-weight: bold; }
 
 /* logs tables */
 .table-logs-header { width: 100%; border-collapse: collapse; }

--- a/InfoLogger/public/common/jsonFetch.js
+++ b/InfoLogger/public/common/jsonFetch.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { fetchClient } from '/js/src/index.js';
+
+/**
+ * Send a request to an endpoint, and extract the response. If errors occurred, return an error containing a message.
+ *
+ * The endpoint is expected to follow some conventions:
+ * - If request is valid but no data was sent as response, it must return a 204
+ * - If an error occurred on the backend:
+ *   - request can be status ok with {message: string} body describing the error
+ *   - or request can be status error with or without body that contains a message field describing the error
+ * - If request is valid and data is sent as response, it must return a json with the expected data
+ * @param {string} endpoint - the remote endpoint to send request to
+ * @param {RequestInit} options - the request options, see {@link fetch } native function
+ * (method, headers, body, abort.signal, etc.)
+ * @returns {Promise<Resolve<object>.Error<{message: string}>>} resolve with the result or reject with the error message
+ */
+export const jsonFetch = async (endpoint, options) => {
+  try {
+    const response = await fetchClient(endpoint, options);
+    if (response.status === 204) {
+      return null;
+    }
+
+    const responseText = await response.text();
+    const hasBody = responseText.trim().length > 0;
+    const result = hasBody ? JSON.parse(responseText) : null;
+
+    if (response.ok) {
+      return result;
+    }
+
+    const serverMessage = result && typeof result.message === 'string'
+      ? result.message
+      : null;
+
+    throw new Error(serverMessage || `Request failed with status ${response.status}`);
+  } catch (error) {
+    if (error && typeof error.message === 'string') {
+      throw error;
+    }
+    throw new Error('Parsing result from server failed', { cause: error });
+  }
+};

--- a/InfoLogger/public/common/jsonFetch.js
+++ b/InfoLogger/public/common/jsonFetch.js
@@ -34,9 +34,7 @@ export const jsonFetch = async (endpoint, options) => {
       return null;
     }
 
-    const responseText = await response.text();
-    const hasBody = responseText.trim().length > 0;
-    const result = hasBody ? JSON.parse(responseText) : null;
+    const result = await response.json();
 
     if (response.ok) {
       return result;

--- a/InfoLogger/public/common/jsonPost.js
+++ b/InfoLogger/public/common/jsonPost.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { jsonFetch } from './jsonFetch.js';
+
+/**
+ * Build and send a POST request to a remote endpoint, and extract the response.
+ * @param {string} endpoint - the remote endpoint to send request to
+ * @param {RequestInit} options - the request options, see {@link fetch } native function
+ * (method, headers, body, abort.signal, etc.)
+ * @returns {Promise<Resolve<object>.Error<{message: string}>>} resolve with the result or reject with the error
+ */
+export const jsonPost = async (endpoint, options = {}) => {
+  if (options.body && typeof options.body === 'object') {
+    options.body = JSON.stringify(options.body);
+  }
+  try {
+    const result = await jsonFetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      ...options,
+    });
+    return result;
+  } catch (error) {
+    return Promise.reject({ message: error.message || error });
+  }
+};

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -341,6 +341,7 @@ export default class Log extends Observable {
     if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
       throw new Error('Query service is not available');
     }
+
     if (!this.filter.hasActiveTextFilters()) {
       if (!window.confirm('No date or text filters set.'
         + ' This will return a large amount of data. Execute query anyway?')) {

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -17,6 +17,7 @@ import LogFilter from '../logFilter/LogFilter.js';
 import ContextMenu from './ContextMenu.js';
 import { MODE } from '../constants/mode.const.js';
 import { TIME_MS } from '../common/Timezone.js';
+import { jsonPost } from '../common/jsonPost.js';
 
 /**
  * Model Log, encapsulate all log management and queries
@@ -48,6 +49,7 @@ export default class Log extends Observable {
     this.limitReached = null;
 
     this.queryResult = RemoteData.notAsked();
+    this.queryAbortController = null;
 
     this.list = [];
     this.item = null;
@@ -327,16 +329,14 @@ export default class Log extends Observable {
   }
 
   /**
-   * Query database according to filters.
-   * Only is service is available and configured on server side.
-   * If live mode is enabled, it is turned off.
-   * `list` is then reset and filled with result.
+   * Method to execute a query with the current filters configuration
+   * If the user has no filters set, a prompt is shown to confirm the execution
+   * If the user is in live mode, first stop live mode and then execute query in order to have a consistent result
+   * Recalculate the stats and go to last log once query is executed
+   * If the query is aborted by user, restore previous query result and do nothing
+   * @returns {Promise<null|object>} null if query is aborted, result of the query otherwise
    */
   async query() {
-    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
-      throw new Error('Query service is not available');
-    }
-
     if (!this.filter.hasActiveTextFilters()) {
       if (!window.confirm('No date or text filters set.'
         + ' This will return a large amount of data. Execute query anyway?')) {
@@ -344,28 +344,35 @@ export default class Log extends Observable {
       }
     }
 
-    this.queryResult = RemoteData.loading();
-    this.notify();
-
     if (this.isLiveModeRunning()) {
       this.liveStop(MODE.QUERY);
     } else {
       this.activeMode = MODE.QUERY;
     }
 
-    const queryArguments = {
-      criterias: this.filter.criterias,
-      options: { limit: this.limit },
-    };
-    const { result, ok } = await this.model.loader.post('/api/query', queryArguments, true);
-    if (!ok) {
-      this.queryResult = RemoteData.failure(result.message);
-      this.list = [];
-    } else {
+    const previousQueryResult = this.queryResult;
+    this.queryResult = RemoteData.loading();
+    this.notify();
+
+    const abortController = new AbortController();
+    this.queryAbortController = abortController;
+
+    let result = 'Unable to execute query';
+    try {
+      result = await jsonPost('/api/query', {
+        body: {
+          criterias: this.filter.criterias,
+          options: { limit: this.limit },
+        },
+        signal: abortController.signal,
+      });
+      this.resetStats();
       this.queryResult = RemoteData.success(result);
       this.list = result.rows;
-      this.limitReached = result.count === this.limit;
+      this.list.forEach((log) => this.addStats(log));
+      this.goToLastItem();
 
+      this.limitReached = result.count === this.limit;
       if (this.limitReached) {
         this.model.notification.show(
           `Matching results reached the buffer size of ${this.limit.toLocaleString('en-US')}.`
@@ -373,13 +380,35 @@ export default class Log extends Observable {
           'warning',
         );
       }
+    } catch (error) {
+      if (abortController.signal.aborted || error.name === 'AbortError') {
+        this.queryResult = previousQueryResult;
+      } else {
+        result = { message: error.message || result };
+        this.queryResult = RemoteData.failure(result.message);
+        this.list = [];
+        this.resetStats();
+      }
+    } finally {
+      this.queryAbortController = null;
+    }
+    this.notify();
+  }
+
+  /**
+   * Method to allow for cancellation of ongoing HTTP request for query mode if:
+   * - a query is still ongoing
+   * - an abort controller is present.
+   * If the query is successfully aborted, a notification is shown to user.
+   * @returns {void}
+   */
+  cancelQuery() {
+    if (!this.queryResult.isLoading() || !this.queryAbortController) {
+      return;
     }
 
-    this.resetStats();
-    this.list.forEach((log) => this.addStats(log));
-
-    this.goToLastItem();
-    this.notify();
+    this.queryAbortController.abort();
+    this.model.notification.show('Query cancelled', 'warning', 2000);
   }
 
   /**

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -385,7 +385,7 @@ export default class Log extends Observable {
         );
       }
     } catch (error) {
-      if (abortController.signal.aborted || error.name === 'AbortError') {
+      if (abortController.signal.aborted) {
         this.queryResult = previousQueryResult;
       } else {
         result = { message: error.message || result };

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -329,7 +329,8 @@ export default class Log extends Observable {
   }
 
   /**
-   * Method to execute a query with the current filters configuration
+   * Method to execute a query with the current filters configuration via button click or "Enter" keypress on filters.
+   * (thus, check of DB status still needed)
    * If the user has no filters set, a prompt is shown to confirm the execution
    * If the user is in live mode, first stop live mode and then execute query in order to have a consistent result
    * Recalculate the stats and go to last log once query is executed
@@ -337,6 +338,9 @@ export default class Log extends Observable {
    * @returns {Promise<null|object>} null if query is aborted, result of the query otherwise
    */
   async query() {
+    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
+      throw new Error('Query service is not available');
+    }
     if (!this.filter.hasActiveTextFilters()) {
       if (!window.confirm('No date or text filters set.'
         + ' This will return a large amount of data. Execute query anyway?')) {

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -107,6 +107,7 @@ const queryButton = (model, frameworkInfo) => {
 
   if (queryResult.isLoading()) {
     return h('button.btn.bold', {
+      id: 'cancel-query-button',
       title: 'Cancel ongoing query',
       className: BUTTON.DANGER,
       onclick: () => logModel.cancelQuery(),
@@ -114,6 +115,7 @@ const queryButton = (model, frameworkInfo) => {
   }
 
   return h('button.btn.bold', {
+    id: 'query-button',
     title: isDbReady ? 'Query database with filters (Enter)' : 'Query service not configured',
     disabled: !isDbReady || queryResult.isLoading(),
     className: queryResult.isLoading() ? 'loading' : queryButtonType,

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -101,12 +101,20 @@ const interactionModesGroupButton = (model) => {
  * @returns {vnode} - the view of the query button
  */
 const queryButton = (model, frameworkInfo) => {
-  const { log: { queryResult } } = model;
+  const { log: logModel } = model;
+  const { queryResult } = logModel;
   const { mysql: { status: { ok: isDbReady = false } = {} } = {} } = frameworkInfo;
-  const title = isDbReady ? 'Query database with filters (Enter)' : 'Query service not configured';
+
+  if (queryResult.isLoading()) {
+    return h('button.btn.bold', {
+      title: 'Cancel ongoing query',
+      className: BUTTON.DANGER,
+      onclick: () => logModel.cancelQuery(),
+    }, 'Cancel');
+  }
 
   return h('button.btn.bold', {
-    title,
+    title: isDbReady ? 'Query database with filters (Enter)' : 'Query service not configured',
     disabled: !isDbReady || queryResult.isLoading(),
     className: queryResult.isLoading() ? 'loading' : queryButtonType,
     onclick: () => toggleButtonStates(model, false),

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -29,12 +29,14 @@ let queryButtonType = BUTTON.PRIMARY;
 let liveButtonType = BUTTON.DEFAULT;
 let liveButtonIcon = iconMediaPlay();
 
-export default (model) => [
+/**
+ * Component for the command buttons (Query, Live, Clear, navigation between errors and download)
+ * @param {Model} model - root model of the application
+ * @returns {vnode} - the view of the command buttons
+ */
+export const commandLogs = (model) => [
   userActionsDropdown(model),
-  h('div.btn-group.mh3', [
-    queryButton(model),
-    liveButton(model),
-  ], ''),
+  h('div.btn-group.mh3', interactionModesGroupButton(model)),
   h('button.btn.mh3', { onclick: () => model.log.empty(), style: 'font-weight: bold' }, 'Clear'),
   h('button.btn', {
     disabled: !model.log.list.length,
@@ -68,6 +70,74 @@ export default (model) => [
   downloadButtonGroup(model.log),
   zoomButtonGroup(model.zoom),
 ];
+
+/**
+ * Group of buttons for switching between Query and Live modes.
+ * @param {Model} model - root model of the application
+ * @returns {vnode} - the view of the interaction mode buttons
+ */
+const interactionModesGroupButton = (model) => {
+  const { frameworkInfo } = model;
+
+  return frameworkInfo.match({
+    NotAsked: () => h('button.btn', { disabled: true }, ''),
+    Loading: () => h('button.btn', { disabled: true, className: 'loading' }, 'Loading'),
+    Failure: () => [],
+    Success: (frameworkInfo) =>
+      [
+        queryButton(model, frameworkInfo),
+        liveButton(model, frameworkInfo),
+      ],
+  });
+};
+
+/**
+ * Query button final state depends on the following states
+ * - services lookup
+ * - services result
+ * - query lookup
+ * @param {Model} model - root model of the application
+ * @param {RemoteData.payload} frameworkInfo - the payload containing framework information
+ * @returns {vnode} - the view of the query button
+ */
+const queryButton = (model, frameworkInfo) => {
+  const { log: { queryResult } } = model;
+  const { mysql: { status: { ok: isDbReady = false } = {} } = {} } = frameworkInfo;
+  const title = isDbReady ? 'Query database with filters (Enter)' : 'Query service not configured';
+
+  return h('button.btn.bold', {
+    title,
+    disabled: !isDbReady || queryResult.isLoading(),
+    className: queryResult.isLoading() ? 'loading' : queryButtonType,
+    onclick: () => toggleButtonStates(model, false),
+  }, 'Query');
+};
+
+/**
+ * Live button final state depends on the following states
+ * - services lookup
+ * - services result
+ * - websocket status
+ * @param {Model} model - root model of the application
+ * @param {RemoteData.payload} frameworkInfo - the payload containing framework information
+ * @returns {vnode} - the view of the live button
+ */
+const liveButton = (model, frameworkInfo) => {
+  const { log: logModel, ws } = model;
+  const { queryResult } = logModel;
+  const { authed: isWsAuthedAndReady = false } = ws;
+  const { infoLoggerServer: { status: { ok: isLiveServiceReady = false } = {} } = {} } = frameworkInfo;
+
+  const isLiveModeReady = isLiveServiceReady && isWsAuthedAndReady;
+  const title = isLiveModeReady ? 'Stream logs with filtering' : 'Live service not configured';
+
+  return h('button.btn.bold', {
+    title,
+    disabled: !isLiveModeReady || queryResult.isLoading(),
+    className: !isLiveModeReady ? 'loading' : liveButtonType,
+    onclick: () => toggleButtonStates(model, true),
+  }, 'Live', ' ', liveButtonIcon);
+};
 
 /**
  * Button dropdown to show current user and logout link
@@ -104,28 +174,6 @@ const saveUserProfileMenuItem = (model) =>
     onclick: () => model.saveUserProfile(),
     title: 'Save the columns size and visibility as your profile',
   }, 'Save Profile');
-
-/**
- * Query button final state depends on the following states
- * - services lookup
- * - services result
- * - query lookup
- * @param {Model} model - root model of the application
- * @returns {vnode} - the view of the query button
- */
-const queryButton = (model) => h('button.btn', model.frameworkInfo.match({
-  NotAsked: () => ({ disabled: true }),
-  Loading: () => ({ disabled: true, className: 'loading' }),
-  Success: (frameworkInfo) => ({
-    title: frameworkInfo.mysql && frameworkInfo.mysql.status.ok
-      ? 'Query database with filters (Enter)' : 'Query service not configured',
-    disabled: !frameworkInfo.mysql || !frameworkInfo.mysql.status.ok || model.log.queryResult.isLoading(),
-    className: model.log.queryResult.isLoading() ? 'loading' : queryButtonType,
-    style: 'font-weight: bold',
-    onclick: () => toggleButtonStates(model, false),
-  }),
-  Failure: () => ({ disabled: true, className: 'danger' }),
-}), 'Query');
 
 /**
  * Group of buttons which allow the user to engage with the download functionality
@@ -185,28 +233,6 @@ const zoomButtonGroup = (zoom) =>
       title: 'Zoom in (Ctrl/Cmd + +)',
     }, h('span', { style: 'font-size:0.8em' }, iconPlus())),
   ]);
-
-/**
- * Live button final state depends on the following states
- * - services lookup
- * - services result
- * - query lookup
- * - websocket status
- * @param {Model} model - root model of the application
- * @returns {vnode} - the view of the live button
- */
-const liveButton = (model) => h('button.btn', model.frameworkInfo.match({
-  NotAsked: () => ({ disabled: true }),
-  Loading: () => ({ disabled: true, className: 'loading' }),
-  Success: (frameworkInfo) => ({
-    title: frameworkInfo.infoLoggerServer.status.ok ? 'Stream logs with filtering' : 'Live service not configured',
-    disabled: !frameworkInfo.infoLoggerServer.status.ok || model.log.queryResult.isLoading(),
-    className: !model.ws.authed ? 'loading' : liveButtonType,
-    style: 'font-weight: bold',
-    onclick: () => toggleButtonStates(model, true),
-  }),
-  Failure: () => ({ disabled: true, className: 'danger' }),
-}), 'Live', ' ', liveButtonIcon);
 
 /**
  * Method to toggle states of the buttons(Query/Live) depending on the mode the tool is running on

--- a/InfoLogger/public/log/commandLogs.js
+++ b/InfoLogger/public/log/commandLogs.js
@@ -118,7 +118,7 @@ const queryButton = (model, frameworkInfo) => {
     id: 'query-button',
     title: isDbReady ? 'Query database with filters (Enter)' : 'Query service not configured',
     disabled: !isDbReady || queryResult.isLoading(),
-    className: queryResult.isLoading() ? 'loading' : queryButtonType,
+    className: queryButtonType,
     onclick: () => toggleButtonStates(model, false),
   }, 'Query');
 };

--- a/InfoLogger/public/view.js
+++ b/InfoLogger/public/view.js
@@ -16,7 +16,7 @@ import { h, notification } from '/js/src/index.js';
 
 import tableFilters from './logFilter/tableFilters.js';
 import commandFilters from './logFilter/commandFilters.js';
-import commandLogs from './log/commandLogs.js';
+import { commandLogs } from './log/commandLogs.js';
 import statusBar from './log/statusBar.js';
 import inspector from './log/inspector.js';
 import tableLogsHeader from './log/tableLogsHeader.js';

--- a/InfoLogger/test/mocha-index.js
+++ b/InfoLogger/test/mocha-index.js
@@ -68,7 +68,7 @@ describe('InfoLogger', function() {
     subprocess.on('error', (error) => console.error(`Server failed due to: ${error}`))
 
     // Start browser to test UI
-    browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox']});
+    browser = await puppeteer.launch({headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox']});
     page = await browser.newPage();
     await page.setViewport({ width: 1440, height: 900 }); // 15" screen equivalent
 

--- a/InfoLogger/test/public/query-mode-mocha.js
+++ b/InfoLogger/test/public/query-mode-mocha.js
@@ -92,9 +92,7 @@ const runQueryWithMocks = (page, { confirmReturn, textFilterOperator }) =>
       postCalls += 1;
       return { ok: true,
         status: 200,
-        json: async () => {
-          [];
-        } };
+        json: async () => [] };
     };
 
     // Mock the frameworkInfo to make the query method think the query service is available in its check

--- a/InfoLogger/test/public/query-mode-mocha.js
+++ b/InfoLogger/test/public/query-mode-mocha.js
@@ -90,7 +90,11 @@ const runQueryWithMocks = (page, { confirmReturn, textFilterOperator }) =>
 
     window.fetch = async () => {
       postCalls += 1;
-      return { ok: true, status: 200, json: async () => JSON.stringify({ rows: [] }) };
+      return { ok: true,
+        status: 200,
+        json: async () => {
+          [];
+        } };
     };
 
     // Mock the frameworkInfo to make the query method think the query service is available in its check

--- a/InfoLogger/test/public/query-mode-mocha.js
+++ b/InfoLogger/test/public/query-mode-mocha.js
@@ -10,9 +10,7 @@
  * In applying this license CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization
  * or submit itself to any jurisdiction.
-*/
-
-/* eslint-disable max-len */
+ */
 
 const assert = require('assert');
 const test = require('../mocha-index');
@@ -39,6 +37,41 @@ const TEXT_FILTER_FIELD_BY_OPERATOR = {
  * @param {string} [options.textFilterOperator] - operator to set before querying
  * @returns {Promise<{confirmCalls: number, postCalls: number}>}
  */
+/**
+ * Sets up common browser-context state for cancel query tests:
+ * confirms all dialogs, mocks frameworkInfo as healthy, and resets log/filter state.
+ * @param {Page} page - puppeteer page
+ * @returns {Promise<void>}
+ */
+const setupQueryTestState = (page) =>
+  page.evaluate(() => {
+    window.confirm = () => true;
+    window.model.frameworkInfo = {
+      isSuccess: () => true,
+      payload: { mysql: { status: { ok: true } } },
+      match: ({ Success }) => Success({ mysql: { status: { ok: true } } }),
+    };
+    window.model.log.filter.resetCriteria();
+    window.model.log.empty();
+  });
+
+/**
+ * Starts a never-resolving query in the browser context, then immediately cancels it.
+ * Useful as a shared setup step for tests that need to assert state after a cancellation.
+ * @param {Page} page - puppeteer page
+ * @returns {Promise<void>}
+ */
+const startAndCancelQuery = (page) =>
+  page.evaluate(async () => {
+    window.fetch = (_url, { signal } = {}) => new Promise((_, reject) => {
+      signal?.addEventListener('abort', () => reject(new DOMException('AbortError', 'AbortError')));
+    });
+    const queryPromise = window.model.log.query();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    window.model.log.cancelQuery();
+    await queryPromise;
+  });
+
 const runQueryWithMocks = (page, { confirmReturn, textFilterOperator }) =>
   // Sets up mocks for confirmation dialog and post request, needs to be run in the browser context
   page.evaluate(async ({
@@ -55,15 +88,16 @@ const runQueryWithMocks = (page, { confirmReturn, textFilterOperator }) =>
       return confirmReturn;
     };
 
-    window.model.loader.post = async () => {
+    window.fetch = async () => {
       postCalls += 1;
-      return { ok: true, result: { rows: [] } };
+      return { ok: true, status: 200, json: async () => JSON.stringify({ rows: [] }) };
     };
 
     // Mock the frameworkInfo to make the query method think the query service is available in its check
     window.model.frameworkInfo = {
       isSuccess: () => true,
       payload: { mysql: { status: { ok: true } } },
+      match: ({ Success }) => Success({ mysql: { status: { ok: true } } }),
     };
 
     // Default state of filters includes no text filters
@@ -94,9 +128,7 @@ describe('Query Mode test-suite', async () => {
 
   it('should fail because it is not configured', async () => {
     try {
-      await page.evaluate(async () => {
-        return await window.model.log.query();
-      });
+      await page.evaluate(async () => await window.model.log.query());
       assert.fail();
     } catch (e) {
       // code failed, so it is a successful test
@@ -130,6 +162,88 @@ describe('Query Mode test-suite', async () => {
         assert.strictEqual(result.confirmCalls, 0, `expected no confirm dialog for operator "${operator}"`);
         assert.strictEqual(result.postCalls, 1, `expected query execution for operator "${operator}"`);
       }
+    });
+  });
+
+  describe('cancel query - AbortController', () => {
+    beforeEach(async () => {
+      await setupQueryTestState(page);
+    });
+
+    it('should display a Cancel button while a query is in flight and the Query button should be absent', async () => {
+      const result = await page.evaluate(async () => {
+        // Never-resolving fetch to keep query in loading state, respects abort signal to allow clean teardown
+        window.fetch = (_url, { signal } = {}) => new Promise((_, reject) => {
+          signal?.addEventListener('abort', () => reject(new DOMException('AbortError', 'AbortError')));
+        });
+
+        const queryPromise = window.model.log.query();
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const cancelButton = document.querySelector('button#cancel-query-button');
+        const queryButton = document.querySelector('button#query-button');
+
+        // Clean up via cancel so the abort signal rejects the fetch and queryPromise resolves
+        window.model.log.cancelQuery();
+        await queryPromise;
+
+        return {
+          cancelButtonPresent: cancelButton !== null && cancelButton.textContent.includes('Cancel'),
+          queryButtonAbsent: queryButton === null,
+        };
+      });
+
+      assert.ok(result.cancelButtonPresent, 'Cancel button should be visible while query is loading');
+      assert.ok(result.queryButtonAbsent, 'Query button should not be visible while query is loading');
+    });
+
+    it('should not mutate list or stats when a query is cancelled via the AbortController', async () => {
+      await page.evaluate(() => {
+        const existingLogs = [
+          { severity: 'E', message: 'existing error', timestamp: Date.now() },
+          { severity: 'I', message: 'existing info', timestamp: Date.now() },
+        ];
+        existingLogs.forEach((log) => window.model.log.addLog(log));
+      });
+
+      await startAndCancelQuery(page);
+
+      const result = await page.evaluate(() => ({
+        listLength: window.model.log.list.length,
+        stats: window.model.log.stats,
+        abortControllerCleared: window.model.log.queryAbortController === null,
+      }));
+
+      assert.strictEqual(result.listLength, 2, 'list should still contain the pre-existing logs after cancellation');
+      assert.strictEqual(result.stats.error, 1, 'error stat should reflect only the pre-existing error log');
+      assert.strictEqual(result.stats.info, 1, 'info stat should reflect only the pre-existing info log');
+      assert.ok(result.abortControllerCleared, 'queryAbortController should be null after cancellation');
+    });
+
+    it('should allow a new query to start successfully after a previous one was cancelled', async () => {
+      await startAndCancelQuery(page);
+
+      const result = await page.evaluate(async () => {
+        // Second query — resolves successfully with one row
+        const fakeRow = { severity: 'I', message: 'ok', timestamp: Date.now() };
+        window.fetch = async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({ rows: [fakeRow], count: 1 }),
+        });
+        await window.model.log.query();
+
+        return {
+          isLoading: window.model.log.queryResult.isLoading(),
+          isSuccess: window.model.log.queryResult.isSuccess(),
+          listLength: window.model.log.list.length,
+        };
+      });
+      await new Promise((r) => setTimeout(r, 200)); // wait for state to update after query
+      assert.ok(!result.isLoading, 'query should not be stuck in loading state after second query');
+      assert.ok(result.isSuccess, 'second query should succeed');
+      assert.strictEqual(result.listLength, 1, 'list should contain the row from the second query');
     });
   });
 });


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds utility methods for using browser native fetch methods with JSON and POST instead of existing loader method from webui framework (behaviour similar to BKP and other GUIs). This is needed to allow for passing an Abort.Signal 
* Refactors the code for query and live buttons so that they do not duplicate the check for frameworkInfo request state
* Query Button is replaced by Cancel button during an ongoing query, allowing the user to cancel their current query and go back to the logs of the previous query (if any)
* mocha index has been updated so that headless mode does not use the `new` deprecated parameter anymore
* adds tests for aforementioned changes