### PR TITLE
[OGUI-1920] Encode filter query in route updates

### DIFF
--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -383,11 +383,20 @@ export default class Model extends Observable {
   }
 
   /**
+   * Builds the an encoded filter query string
+   * @param {object} filters - The filter object
+   * @returns {string} The query string representation of the filter criteria
+   */
+  buildFilterQueryString(filters) {
+    return `?q=${encodeURIComponent(JSON.stringify(filters))}`;
+  }
+
+  /**
    * When model change (filters), update address bar with the filter
    * do it silently to avoid infinite loop
    */
   updateRouteOnModelChange() {
-    this.router.go(`?q=${JSON.stringify(this.log.filter.toObject())}`, true, true);
+    this.router.go(this.buildFilterQueryString(this.log.filter.toObject()), true, true);
   }
 
   /**

--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -383,20 +383,11 @@ export default class Model extends Observable {
   }
 
   /**
-   * Builds the an encoded filter query string
-   * @param {object} filters - The filter object
-   * @returns {string} The query string representation of the filter criteria
-   */
-  buildFilterQueryString(filters) {
-    return `?q=${encodeURIComponent(JSON.stringify(filters))}`;
-  }
-
-  /**
    * When model change (filters), update address bar with the filter
    * do it silently to avoid infinite loop
    */
   updateRouteOnModelChange() {
-    this.router.go(this.buildFilterQueryString(this.log.filter.toObject()), true, true);
+    this.router.go(this.log.filter.queryString, true, true);
   }
 
   /**

--- a/InfoLogger/public/Model.js
+++ b/InfoLogger/public/Model.js
@@ -371,7 +371,7 @@ export default class Model extends Observable {
     } else if (params.q) {
       this.getUserProfile();
       try {
-        this.log.filter.fromObject(JSON.parse(params.q.replaceAll('\n', '\\n')));
+        this.log.filter.fromObject(JSON.parse(params.q));
       } catch (error) {
         this.log.filter.resetCriteria();
         this.updateRouteOnModelChange();

--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -140,9 +140,6 @@ export default class LogFilter extends Observable {
         // remote empty inputs
         if (!criterias[field][operator]) {
           delete criterias[field][operator];
-        } else if (operator === 'match' || operator === 'exclude') {
-          // encode potential breaking characters and escape double quotes as are used by browser by default
-          criterias[field][operator] = encodeURIComponent(criterias[field][operator].replace(/["]+/g, '\\"'));
         }
 
         // remove empty fields

--- a/InfoLogger/public/logFilter/LogFilter.js
+++ b/InfoLogger/public/logFilter/LogFilter.js
@@ -12,7 +12,7 @@
  * or submit itself to any jurisdiction.
  */
 
-import { Observable } from '/js/src/index.js';
+import { Observable, buildUrl } from '/js/src/index.js';
 import { TEXT_FILTER_OPERATORS } from '../constants/text-filter-operators.const.js';
 import { getDisabledSeverities } from '../constants/log-level-filters.const.js';
 
@@ -149,6 +149,14 @@ export default class LogFilter extends Observable {
       }
     }
     return criterias;
