### PR TITLE
[OGUI-1913] Reset test profile DB before each test run to fix alternating pass/fail

### DIFF
--- a/InfoLogger/test/mocha-index.js
+++ b/InfoLogger/test/mocha-index.js
@@ -16,6 +16,7 @@
 const puppeteer = require('puppeteer');
 const assert = require('assert');
 const { spawn } = require('child_process');
+const fs = require('fs');
 
 const config = require('./test-config.js');
 const { createServer, closeServer } = require('./live-simulator/infoLoggerServer.js');
@@ -57,6 +58,10 @@ describe('InfoLogger', function () {
         console.error('[Test Setup] Stack:', error.stack);
       }
     });
+
+    // Remove any leftover user profile DB from a previous run so tests that modify
+    // profile state (e.g. user-actions-mocha) always start from the same known state.
+    fs.rmSync(config.dbFile, { force: true });
 
     // Start infologger server simulator
     ilgServer = createServer();


### PR DESCRIPTION
`testdb.json` is used by the test server to persist user profiles, but it is never cleaned up between separate test runs (`npm run test`).

`successfully save the profile of the user when pressed the "Save Profile" menu-item` test in `user-actions-mocha.js` toggles a column's visibility and saves it. Because the file isn't reset between runs, this modified state carries over to the next time the suite runs, causing the subsequent test, which relies on the visibility being what it originally was, to fail on that next run.

#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [x] FLP integration tests were ran successful
