### PR TITLE
[OGUI-1193] Shuffle fakeData.json to remove groupings of similar logs

### DIFF
--- a/InfoLogger/test/live-simulator/infoLoggerServer.js
+++ b/InfoLogger/test/live-simulator/infoLoggerServer.js
@@ -19,7 +19,10 @@
 // https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener
 
 const net = require('net');
-const fakeData = require('./fakeData.json');
+const rawFakeData = require('./fakeData.json');
+const { shuffle } = require('./utils.js');
+
+const fakeData = shuffle([...rawFakeData]);
 
 const createServer = () => {
   const server = net.createServer(connectionListener);

--- a/InfoLogger/test/live-simulator/infoLoggerServer.js
+++ b/InfoLogger/test/live-simulator/infoLoggerServer.js
@@ -10,10 +10,9 @@
  * In applying this license CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization
  * or submit itself to any jurisdiction.
-*/
+ */
 
 /* eslint-disable no-console */
-/* eslint-disable require-jsdoc */
 
 // Documentation:
 // https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener
@@ -28,9 +27,13 @@ const createServer = () => {
   const server = net.createServer(connectionListener);
   const port = 6102; // infoLoggerServer default port
 
+  /**
+   * Listener for new client connections. It sends fake log messages to the client at random intervals.
+   * @param {net.Socket} client - The connected client socket
+   */
   function connectionListener(client) {
     console.log('[InfoLogger Server] Client connected at:', new Date().toISOString());
-    let timer;
+    let timer = null;
     let currentLogIndex = 0;
 
     client.on('close', onClientDisconnect);
@@ -45,14 +48,17 @@ const createServer = () => {
     });
     sendNextLog();
 
+    /**
+     * Sends the next log message to the connected client.
+     */
     function sendNextLog() {
       const log = fakeData[currentLogIndex % fakeData.length];
-      const timestamp = (new Date()).getTime() / 1000; // seconds
-      const nextLogTimeout = 100 - (Math.random() * 100); // [0 ; 500]ms
+      const timestamp = new Date().getTime() / 1000; // seconds
+      const nextLogTimeout = 100 - Math.random() * 100; // [0 ; 500]ms
 
       // switch protocol after each log sent to try both protocols
       if (currentLogIndex % 2 === 1) {
-        client.write(`*1.4#` +
+        client.write('*1.4#' +
           `${log.severity || ''}#` +
           `${log.level || ''}#` +
           `${timestamp || ''}#` +
@@ -70,7 +76,7 @@ const createServer = () => {
           `${log.errsource || ''}#` +
           `${log.message || ''}\r\n`);
       } else {
-        client.write(`*1.3#` +
+        client.write('*1.3#' +
           `${log.severity || ''}#` +
           `${log.level || ''}#` +
           `${timestamp || ''}#` +
@@ -82,7 +88,7 @@ const createServer = () => {
           `${log.facility || ''}#` +
           `${log.detector || ''}#` +
           `${log.partition || ''}#` +
-          `#` + // dest field
+          '#' + // dest field
           `${log.run || ''}#` +
           `${log.errcode || ''}#` +
           `${log.errline || ''}#` +
@@ -94,6 +100,9 @@ const createServer = () => {
       timer = setTimeout(sendNextLog, nextLogTimeout);
     }
 
+    /**
+     * Handler for client disconnection. It clears the log sending timer and logs the disconnection event.
+     */
     function onClientDisconnect() {
       console.log('[InfoLogger Server] Client disconnected at:', new Date().toISOString());
       clearTimeout(timer);
@@ -117,8 +126,8 @@ const createServer = () => {
   server.listen(port, () => {
     console.log(`[InfoLogger Server] InfoLoggerServer is running on port ${port}`);
   });
-  return server
-}
+  return server;
+};
 
 const closeServer = (server) => {
   console.log('[InfoLogger Server] Closing server at:', new Date().toISOString());
@@ -136,6 +145,6 @@ const closeServer = (server) => {
     console.error('[InfoLogger Server] Exception while closing server:', err.message);
     console.error('[InfoLogger Server] Stack:', err.stack);
   }
-}
+};
 
-module.exports = {createServer, closeServer};
+module.exports = { createServer, closeServer };

--- a/InfoLogger/test/live-simulator/utils.js
+++ b/InfoLogger/test/live-simulator/utils.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * Shuffle an array in place using the Fisher-Yates algorithm.
+ * @param {Array} array - the array to shuffle
+ * @returns {Array} the shuffled array
+ */
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+module.exports = { shuffle };

--- a/InfoLogger/test/public/live-mode-mocha.js
+++ b/InfoLogger/test/public/live-mode-mocha.js
@@ -127,7 +127,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'match');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 5000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allEmpty = list.every((log) => isFieldEmpty(log.rolename));
@@ -143,7 +143,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'exclude');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 5000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allNonEmpty = list.every((log) => !isFieldEmpty(log.rolename));
@@ -160,7 +160,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'match');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 5000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allValid = list.every((log) => isFieldEmpty(log.rolename) || log.rolename === 'mon-DA-PHS-0');
@@ -177,7 +177,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'exclude');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 5000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allValid = list.every((log) => !isFieldEmpty(log.rolename) && log.rolename !== 'mon-DA-PHS-0');

--- a/InfoLogger/test/public/live-mode-mocha.js
+++ b/InfoLogger/test/public/live-mode-mocha.js
@@ -127,7 +127,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'match');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 10000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allEmpty = list.every((log) => isFieldEmpty(log.rolename));
@@ -143,7 +143,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'exclude');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 10000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allNonEmpty = list.every((log) => !isFieldEmpty(log.rolename));
@@ -160,7 +160,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'match');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 5000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allValid = list.every((log) => isFieldEmpty(log.rolename) || log.rolename === 'mon-DA-PHS-0');
@@ -177,7 +177,7 @@ describe('Live Mode test-suite', async () => {
         window.model.log.filter.setCriteria('rolename', 'emptyFor', 'exclude');
       });
       await page.evaluate(() => window.model.log.liveStart());
-      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 10000 });
+      await page.waitForFunction('window.model.log.list.length > 5', { timeout: 15000 });
 
       const list = await page.evaluate(() => window.model.log.list);
       const allValid = list.every((log) => !isFieldEmpty(log.rolename) && log.rolename !== 'mon-DA-PHS-0');


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

FIxing macOS timeouts for ILG test. 

Add shuffle utility that scrambles the `fakeData.json` file to get rid of groupings of similar logs. These groupings made tests that wait for a set number of logs to match their filters take much longer than needed to complete.

**Result on the troublesome "Empty field filters in live mode" suite:**

| Test | Before | After |
|---|---|---|
| match OR empty | 1632ms | <1s |
| exclude AND non-empty | **6549ms** | **616ms** |