+  }
+
+  /**
+   * Builds a URI encoded filter query string
+   * @returns {string} The query string representation of the filter criteria
+   */
+  get queryString() {
+    return buildUrl('?', { q: JSON.stringify(this.toObject()) });
   }
 
   /**

--- a/InfoLogger/test/mocha-index.js
+++ b/InfoLogger/test/mocha-index.js
@@ -109,6 +109,7 @@ describe('InfoLogger', function () {
 
   require('./public/user-actions-mocha');
   require('./public/log-filter-actions-mocha');
+  require('./public/log-filter-url-mocha');
   require('./public/live-mode-mocha');
   require('./public/query-mode-mocha');
   require('./public/status-bar-mocha');

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -257,30 +257,6 @@ describe('Filter actions test-suite', async () => {
     assert.deepStrictEqual($in, ['I', 'W', 'E', 'F']);
   });
 
-  it('should encode special characters correctly into the URL', async () => {
-    const pidMatch = await page.evaluate(() => {
-      window.model.log.filter.setCriteria('pid', 'match', 'a+b c %d #anchor & = héllo wörld 日本語');
-      return window.model.log.filter.criterias.pid.$match;
-    });
-
-    assert.strictEqual(pidMatch, 'a+b c %d #anchor & = héllo wörld 日本語');
-
-    const searchParams = await page.evaluate(() => {
-      window.model.updateRouteOnModelChange();
-      return window.location.search;
-    });
-
-    assert.ok(searchParams.includes('a%2Bb%20c%20%25d%20%23anchor%20%26%20%3D%20h%C3%A9llo%20w%C3%B6rld%20%E6%97%A5%E6%9C%AC%E8%AA%9E'));
-  });
-
-  it('should decode special characters correctly from the URL', async () => {
-    await page.goto(`${baseUrl}?q={%22pid%22:{%22match%22:%22a%2Bb%20c%20%25d%20%23anchor%20%26%20%3D%20h%C3%A9llo%20w%C3%B6rld%20%E6%97%A5%E6%9C%AC%E8%AA%9E%22}}`, { waitUntil: 'networkidle0' });
-
-    const pidMatch = await page.evaluate(() => window.model.log.filter.criterias.pid.$match);
-
-    assert.strictEqual(pidMatch, 'a+b c %d #anchor & = héllo wörld 日本語');
-  });
-
   it('should reset filters and set them again', async () => {
     const criterias = await page.evaluate(() => {
       window.model.log.filter.resetCriteria();

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -105,7 +105,8 @@ describe('Filter actions test-suite', async () => {
 
   it('should update filters based on profile when passed in the URI', async () => {
     // for now check if the filters are reset once the profile is passed
-    const expectedParams = '?q={%22severity%22:{%22in%22:%22I%20W%20E%20F%22},%22level%22:{%22max%22:1}}';
+    const expectedParams =
+      '?q=%7B%22severity%22%3A%7B%22in%22%3A%22I%20W%20E%20F%22%7D%2C%22level%22%3A%7B%22max%22%3A1%7D%7D';
 
     const searchParams = await page.evaluate(() => {
       const params = { profile: 'physicist' };
@@ -123,7 +124,8 @@ describe('Filter actions test-suite', async () => {
   it('should reset filters and show warning message when profile and filters are passed', async () => {
     // wait until the previous notification is hidden
     await page.waitForFunction('window.model.notification.state === \'hidden\'');
-    const expectedParams = '?q={%22severity%22:{%22in%22:%22I%20W%20E%20F%22},%22level%22:{%22max%22:1}}';
+    const expectedParams =
+      '?q=%7B%22severity%22%3A%7B%22in%22%3A%22I%20W%20E%20F%22%7D%2C%22level%22%3A%7B%22max%22%3A1%7D%7D';
     const searchParams = await page.evaluate(() => {
       const params = { profile: 'physicist', q: '"severity":{"in":"I W E F"}}' };
       window.model.parseLocation(params);
@@ -148,7 +150,7 @@ describe('Filter actions test-suite', async () => {
       };
     });
 
-    assert.strictEqual(decodeURI(locationAndNotification.search), expectedDefaultParams);
+    assert.strictEqual(decodeURIComponent(locationAndNotification.search), expectedDefaultParams);
     assert.strictEqual(locationAndNotification.notification.type, 'danger');
     // CI/CD runs on Chromium so this assertion is based on Chromium's JSON engine's error message
     assert.strictEqual(
@@ -159,7 +161,8 @@ describe('Filter actions test-suite', async () => {
 
   it('should update URI with new encoded "match" criteria', async () => {
     const decodedParams = '?q={"hostname":{"match":"\\"%ald_qdip01%"},"severity":{"in":"I W E F"}}';
-    const expectedParams = '?q={%22hostname%22:{%22match%22:%22%5C%22%25ald_qdip01%25%22},%22severity%22:{%22in%22:%22I%20W%20E%20F%22}}';
+    const expectedParams = '?q=%7B%22hostname%22%3A%7B%22match%22%3A%22%5C%22%25ald_qdip01%25%22%7D'
+      + '%2C%22severity%22%3A%7B%22in%22%3A%22I%20W%20E%20F%22%7D%7D';
     const searchParams = await page.evaluate(() => {
       window.model.log.filter.setCriteria('hostname', 'match', '"%ald_qdip01%');
       window.model.updateRouteOnModelChange();
@@ -167,12 +170,13 @@ describe('Filter actions test-suite', async () => {
     });
 
     assert.deepStrictEqual(searchParams, expectedParams);
-    assert.deepStrictEqual(decodeURI(searchParams), decodedParams);
+    assert.deepStrictEqual(decodeURIComponent(searchParams), decodedParams);
   });
 
   it('should update URI with new encoded "exclude" criteria', async () => {
     const decodedParams = '?q={"hostname":{"exclude":"\\"%ald_qdip01%"},"severity":{"in":"I W E F"}}';
-    const expectedParams = '?q={%22hostname%22:{%22exclude%22:%22%5C%22%25ald_qdip01%25%22},%22severity%22:{%22in%22:%22I%20W%20E%20F%22}}';
+    const expectedParams = '?q=%7B%22hostname%22%3A%7B%22exclude%22%3A%22%5C%22%25ald_qdip01%25%22%7D'
+      + '%2C%22severity%22%3A%7B%22in%22%3A%22I%20W%20E%20F%22%7D%7D';
     const searchParams = await page.evaluate(() => {
       window.model.log.filter.resetCriteria();
       window.model.log.filter.setCriteria('hostname', 'exclude', '"%ald_qdip01%');
@@ -181,7 +185,7 @@ describe('Filter actions test-suite', async () => {
     });
 
     assert.deepStrictEqual(searchParams, expectedParams);
-    assert.deepStrictEqual(decodeURI(searchParams), decodedParams);
+    assert.deepStrictEqual(decodeURIComponent(searchParams), decodedParams);
   });
 
   it('should parse dates in format DD/MM/YY', async () => {

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -135,7 +135,7 @@ describe('Filter actions test-suite', async () => {
     await page.waitForFunction('window.model.notification.state === \'shown\'');
     await page.waitForFunction('window.model.notification.type === \'warning\'');
     const notificationMessage = await page.evaluate(() => window.model.notification.message);
-    await page.waitForFunction(`window.model.notification.message === "${notificationMessage}"`);
+    assert.strictEqual(notificationMessage, 'URL can contain only filters or profile, not both');
     assert.strictEqual(searchParams, expectedParams);
   });
 

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -167,6 +167,7 @@ describe('Filter actions test-suite', async () => {
     const expectedParams = '?q=%7B%22hostname%22%3A%7B%22match%22%3A%22%5C%22%25ald_qdip01%25%22%7D'
       + '%2C%22severity%22%3A%7B%22in%22%3A%22I%20W%20E%20F%22%7D%7D';
     const searchParams = await page.evaluate(() => {
+      window.model.log.filter.resetCriteria();
       window.model.log.filter.setCriteria('hostname', 'match', '"%ald_qdip01%');
       window.model.updateRouteOnModelChange();
       return window.location.search;

--- a/InfoLogger/test/public/log-filter-actions-mocha.js
+++ b/InfoLogger/test/public/log-filter-actions-mocha.js
@@ -134,7 +134,8 @@ describe('Filter actions test-suite', async () => {
 
     await page.waitForFunction('window.model.notification.state === \'shown\'');
     await page.waitForFunction('window.model.notification.type === \'warning\'');
-    await page.waitForFunction('window.model.notification.message === "URL can contain only filters or profile, not both"');
+    const notificationMessage = await page.evaluate(() => window.model.notification.message);
+    await page.waitForFunction(`window.model.notification.message === "${notificationMessage}"`);
     assert.strictEqual(searchParams, expectedParams);
   });
 
@@ -152,10 +153,12 @@ describe('Filter actions test-suite', async () => {
 
     assert.strictEqual(decodeURIComponent(locationAndNotification.search), expectedDefaultParams);
     assert.strictEqual(locationAndNotification.notification.type, 'danger');
+    const expectedMessage = 'Invalid URL filter format: Expected \',\' or \'}\''
+    + ' after property value in JSON at position 27 (line 1 column 28)';
     // CI/CD runs on Chromium so this assertion is based on Chromium's JSON engine's error message
     assert.strictEqual(
       locationAndNotification.notification.message,
-      'Invalid URL filter format: Expected \',\' or \'}\' after property value in JSON at position 27 (line 1 column 28)',
+      expectedMessage,
     );
   });
 

--- a/InfoLogger/test/public/log-filter-url-mocha.js
+++ b/InfoLogger/test/public/log-filter-url-mocha.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+ * See http://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+ * All rights not expressly granted are reserved.
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const assert = require('assert');
+const test = require('../mocha-index');
+
+describe('URL Encoding/Decoding Suite', async () => {
+  let page = null;
+
+  before(async () => {
+    ({ page } = test);
+    await page.goto(test.helpers.baseUrl, { waitUntil: 'networkidle0' });
+  });
+
+  describe('Filter round-trip through the URL', async () => {
+    /**
+     * Sets message match criteria, then reloads the page on the URL the model produced for it
+     * @param {string} value - the raw filter value to round-trip
+     * @returns {Promise<string>} the value held by the model after the reload
+     */
+    const roundTrip = async (value) => {
+      const url = await page.evaluate((raw) => {
+        window.model.log.filter.setCriteria('message', 'match', raw);
+        window.model.updateRouteOnModelChange();
+        return window.location.href;
+      }, value);
+
+      await page.goto(url, { waitUntil: 'networkidle0' });
+      return await page.evaluate(() => window.model.log.filter.criterias.message.match);
+    };
+
+    it('should preserve consecutive double quotes', async () => {
+    // /["]+/g collapsed a run of quotes into a single escaped one, so "" came back as "
+      const stringToTest = 'a""b';
+      assert.strictEqual(await roundTrip(stringToTest), stringToTest);
+    });
+
+    it('should preserve a backslash that forms a valid JSON escape', async () => {
+    // C:\temp used to reach JSON.parse unescaped and come back as C:<tab>emp
+      const stringToTest = 'C:\\temp';
+      assert.strictEqual(await roundTrip(stringToTest), stringToTest);
+    });
+
+    it('should preserve a backslash that does not form a valid JSON escape', async () => {
+    // C:\xyz used to throw, resetting every filter
+      const stringToTest = 'C:\\xyz';
+      assert.strictEqual(await roundTrip(stringToTest), stringToTest);
+    });
+
+    it('should preserve a multi-line message filter', async () => {
+      const stringToTest = 'first\nsecond';
+      assert.strictEqual(await roundTrip(stringToTest), stringToTest);
+    });
+
+    it('should preserve a value containing URL-significant characters', async () => {
+      const stringToTest = 'a&b#c=d?e %20 a+b c %d #anchor & = héllo wörld 日本語';
+      assert.strictEqual(await roundTrip(stringToTest), stringToTest);
+    });
+
+    it('should store the value unencoded in the model', async () => {
+      const stringToTest = 'a&b#c=d?e %20 a+b c %d #anchor & = héllo wörld 日本語';
+      const stored = await page.evaluate((stringToTest) => {
+        window.model.log.filter.setCriteria('message', 'match', stringToTest);
+        return window.model.log.filter.toObject().message.match;
+      }, stringToTest);
+
+      assert.strictEqual(stored, stringToTest);
+    });
+  });
+});


### PR DESCRIPTION
#### I have JIRA issue created
- [x] branch and/or PR name(s) includes JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected
- [ ] FLP integration tests were ran successful

Ticket:
The `q` URL parameter in ILG, containing the JSON object of active filters, is not being encoded in the correct order creating opportunity for corruption when sharing or decoding.

The changes to the code include:
- Reversing the order of encoding to be correct and encoding the whole object not just its values.
- Removing any special handling of new lines or quotations as encoding handles this safely now.
- Updating tests that assert against URL strings to use their fully-encoded versions.
- Adding round-trip URL tests so encoding/decoding changes will be held up against best practice, fully-encoded URLs.

Reviewer can test with a filter value of `C:\temp` on a dev instance before and after the branch's changes and note the difference:
- Before the URL contains raw `{` and `}`and the filter value is `C:<tab>emp` as the `\t` was incorrectly consumed as a JSON escape.
- After the URL contains only valid, percent-encoded characters and the filter value is `C:\temp`.

Reviewer should note the filter JSON object is now wholly-encoded as oppose to before when it was just its values.

Reviewer should note that changes to an ILG integration test will be required as it asserts against not a fully-encoded query string.

Reviewer should note the address bar decodes double quotation marks for readability but will copy the encoded version.