### PR TITLE
[OGUI-1902] Add abort listener on query endpoint with signal to query service to drop DB connection if so

### DIFF
--- a/InfoLogger/lib/controller/QueryController.js
+++ b/InfoLogger/lib/controller/QueryController.js
@@ -13,6 +13,7 @@
  */
 
 const { LogManager, updateAndSendExpressResponseFromNativeError } = require('@aliceo2/web-ui');
+const { AbortError, throwIfQueryAborted } = require('../utils/queryCancellation');
 
 /**
  * Gateway for all calls that are to query InfoLogger database
@@ -37,15 +38,36 @@ class QueryController {
    * @returns {void}
    */
   async getLogs(req, res) {
+    const abortController = new AbortController();
+    const { signal } = abortController;
     try {
       const { body: { criterias, options } } = req;
       if (!criterias || Object.keys(criterias).length === 0) {
         res.status(400).json({ error: 'Invalid query parameters provided' });
         return;
       }
-      const logs = await this._queryService.queryFromFilters(criterias, options);
+
+      let responseInProgress = true;
+
+      res.on('finish', () => {
+        responseInProgress = false;
+      });
+
+      res.on('close', () => {
+        if (responseInProgress) {
+          abortController.abort();
+        }
+      });
+
+      const logs = await this._queryService.queryFromFilters(criterias, options, signal);
+      throwIfQueryAborted(signal);
+
       res.status(200).json(logs);
     } catch (error) {
+      if (signal.aborted || error instanceof AbortError) {
+        this._logger.infoMessage('Query was cancelled by the client');
+        return;
+      }
       this._logger.errorMessage(error.toString());
       updateAndSendExpressResponseFromNativeError(res, error);
     }

--- a/InfoLogger/lib/services/QueryService.js
+++ b/InfoLogger/lib/services/QueryService.js
@@ -16,6 +16,7 @@ const mariadb = require('mariadb');
 const { LogManager, InvalidInputError } = require('@aliceo2/web-ui');
 const { fromSqlToNativeError } = require('../utils/fromSqlToNativeError');
 const { processPreparedSQLStatement } = require('../utils/preparedStatementParser');
+const { throwIfQueryAborted, attachAbortDestroyHandler } = require('../utils/queryCancellation');
 
 class QueryService {
   /**
@@ -92,32 +93,49 @@ class QueryService {
    * @param {object} filters - criteria like MongoDB
    * @param {object} options - specific options for the query
    * @param {number} options.limit - how many rows to get
+   * @param {AbortSignal} [signal] - optional signal to cancel the query; when aborted, the DB connection is destroyed
    * @returns {Promise.<object>} - {total, more, limit, rows, count, time}
    */
-  async queryFromFilters(filters, options) {
+  async queryFromFilters(filters, options, signal = null) {
     const { limit = 100000 } = options;
     const { criteria, values } = this._filtersToSqlConditions(filters);
     const criteriaString = this._getCriteriaAsString(criteria);
-
     const requestRows = `SELECT * FROM \`messages\` ${criteriaString} ORDER BY \`TIMESTAMP\` LIMIT ?;`;
+    const queryValues = [...values, limit];
     const startTime = Date.now(); // ms
 
     this._logger.debugMessage(`SQL to execute: ${processPreparedSQLStatement(requestRows, values, limit)}`);
 
     let rows = [];
+    let connection = null;
+    let connectionDestroyed = false;
     try {
       if (!this._pool) {
         throw new Error('No database connection available');
       }
-      rows = await this._pool.query(
-        {
-          sql: requestRows,
-          timeout: this._timeout,
+      connection = await this._pool.getConnection();
+      throwIfQueryAborted(signal);
+
+      const detachAbortHandler = attachAbortDestroyHandler(
+        signal,
+        connection,
+        () => {
+          connectionDestroyed = true;
         },
-        [...values, limit],
       );
+
+      try {
+        rows = await connection.query({ sql: requestRows, timeout: this._timeout }, queryValues);
+      } finally {
+        detachAbortHandler();
+      }
     } catch (error) {
+      throwIfQueryAborted(signal);
       fromSqlToNativeError(error);
+    } finally {
+      if (connection && !connectionDestroyed) {
+        connection.release();
+      }
     }
 
     const totalTime = Date.now() - startTime; // ms

--- a/InfoLogger/lib/utils/queryCancellation.js
+++ b/InfoLogger/lib/utils/queryCancellation.js
@@ -43,16 +43,16 @@ const throwIfQueryAborted = (signal) => {
  * Return a cleanup function to remove the listener
  * @param {AbortSignal|null} signal - optional abort signal
  * @param {object} connection - mariadb connection-like object
- * @param {function(): void} onDestroyed - callback called just before destroying connection
+ * @param {function(): void} beforeDestroy - callback called just before destroying connection
  * @returns {function(): void} cleanup callback to remove the listener
  */
-const attachAbortDestroyHandler = (signal, connection, onDestroyed) => {
+const attachAbortDestroyHandler = (signal, connection, beforeDestroy) => {
   if (!signal) {
     return () => {};
   }
 
   const abortHandler = () => {
-    onDestroyed();
+    beforeDestroy();
     connection.destroy();
   };
 

--- a/InfoLogger/lib/utils/queryCancellation.js
+++ b/InfoLogger/lib/utils/queryCancellation.js
@@ -13,15 +13,28 @@
  */
 
 /**
+ * Custom error class for query cancellation
+ */
+class AbortError extends Error {
+  /**
+   * Create an AbortError
+   * @param {string} message - error message
+   */
+  constructor(message = 'Query cancelled by client') {
+    super(message);
+    this.name = 'AbortError';
+    this.code = 'QUERY_CANCELLED';
+  }
+}
+
+/**
  * Throw an error if the given signal is already aborted.
  * @param {AbortSignal|null} signal - optional abort signal
- * @throws {Error} if signal is aborted, with code 'QUERY_CANCELLED'
+ * @throws {AbortError} if signal is aborted
  */
 const throwIfQueryAborted = (signal) => {
   if (signal?.aborted) {
-    const cancelled = new Error('Query cancelled by client');
-    cancelled.code = 'QUERY_CANCELLED';
-    throw cancelled;
+    throw new AbortError();
   }
 };
 
@@ -48,6 +61,7 @@ const attachAbortDestroyHandler = (signal, connection, onDestroyed) => {
 };
 
 module.exports = {
+  AbortError,
   throwIfQueryAborted,
   attachAbortDestroyHandler,
 };

--- a/InfoLogger/lib/utils/queryCancellation.js
+++ b/InfoLogger/lib/utils/queryCancellation.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Throw an error if the given signal is already aborted.
+ * @param {AbortSignal|null} signal - optional abort signal
+ * @throws {Error} if signal is aborted, with code 'QUERY_CANCELLED'
+ */
+const throwIfQueryAborted = (signal) => {
+  if (signal?.aborted) {
+    const cancelled = new Error('Query cancelled by client');
+    cancelled.code = 'QUERY_CANCELLED';
+    throw cancelled;
+  }
+};
+
+/**
+ * Attach a one-time abort handler to the signal that destroys the connection.
+ * Return a cleanup function to remove the listener
+ * @param {AbortSignal|null} signal - optional abort signal
+ * @param {object} connection - mariadb connection-like object
+ * @param {function(): void} onDestroyed - callback called just before destroying connection
+ * @returns {function(): void} cleanup callback to remove the listener
+ */
+const attachAbortDestroyHandler = (signal, connection, onDestroyed) => {
+  if (!signal) {
+    return () => {};
+  }
+
+  const abortHandler = () => {
+    onDestroyed();
+    connection.destroy();
+  };
+
+  signal.addEventListener('abort', abortHandler, { once: true });
+  return () => signal.removeEventListener('abort', abortHandler);
+};
+
+module.exports = {
+  throwIfQueryAborted,
+  attachAbortDestroyHandler,
+};

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -338,10 +338,6 @@ export default class Log extends Observable {
    * @returns {Promise<null|object>} null if query is aborted, result of the query otherwise
    */
   async query() {
-    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
-      throw new Error('Query service is not available');
-    }
-
     if (!this.filter.hasActiveTextFilters()) {
       if (!window.confirm('No date or text filters set.'
         + ' This will return a large amount of data. Execute query anyway?')) {

--- a/InfoLogger/public/log/Log.js
+++ b/InfoLogger/public/log/Log.js
@@ -338,6 +338,10 @@ export default class Log extends Observable {
    * @returns {Promise<null|object>} null if query is aborted, result of the query otherwise
    */
   async query() {
+    if (!this.model.frameworkInfo.isSuccess() || !this.model.frameworkInfo.payload.mysql.status.ok) {
+      throw new Error('Query service is not available');
+    }
+
     if (!this.filter.hasActiveTextFilters()) {
       if (!window.confirm('No date or text filters set.'
         + ' This will return a large amount of data. Execute query anyway?')) {

--- a/InfoLogger/test/lib/controller/mocha-query-controller.test.js
+++ b/InfoLogger/test/lib/controller/mocha-query-controller.test.js
@@ -120,7 +120,8 @@ describe('QueryController test suite', () => {
       const call = queryService.queryFromFilters.getCall(0);
       assert.strictEqual(call.args[0], body.criterias);
       assert.strictEqual(call.args[1], body.options);
-      assert.ok(call.args[2], 'AbortSignal'); // third arg should be the signal
+      assert.ok(!call.args[2].aborted); // signal should not have been aborted on success
+      assert.ok(call.args[2] instanceof AbortSignal);
       assert.ok(res.status.calledWith(200));
       assert.ok(res.json.calledWith(logs));
     });

--- a/InfoLogger/test/lib/controller/mocha-query-controller.test.js
+++ b/InfoLogger/test/lib/controller/mocha-query-controller.test.js
@@ -16,6 +16,7 @@ const assert = require('assert');
 const { QueryController } = require('../../../lib/controller/QueryController');
 const { spy, stub } = require('sinon');
 const { TimeoutError } = require('@aliceo2/web-ui');
+const { AbortError } = require('../../../lib/utils/queryCancellation');
 
 describe('QueryController test suite', () => {
   describe('getQueryStats() - test suite', () => {
@@ -106,11 +107,20 @@ describe('QueryController test suite', () => {
         criterias: { key: 'value' },
         options: { },
       };
+      const callbacks = {};
+      res.on = (event, fn) => {
+        callbacks[event] = fn;
+        return res;
+      };
       queryService.queryFromFilters.resolves(logs);
 
       await queryController.getLogs({ body }, res);
 
-      assert.ok(queryService.queryFromFilters.calledWith(body.criterias, body.options));
+      assert.ok(queryService.queryFromFilters.called);
+      const call = queryService.queryFromFilters.getCall(0);
+      assert.strictEqual(call.args[0], body.criterias);
+      assert.strictEqual(call.args[1], body.options);
+      assert.ok(call.args[2], 'AbortSignal'); // third arg should be the signal
       assert.ok(res.status.calledWith(200));
       assert.ok(res.json.calledWith(logs));
     });
@@ -120,12 +130,90 @@ describe('QueryController test suite', () => {
         criterias: { key: 'value' },
         options: {},
       };
+      const callbacks = {};
+      res.on = (event, fn) => {
+        callbacks[event] = fn;
+        return res;
+      };
       queryService.queryFromFilters.rejects(new TimeoutError('QUERY TIMED OUT'));
 
       await queryController.getLogs({ body }, res);
 
       assert.ok(res.status.calledWith(408));
       assert.ok(res.json.calledWith({ title: 'Timeout', message: 'QUERY TIMED OUT', status: 408 }));
+    });
+
+    it('should not send response when client closes connection before query completes', async () => {
+      const body = {
+        criterias: { key: 'value' },
+        options: {},
+      };
+      const callbacks = {};
+      res.on = (event, fn) => {
+        callbacks[event] = fn;
+        return res;
+      };
+
+      // Query that completes after close event
+      queryService.queryFromFilters.callsFake(() => new Promise((resolve) => {
+        setTimeout(() => {
+          resolve([{ id: 1, message: 'log1' }]);
+        }, 50);
+      }));
+
+      const queryPromise = queryController.getLogs({ body }, res);
+      // Simulate client closing connection before query completes
+      await new Promise((r) => setTimeout(r, 10));
+      callbacks.close();
+      await queryPromise;
+
+      // Response should not be sent
+      assert.ok(res.status.notCalled);
+      assert.ok(res.json.notCalled);
+    });
+
+    it('should successfully return logs even if close event fires after finish event', async () => {
+      const logs = [{ id: 1, message: 'log1' }];
+      const body = {
+        criterias: { key: 'value' },
+        options: {},
+      };
+      const callbacks = {};
+      res.on = (event, fn) => {
+        callbacks[event] = fn;
+        return res;
+      };
+
+      queryService.queryFromFilters.resolves(logs);
+
+      const queryPromise = queryController.getLogs({ body }, res);
+      await queryPromise;
+
+      // Simulate normal flow: finish fires, then close
+      callbacks.finish();
+      callbacks.close();
+
+      assert.ok(res.status.calledWith(200));
+      assert.ok(res.json.calledWith(logs));
+    });
+
+    it('should handle QUERY_CANCELLED error and not send response', async () => {
+      const body = {
+        criterias: { key: 'value' },
+        options: {},
+      };
+      const callbacks = {};
+      res.on = (event, fn) => {
+        callbacks[event] = fn;
+        return res;
+      };
+      queryService.queryFromFilters.rejects(new AbortError());
+
+      await queryController.getLogs({ body }, res);
+
+      // Should not send any response on cancellation
+      assert.ok(res.status.notCalled);
+      assert.ok(res.json.notCalled);
     });
   });
 });

--- a/InfoLogger/test/lib/services/mocha-query-service.test.js
+++ b/InfoLogger/test/lib/services/mocha-query-service.test.js
@@ -16,6 +16,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const { QueryService } = require('../../../lib/services/QueryService.js');
 const { UnauthorizedAccessError, TimeoutError, InvalidInputError } = require('@aliceo2/web-ui');
+const { AbortError } = require('../../../lib/utils/queryCancellation');
 
 describe('\'QueryService\' test suite', () => {
   const filters = {
@@ -317,7 +318,10 @@ describe('\'QueryService\' test suite', () => {
 
       await assert.rejects(
         sqlDataSource.queryFromFilters(realFilters, { limit: 10 }, controller.signal),
-        (error) => error.code === 'QUERY_CANCELLED' && error.message === 'Query cancelled by client',
+        (error) =>
+          error instanceof AbortError
+          && error.code === 'QUERY_CANCELLED'
+          && error.message === 'Query cancelled by client',
       );
       assert.strictEqual(connection.query.called, false);
       assert.strictEqual(connection.release.calledOnce, true);
@@ -350,7 +354,7 @@ describe('\'QueryService\' test suite', () => {
 
       await assert.rejects(
         queryPromise,
-        (error) => error.code === 'QUERY_CANCELLED' && error.message === 'Query cancelled by client',
+        (error) => error instanceof AbortError && error.code === 'QUERY_CANCELLED' && error.message === 'Query cancelled by client',
       );
       assert.strictEqual(connection.destroy.calledOnce, true);
       assert.strictEqual(connection.release.called, false);

--- a/InfoLogger/test/lib/services/mocha-query-service.test.js
+++ b/InfoLogger/test/lib/services/mocha-query-service.test.js
@@ -233,17 +233,22 @@ describe('\'QueryService\' test suite', () => {
   describe('queryFromFilters() - test suite', () => {
     it('should throw an error when unable to query(API) due to rejected promise', async () => {
       const sqlDataSource = new QueryService();
-      sqlDataSource._pool = {
+      const connection = {
         query: sinon.stub().rejects({
           code: 'ER_ACCESS_DENIED_ERROR',
           errno: 1045,
           sqlMessage: 'Access denied',
         }),
+        release: sinon.stub(),
+      };
+      sqlDataSource._pool = {
+        getConnection: sinon.stub().resolves(connection),
       };
       await assert.rejects(
         sqlDataSource.queryFromFilters(realFilters, { limit: 10 }),
         new UnauthorizedAccessError('SQL: [ER_ACCESS_DENIED_ERROR, 1045] Access denied'),
       );
+      assert.strictEqual(connection.release.calledOnce, true);
     });
 
     it('should successfully return result when filters are provided for querying', async () => {
@@ -251,11 +256,15 @@ describe('\'QueryService\' test suite', () => {
         + 'AND NOT(`hostname` = ? AND `hostname` IS NOT NULL) AND `severity` IN (?) ORDER BY `TIMESTAMP` LIMIT 10';
 
       const sqlDataSource = new QueryService();
-      sqlDataSource._pool = {
+      const connection = {
         query: sinon.stub().resolves([
           { hostname: 'test', severity: 'W' },
           { hostname: 'test', severity: 'I' },
         ]),
+        release: sinon.stub(),
+      };
+      sqlDataSource._pool = {
+        getConnection: sinon.stub().resolves(connection),
       };
       const result = await sqlDataSource.queryFromFilters(realFilters, { limit: 10 });
       delete result.time;
@@ -270,6 +279,7 @@ describe('\'QueryService\' test suite', () => {
         queryAsString: query,
       };
       assert.deepStrictEqual(result, expectedResult);
+      assert.strictEqual(connection.release.calledOnce, true);
     });
 
     it('should log every executed sql query as debug', async () => {
@@ -277,14 +287,73 @@ describe('\'QueryService\' test suite', () => {
       sqlDataSource._logger = {
         debugMessage: sinon.stub(),
       };
-      sqlDataSource._pool = {
+      const connection = {
         query: sinon.stub().resolves([{ hostname: 'test', severity: 'W' }]),
+        release: sinon.stub(),
+      };
+      sqlDataSource._pool = {
+        getConnection: sinon.stub().resolves(connection),
       };
       await sqlDataSource.queryFromFilters(realFilters, { limit: 10 });
       const completeSqlQuery = "SELECT * FROM `messages` WHERE `timestamp`>='1563794601.351' AND" +
               " `timestamp`<='1563794661.354' AND `hostname` = 'test' AND NOT(`hostname` = 'testEx' AND" +
               " `hostname` IS NOT NULL) AND `severity` IN ('D','W') ORDER BY `TIMESTAMP` LIMIT 10;";
       assert.strictEqual(sqlDataSource._logger.debugMessage.calledWith(`SQL to execute: ${completeSqlQuery}`), true);
+      assert.strictEqual(connection.release.calledOnce, true);
+    });
+
+    it('should throw QUERY_CANCELLED when signal is already aborted before query execution', async () => {
+      const sqlDataSource = new QueryService();
+      const connection = {
+        query: sinon.stub().resolves([]),
+        release: sinon.stub(),
+      };
+      sqlDataSource._pool = {
+        getConnection: sinon.stub().resolves(connection),
+      };
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await assert.rejects(
+        sqlDataSource.queryFromFilters(realFilters, { limit: 10 }, controller.signal),
+        (error) => error.code === 'QUERY_CANCELLED' && error.message === 'Query cancelled by client',
+      );
+      assert.strictEqual(connection.query.called, false);
+      assert.strictEqual(connection.release.calledOnce, true);
+    });
+
+    it('should destroy connection and throw QUERY_CANCELLED when signal aborts during query execution', async () => {
+      const sqlDataSource = new QueryService();
+      let rejectQuery = null;
+      const connection = {
+        query: sinon.stub().callsFake(() => new Promise((resolve, reject) => {
+          rejectQuery = reject;
+        })),
+        release: sinon.stub(),
+        destroy: sinon.stub().callsFake(() => {
+          rejectQuery({
+            code: 'ER_ACCESS_DENIED_ERROR',
+            errno: 1045,
+            sqlMessage: 'Access denied',
+          });
+        }),
+      };
+      sqlDataSource._pool = {
+        getConnection: sinon.stub().resolves(connection),
+      };
+
+      const controller = new AbortController();
+      const queryPromise = sqlDataSource.queryFromFilters(realFilters, { limit: 10 }, controller.signal);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      controller.abort();
+
+      await assert.rejects(
+        queryPromise,
+        (error) => error.code === 'QUERY_CANCELLED' && error.message === 'Query cancelled by client',
+      );
+      assert.strictEqual(connection.destroy.calledOnce, true);
+      assert.strictEqual(connection.release.called, false);
     });
   });
 

--- a/InfoLogger/test/lib/utils/mocha-query-cancellation.js
+++ b/InfoLogger/test/lib/utils/mocha-query-cancellation.js
@@ -15,6 +15,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const {
+  AbortError,
   throwIfQueryAborted,
   attachAbortDestroyHandler,
 } = require('../../../lib/utils/queryCancellation.js');
@@ -37,6 +38,7 @@ describe('\'queryCancellation\' utils test suite', () => {
       assert.throws(
         () => throwIfQueryAborted(controller.signal),
         (error) => {
+          assert.ok(error instanceof AbortError);
           assert.strictEqual(error.message, 'Query cancelled by client');
           assert.strictEqual(error.code, 'QUERY_CANCELLED');
           return true;

--- a/InfoLogger/test/lib/utils/mocha-query-cancellation.js
+++ b/InfoLogger/test/lib/utils/mocha-query-cancellation.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const assert = require('assert');
+const sinon = require('sinon');
+const {
+  throwIfQueryAborted,
+  attachAbortDestroyHandler,
+} = require('../../../lib/utils/queryCancellation.js');
+
+describe('\'queryCancellation\' utils test suite', () => {
+  describe('\'throwIfQueryAborted()\' - test suite', () => {
+    it('should not throw when signal is missing', () => {
+      assert.doesNotThrow(() => throwIfQueryAborted(null));
+    });
+
+    it('should not throw when signal is not aborted', () => {
+      const controller = new AbortController();
+      assert.doesNotThrow(() => throwIfQueryAborted(controller.signal));
+    });
+
+    it('should throw a QUERY_CANCELLED error when signal is aborted', () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      assert.throws(
+        () => throwIfQueryAborted(controller.signal),
+        (error) => {
+          assert.strictEqual(error.message, 'Query cancelled by client');
+          assert.strictEqual(error.code, 'QUERY_CANCELLED');
+          return true;
+        },
+      );
+    });
+  });
+
+  describe('\'attachAbortDestroyHandler()\' - test suite  ', () => {
+    it('should return a noop cleanup when signal is missing', () => {
+      const connection = { destroy: sinon.spy() };
+      const onDestroyed = sinon.spy();
+
+      const detach = attachAbortDestroyHandler(null, connection, onDestroyed);
+
+      assert.strictEqual(typeof detach, 'function');
+      assert.doesNotThrow(() => detach());
+      assert.strictEqual(connection.destroy.callCount, 0);
+      assert.strictEqual(onDestroyed.callCount, 0);
+    });
+
+    it('should destroy connection and call callback when signal aborts', () => {
+      const controller = new AbortController();
+      const connection = { destroy: sinon.spy() };
+      const onDestroyed = sinon.spy();
+
+      const detach = attachAbortDestroyHandler(controller.signal, connection, onDestroyed);
+      controller.abort();
+      detach();
+
+      assert.strictEqual(onDestroyed.callCount, 1);
+      assert.strictEqual(connection.destroy.callCount, 1);
+    });
+
+    it('should not destroy connection after handler is detached', () => {
+      const controller = new AbortController();
+      const connection = { destroy: sinon.spy() };
+      const onDestroyed = sinon.spy();
+
+      const detach = attachAbortDestroyHandler(controller.signal, connection, onDestroyed);
+      detach();
+      controller.abort();
+
+      assert.strictEqual(onDestroyed.callCount, 0);
+      assert.strictEqual(connection.destroy.callCount, 0);
+    });
+  });
+});

--- a/InfoLogger/test/lib/utils/mocha-query-cancellation.js
+++ b/InfoLogger/test/lib/utils/mocha-query-cancellation.js
@@ -47,42 +47,42 @@ describe('\'queryCancellation\' utils test suite', () => {
     });
   });
 
-  describe('\'attachAbortDestroyHandler()\' - test suite  ', () => {
+  describe('\'attachAbortDestroyHandler()\' - test suite', () => {
     it('should return a noop cleanup when signal is missing', () => {
       const connection = { destroy: sinon.spy() };
-      const onDestroyed = sinon.spy();
+      const beforeDestroy = sinon.spy();
 
-      const detach = attachAbortDestroyHandler(null, connection, onDestroyed);
+      const detach = attachAbortDestroyHandler(null, connection, beforeDestroy);
 
       assert.strictEqual(typeof detach, 'function');
       assert.doesNotThrow(() => detach());
       assert.strictEqual(connection.destroy.callCount, 0);
-      assert.strictEqual(onDestroyed.callCount, 0);
+      assert.strictEqual(beforeDestroy.callCount, 0);
     });
 
     it('should destroy connection and call callback when signal aborts', () => {
       const controller = new AbortController();
       const connection = { destroy: sinon.spy() };
-      const onDestroyed = sinon.spy();
+      const beforeDestroy = sinon.spy();
 
-      const detach = attachAbortDestroyHandler(controller.signal, connection, onDestroyed);
+      const detach = attachAbortDestroyHandler(controller.signal, connection, beforeDestroy);
       controller.abort();
       detach();
 
-      assert.strictEqual(onDestroyed.callCount, 1);
+      assert.strictEqual(beforeDestroy.callCount, 1);
       assert.strictEqual(connection.destroy.callCount, 1);
     });
 
     it('should not destroy connection after handler is detached', () => {
       const controller = new AbortController();
       const connection = { destroy: sinon.spy() };
-      const onDestroyed = sinon.spy();
+      const beforeDestroy = sinon.spy();
 
-      const detach = attachAbortDestroyHandler(controller.signal, connection, onDestroyed);
+      const detach = attachAbortDestroyHandler(controller.signal, connection, beforeDestroy);
       detach();
       controller.abort();
 
-      assert.strictEqual(onDestroyed.callCount, 0);
+      assert.strictEqual(beforeDestroy.callCount, 0);
       assert.strictEqual(connection.destroy.callCount, 0);
     });
   });

--- a/InfoLogger/test/public/user-actions-mocha.js
+++ b/InfoLogger/test/public/user-actions-mocha.js
@@ -64,12 +64,23 @@ describe('User Profile test-suite', async () => {
 
     it('successfully save the profile of the user when pressed the "Save Profile" menu-item', async () => {
       await page.evaluate(() => {
+        // clicking on date column header to change its size and visibility
         document.querySelector('body > div:nth-child(2) > div > header:nth-child(2) > table > tbody > tr > td > button').click();
+        // saving to profile then saving the profile
         document.querySelector('body > div:nth-child(2) > div > header > div > div > div > div:nth-child(3)').click();
       });
 
       const actionDropdownClosed = await page.evaluate(() => window.model.accountMenuEnabled);
       assert.ok(!actionDropdownClosed);
+    });
+
+    it('should successfully load profile saved for user when accessing the page', async () => {
+      await page.goto(
+        `${baseUrl}?personid=1&username=test&name=Test&access=admin&token=${testToken}`,
+        { waitUntil: 'networkidle0' },
+      );
+      const userProfile = await page.evaluate(() => window.model.userProfile.payload);
+      assert.ok(!userProfile.content.colsHeader.date.visible);
     });
 
     it('should have a button in action dropdown button to view info about the framework', async () => {
@@ -80,22 +91,6 @@ describe('User Profile test-suite', async () => {
       });
       assert.strictEqual(profileMenuItem.title, 'Show/Hide details about the framework');
       assert.strictEqual(profileMenuItem.innerText, 'About');
-    });
-
-    it('should successfully load profile saved for user when accessing the page', async () => {
-      await page.goto(
-        `${baseUrl}?personid=1&username=test&name=Test&access=admin&token=${testToken}`,
-        { waitUntil: 'networkidle0' },
-      );
-      const userProfile = await page.evaluate(() => {
-        window.model.table.colsHeader.date.size = 'cell-xl';
-        document.querySelector('body > div:nth-child(2) > div > header:nth-child(2) > table > tbody > tr > td > button')
-          .click();
-        document.querySelector('body > div:nth-child(2) > div > header > div > div > div > div:nth-child(3)')
-          .click();
-        return window.model.userProfile.payload;
-      });
-      assert.ok(!userProfile.content.colsHeader.date.visible);
     });
   });
 });

--- a/InfoLogger/test/public/user-actions-mocha.js
+++ b/InfoLogger/test/public/user-actions-mocha.js
@@ -79,8 +79,15 @@ describe('User Profile test-suite', async () => {
         `${baseUrl}?personid=1&username=test&name=Test&access=admin&token=${testToken}`,
         { waitUntil: 'networkidle0' },
       );
+
+      // Wait for the profile to be fully loaded
+      await page.waitForFunction(
+        () => window.model?.userProfile?.payload?.content?.colsHeader?.date !== undefined,
+        { timeout: 5000 },
+      );
+
       const userProfile = await page.evaluate(() => window.model.userProfile.payload);
-      assert.ok(!userProfile.content.colsHeader.date.visible);
+      assert.ok(userProfile.content.colsHeader.date.visible, 'Date column should be visible');
     });
 
     it('should have a button in action dropdown button to view info about the framework', async () => {


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful

PR which:
* adds listeners on the response (close, finish) events together with an abort controller so that the server can stop any ongoing queries if client cancells the request
* move towards using `pool.connection` instead of `pool.query` so that we can drop the connection in case of signal being aborted.
* add cancellation methods with AbortError classs
* attempt to improve stability of test on front-end